### PR TITLE
App Mesh docs

### DIFF
--- a/charts/flagger/templates/crd.yaml
+++ b/charts/flagger/templates/crd.yaml
@@ -3,6 +3,8 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: canaries.flagger.app
+  annotations:
+    helm.sh/resource-policy: keep
 spec:
   group: flagger.app
   version: v1alpha3

--- a/charts/loadtester/templates/deployment.yaml
+++ b/charts/loadtester/templates/deployment.yaml
@@ -16,6 +16,8 @@ spec:
     metadata:
       labels:
         app: {{ include "loadtester.name" . }}
+      annotations:
+        appmesh.k8s.aws/ports: "444"
     spec:
       containers:
         - name: {{ .Chart.Name }}

--- a/charts/loadtester/templates/service.yaml
+++ b/charts/loadtester/templates/service.yaml
@@ -13,6 +13,6 @@ spec:
     - port: {{ .Values.service.port }}
       targetPort: http
       protocol: TCP
-      name: http
+      name: 8080
   selector:
     app: {{ include "loadtester.name" . }}

--- a/charts/loadtester/templates/virtual-node.yaml
+++ b/charts/loadtester/templates/virtual-node.yaml
@@ -12,7 +12,7 @@ spec:
   meshName: {{ .Values.meshName }}
   listeners:
     - portMapping:
-        port: 80
+        port: 444
         protocol: http
   serviceDiscovery:
     dns:

--- a/docs/gitbook/install/flagger-install-on-eks-appmesh.md
+++ b/docs/gitbook/install/flagger-install-on-eks-appmesh.md
@@ -23,11 +23,11 @@ Prerequisites:
 
 ### Create a Kubernetes cluster
 
-In order to create an EKS cluster you can use [eksctl](https://eksctl.io).
-Eksctl is an open source command-line utility made by Weaveworks in collaboration with Amazon, 
+In order to create an EKS cluster you can use [EKSctl](https://eksctl.io).
+EKSctl is an open source command-line utility made by Weaveworks in collaboration with Amazon, 
 it's written in Go and is based on EKS CloudFormation templates.
 
-On MacOS you can install eksctl with Homebrew:
+On MacOS you can install EKSctl with Homebrew:
 
 ```bash
 brew tap weaveworks/tap
@@ -126,8 +126,8 @@ Status:
 
 ### Install Prometheus
 
-In order to expose the App Mesh metrics to Flagger, 
-you'll need to use Prometheus to scrapes the Envoy sidecars.
+In order to collect the App Mesh metrics that Flagger needs to run the canary analysis, 
+you'll need to setup a Prometheus instance to scrape the Envoy sidecars.
 
 Deploy Prometheus in the `appmesh-system` namespace:
 

--- a/docs/gitbook/install/flagger-install-on-eks-appmesh.md
+++ b/docs/gitbook/install/flagger-install-on-eks-appmesh.md
@@ -97,39 +97,21 @@ kubectl -n kube-system top pods
 
 ### Install the App Mesh components
 
-Clone the config repo:
+Run the App Mesh installer:
 
 ```bash
-git clone https://github.com/stefanprodan/appmesh-eks
-cd appmesh-eks
+curl -fsSL https://git.io/get-app-mesh-eks.sh | bash -
 ```
 
-Create the `appmesh-system` namespace:
+The installer will do the following:
 
-```bash
-kubectl apply -f /namespaces/appmesh-system.yaml
-```
-
-Deploy the App Mesh Kubernetes CRDs and controller:
-
-```bash
-kubectl apply -f ./operator/
-```
-
-Install the App Mesh sidecar injector in the `appmesh-system` namespace:
-
-```bash
-./injector/install.sh
-```
-
-The above script generates a certificate signed by Kubernetes CA,
-registers the App Mesh mutating webhook and deploys the injector.
-
-Create a mesh called global in the `appmesh-system` namespace:
-
-```bash
-kubectl apply -f ./appmesh/global.yaml
-```
+* creates the `appmesh-system` namespace
+* generates a certificate with openssl signed by Kubernetes CA
+* registers the App Mesh mutating webhook
+* deploys the App Mesh webhook
+* deploys the App Mesh CRDs
+* deploys the App Mesh controller
+* creates a mesh called `global` in the `appmesh-system` namespace
 
 Verify that the global mesh is active:
 
@@ -201,23 +183,3 @@ You can access Grafana using port forwarding:
 kubectl -n appmesh-system port-forward svc/flagger-grafana 3000:80
 ```
 
-###  Install the load tester
-
-Flagger comes with an optional load testing service that generates traffic 
-during canary analysis when configured as a webhook.
-
-Create a test namespace with sidecar injector enabled:
-
-```bash
-kubectl apply -f ./namespaces/test.yaml
-```
-
-Deploy the load test runner with Helm:
-
-```bash
-helm upgrade -i flagger-loadtester flagger/loadtester \
---namespace=test \
---set meshName=global.appmesh-system \
---set backends[0]=frontend.test \
---set backends[1]=backend.test
-```

--- a/docs/gitbook/usage/appmesh-progressive-delivery.md
+++ b/docs/gitbook/usage/appmesh-progressive-delivery.md
@@ -9,7 +9,7 @@ You'll need an EKS cluster configured with App Mesh, you can find the install gu
 Flagger takes a Kubernetes deployment and optionally a horizontal pod autoscaler (HPA), 
 then creates a series of objects (Kubernetes deployments, ClusterIP services, App Mesh virtual nodes and services). 
 These objects expose the application on the mesh and drive the canary analysis and promotion.
-The only App Mesh object you need to creat by yourself is the mesh resource.
+The only App Mesh object you need to create by yourself is the mesh resource.
 
 Create a mesh called `global` in the `appmesh-system` namespace:
 
@@ -160,6 +160,12 @@ Find the ingress public address:
 kubectl -n test describe svc/ingress | grep Ingress
 
 LoadBalancer Ingress:     yyy-xx.us-west-2.elb.amazonaws.com
+```
+
+Wait for the ELB to become active:
+
+```bash
+ watch curl -sS ${INGRESS_URL}
 ```
 
 Open your browser and navigate to the ingress address to access podinfo UI.


### PR DESCRIPTION
* use App Mesh installer script https://github.com/stefanprodan/appmesh-eks
* allow ingress access to load tester from outside the mesh
* prevent the removal of the Canary CRD on Helm uninstall