### PR TITLE
Allow setting name of ports in generated services

### DIFF
--- a/docs/gitbook/how-it-works.md
+++ b/docs/gitbook/how-it-works.md
@@ -488,6 +488,37 @@ The above configuration validates the canary by checking
 if the HTTP 404 req/sec percentage is below 5 percent of the total traffic.
 If the 404s rate reaches the 5% threshold, then the canary fails.
 
+```yaml
+  canaryAnalysis:
+    threshold: 1
+    maxWeight: 50
+    stepWeight: 5
+    metrics:
+    - name: "rpc error rate"
+      threshold: 5
+      query: |
+        100 - (sum
+            rate(
+                grpc_server_handled_total{
+                  grpc_service="my.TestService",
+                  grpc_code!="OK"
+                }[1m]
+            )
+        )
+        /
+        sum(
+            rate(
+                grpc_server_started_total{
+                  grpc_service="my.TestService"
+                }[1m]
+            )
+        ) * 100
+```
+
+The above configuration validates the canary by checking if the percentage of
+non-OK GRPC req/sec is below 5 percent of the total requests. If the non-OK
+rate reaches the 5% threshold, then the canary fails.
+
 When specifying a query, Flagger will run the promql query and convert the result to float64. 
 Then it compares the query result value with the metric threshold value.
 

--- a/docs/gitbook/how-it-works.md
+++ b/docs/gitbook/how-it-works.md
@@ -33,6 +33,8 @@ spec:
   service:
     # container port
     port: 9898
+    # service port name (optional, will default to "http")
+    portName: http-podinfo
     # Istio gateways (optional)
     gateways:
     - public-gateway.istio-system.svc.cluster.local
@@ -115,6 +117,8 @@ spec:
   service:
     # container port
     port: 9898
+    # service port name (optional, will default to "http")
+    portName: http-frontend
     # Istio gateways (optional)
     gateways:
     - public-gateway.istio-system.svc.cluster.local

--- a/pkg/apis/flagger/v1alpha3/types.go
+++ b/pkg/apis/flagger/v1alpha3/types.go
@@ -17,10 +17,11 @@ limitations under the License.
 package v1alpha3
 
 import (
+	"time"
+
 	istiov1alpha3 "github.com/weaveworks/flagger/pkg/apis/istio/v1alpha3"
 	hpav1 "k8s.io/api/autoscaling/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"time"
 )
 
 const (
@@ -111,6 +112,7 @@ type CanaryStatus struct {
 // and Istio Virtual Service
 type CanaryService struct {
 	Port       int32                            `json:"port"`
+	PortName   string                           `json:"portName,omitempty"`
 	Match      []istiov1alpha3.HTTPMatchRequest `json:"match,omitempty"`
 	Rewrite    *istiov1alpha3.HTTPRewrite       `json:"rewrite,omitempty"`
 	Timeout    string                           `json:"timeout,omitempty"`


### PR DESCRIPTION
I'm taking Flagger for a spin (loving it), but I'm having some issues with our GRPC services that no longer work as expected when Flagger is managing the VirtualService/Service instances surrounding the services. This is namely due to the name of the ports in the generated Service objects hardcoded to be `http`, where in GRPCs case they should be set to `http2` or `grpc` (or `http2-something` or `grpc-something` in order for Envoy to configure itself as a HTTP2 proxy instead of a HTTP1-proxy.

I did a quick change in the `CanaryService` API type and the `router.KubernetesRouter` in order to be able to specify a `portName` in addition to a `port` in my canary service definition; this solves my issue, but it might not be the way you guys would prefer to solve this - so I'm mostly opening up this PR to have a place to discuss the appropriate implementation. I couldn't find any tests that verified the Service creation (only retrieval/mapping) so this change is not covered by any tests.

Fix: #115 