### PR TITLE
 Refactor Prometheus recorder

### DIFF
--- a/cmd/flagger/main.go
+++ b/cmd/flagger/main.go
@@ -135,6 +135,7 @@ func main() {
 		logger,
 		slack,
 		meshProvider,
+		version.VERSION,
 	)
 
 	flaggerInformerFactory.Start(stopCh)

--- a/docs/gitbook/usage/monitoring.md
+++ b/docs/gitbook/usage/monitoring.md
@@ -46,6 +46,9 @@ Flagger exposes Prometheus metrics that can be used to determine the canary anal
 the destination weight values:
 
 ```bash
+# Flagger version and mesh provider gauge
+flagger_info{version="0.10.0", mesh_provider="istio"} 1
+
 # Canaries total gauge
 flagger_canary_total{namespace="test"} 1
 

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"fmt"
+	"github.com/weaveworks/flagger/pkg/metrics"
 	"sync"
 	"time"
 
@@ -42,7 +43,7 @@ type Controller struct {
 	jobs          map[string]CanaryJob
 	deployer      CanaryDeployer
 	observer      CanaryObserver
-	recorder      CanaryRecorder
+	recorder      metrics.CanaryRecorder
 	notifier      *notifier.Slack
 	meshProvider  string
 }
@@ -57,7 +58,7 @@ func NewController(
 	logger *zap.SugaredLogger,
 	notifier *notifier.Slack,
 	meshProvider string,
-
+	version string,
 ) *Controller {
 	logger.Debug("Creating event broadcaster")
 	flaggerscheme.AddToScheme(scheme.Scheme)
@@ -84,7 +85,8 @@ func NewController(
 		metricsServer: metricServer,
 	}
 
-	recorder := NewCanaryRecorder(true)
+	recorder := metrics.NewCanaryRecorder(controllerAgentName, true)
+	recorder.SetInfo(version, meshProvider)
 
 	ctrl := &Controller{
 		kubeClient:    kubeClient,

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -8,6 +8,7 @@ import (
 	fakeFlagger "github.com/weaveworks/flagger/pkg/client/clientset/versioned/fake"
 	informers "github.com/weaveworks/flagger/pkg/client/informers/externalversions"
 	"github.com/weaveworks/flagger/pkg/logging"
+	"github.com/weaveworks/flagger/pkg/metrics"
 	"github.com/weaveworks/flagger/pkg/router"
 	"go.uber.org/zap"
 	appsv1 "k8s.io/api/apps/v1"
@@ -94,7 +95,7 @@ func SetupMocks(abtest bool) Mocks {
 		flaggerWindow: time.Second,
 		deployer:      deployer,
 		observer:      observer,
-		recorder:      NewCanaryRecorder(false),
+		recorder:      metrics.NewCanaryRecorder(controllerAgentName, false),
 	}
 	ctrl.flaggerSynced = alwaysReady
 

--- a/pkg/controller/scheduler.go
+++ b/pkg/controller/scheduler.go
@@ -118,6 +118,7 @@ func (c *Controller) advanceCanary(name string, namespace string, skipLivenessCh
 	}
 
 	if !shouldAdvance {
+		c.recorder.SetStatus(cd, cd.Status.Phase)
 		return
 	}
 


### PR DESCRIPTION
- add `flagger_info` gauge metric
- expose the version and mesh provider as labels
- move the recorder to the metrics package
- ensure the `flagger_canary_status` metric is set after a restart

Fix: #126 