### PR TITLE
Fix canary status prom metric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Adds support for AWS App Mesh EKS
 #### Fixes
 
 - Copy pod labels from canary to primary [#105](https://github.com/weaveworks/flagger/pull/105)
+- Fix canary status Prometheus metric [#121](https://github.com/weaveworks/flagger/pull/121)
 
 ## 0.9.0 (2019-03-11)
 

--- a/pkg/controller/recorder.go
+++ b/pkg/controller/recorder.go
@@ -70,9 +70,9 @@ func (cr *CanaryRecorder) SetTotal(namespace string, total int) {
 }
 
 // SetStatus sets the last known canary analysis status
-func (cr *CanaryRecorder) SetStatus(cd *flaggerv1.Canary) {
+func (cr *CanaryRecorder) SetStatus(cd *flaggerv1.Canary, phase flaggerv1.CanaryPhase) {
 	status := 1
-	switch cd.Status.Phase {
+	switch phase {
 	case flaggerv1.CanaryProgressing:
 		status = 0
 	case flaggerv1.CanaryFailed:

--- a/pkg/controller/scheduler.go
+++ b/pkg/controller/scheduler.go
@@ -238,7 +238,7 @@ func (c *Controller) advanceCanary(name string, namespace string, skipLivenessCh
 			return
 		}
 
-		c.recorder.SetStatus(cd)
+		c.recorder.SetStatus(cd, flaggerv1.CanaryFailed)
 		return
 	}
 
@@ -312,7 +312,7 @@ func (c *Controller) advanceCanary(name string, namespace string, skipLivenessCh
 				c.recordEventWarningf(cd, "%v", err)
 				return
 			}
-			c.recorder.SetStatus(cd)
+			c.recorder.SetStatus(cd, flaggerv1.CanarySucceeded)
 			c.sendNotification(cd, "Canary analysis completed successfully, promotion finished.",
 				false, false)
 			return
@@ -378,7 +378,7 @@ func (c *Controller) advanceCanary(name string, namespace string, skipLivenessCh
 			c.recordEventWarningf(cd, "%v", err)
 			return
 		}
-		c.recorder.SetStatus(cd)
+		c.recorder.SetStatus(cd, flaggerv1.CanarySucceeded)
 		c.sendNotification(cd, "Canary analysis completed successfully, promotion finished.",
 			false, false)
 	}
@@ -419,7 +419,7 @@ func (c *Controller) shouldSkipAnalysis(cd *flaggerv1.Canary, meshRouter router.
 	}
 
 	// notify
-	c.recorder.SetStatus(cd)
+	c.recorder.SetStatus(cd, flaggerv1.CanarySucceeded)
 	c.recordEventInfof(cd, "Promotion completed! Canary analysis was skipped for %s.%s",
 		cd.Spec.TargetRef.Name, cd.Namespace)
 	c.sendNotification(cd, "Canary analysis was skipped, promotion finished.",
@@ -429,7 +429,7 @@ func (c *Controller) shouldSkipAnalysis(cd *flaggerv1.Canary, meshRouter router.
 }
 
 func (c *Controller) checkCanaryStatus(cd *flaggerv1.Canary, shouldAdvance bool) bool {
-	c.recorder.SetStatus(cd)
+	c.recorder.SetStatus(cd, cd.Status.Phase)
 	if cd.Status.Phase == flaggerv1.CanaryProgressing {
 		return true
 	}
@@ -439,7 +439,7 @@ func (c *Controller) checkCanaryStatus(cd *flaggerv1.Canary, shouldAdvance bool)
 			c.logger.With("canary", fmt.Sprintf("%s.%s", cd.Name, cd.Namespace)).Errorf("%v", err)
 			return false
 		}
-		c.recorder.SetStatus(cd)
+		c.recorder.SetStatus(cd, flaggerv1.CanaryInitialized)
 		c.recordEventInfof(cd, "Initialization done! %s.%s", cd.Name, cd.Namespace)
 		c.sendNotification(cd, "New deployment detected, initialization completed.",
 			true, false)
@@ -458,7 +458,7 @@ func (c *Controller) checkCanaryStatus(cd *flaggerv1.Canary, shouldAdvance bool)
 			c.logger.With("canary", fmt.Sprintf("%s.%s", cd.Name, cd.Namespace)).Errorf("%v", err)
 			return false
 		}
-		c.recorder.SetStatus(cd)
+		c.recorder.SetStatus(cd, flaggerv1.CanaryProgressing)
 		return false
 	}
 	return false


### PR DESCRIPTION
Set `flagger_canary_status` value based on the current status instead of relying on the cached canary object.