### PR TITLE
Refactor the metrics observer 

### DIFF
--- a/cmd/flagger/main.go
+++ b/cmd/flagger/main.go
@@ -7,6 +7,7 @@ import (
 	informers "github.com/weaveworks/flagger/pkg/client/informers/externalversions"
 	"github.com/weaveworks/flagger/pkg/controller"
 	"github.com/weaveworks/flagger/pkg/logging"
+	"github.com/weaveworks/flagger/pkg/metrics"
 	"github.com/weaveworks/flagger/pkg/notifier"
 	"github.com/weaveworks/flagger/pkg/server"
 	"github.com/weaveworks/flagger/pkg/signals"
@@ -105,7 +106,7 @@ func main() {
 		logger.Infof("Watching namespace %s", namespace)
 	}
 
-	ok, err := controller.CheckMetricsServer(metricsServer)
+	ok, err := metrics.CheckMetricsServer(metricsServer)
 	if ok {
 		logger.Infof("Connected to metrics server %s", metricsServer)
 	} else {

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -42,8 +42,8 @@ type Controller struct {
 	canaries      *sync.Map
 	jobs          map[string]CanaryJob
 	deployer      CanaryDeployer
-	observer      metrics.CanaryObserver
-	recorder      metrics.CanaryRecorder
+	observer      metrics.Observer
+	recorder      metrics.Recorder
 	notifier      *notifier.Slack
 	meshProvider  string
 }
@@ -81,7 +81,7 @@ func NewController(
 		},
 	}
 
-	recorder := metrics.NewCanaryRecorder(controllerAgentName, true)
+	recorder := metrics.NewRecorder(controllerAgentName, true)
 	recorder.SetInfo(version, meshProvider)
 
 	ctrl := &Controller{

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -42,7 +42,7 @@ type Controller struct {
 	canaries      *sync.Map
 	jobs          map[string]CanaryJob
 	deployer      CanaryDeployer
-	observer      CanaryObserver
+	observer      metrics.CanaryObserver
 	recorder      metrics.CanaryRecorder
 	notifier      *notifier.Slack
 	meshProvider  string
@@ -81,10 +81,6 @@ func NewController(
 		},
 	}
 
-	observer := CanaryObserver{
-		metricsServer: metricServer,
-	}
-
 	recorder := metrics.NewCanaryRecorder(controllerAgentName, true)
 	recorder.SetInfo(version, meshProvider)
 
@@ -101,7 +97,7 @@ func NewController(
 		jobs:          map[string]CanaryJob{},
 		flaggerWindow: flaggerWindow,
 		deployer:      deployer,
-		observer:      observer,
+		observer:      metrics.NewObserver(metricServer),
 		recorder:      recorder,
 		notifier:      notifier,
 		meshProvider:  meshProvider,

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -35,7 +35,7 @@ type Mocks struct {
 	meshClient    clientset.Interface
 	flaggerClient clientset.Interface
 	deployer      CanaryDeployer
-	observer      CanaryObserver
+	observer      metrics.CanaryObserver
 	ctrl          *Controller
 	logger        *zap.SugaredLogger
 	router        router.Interface
@@ -74,9 +74,6 @@ func SetupMocks(abtest bool) Mocks {
 			flaggerClient: flaggerClient,
 		},
 	}
-	observer := CanaryObserver{
-		metricsServer: "fake",
-	}
 
 	// init controller
 	flaggerInformerFactory := informers.NewSharedInformerFactory(flaggerClient, noResyncPeriodFunc())
@@ -94,7 +91,7 @@ func SetupMocks(abtest bool) Mocks {
 		canaries:      new(sync.Map),
 		flaggerWindow: time.Second,
 		deployer:      deployer,
-		observer:      observer,
+		observer:      metrics.NewObserver("fake"),
 		recorder:      metrics.NewCanaryRecorder(controllerAgentName, false),
 	}
 	ctrl.flaggerSynced = alwaysReady

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -74,6 +74,7 @@ func SetupMocks(abtest bool) Mocks {
 			flaggerClient: flaggerClient,
 		},
 	}
+	observer := metrics.NewObserver("fake")
 
 	// init controller
 	flaggerInformerFactory := informers.NewSharedInformerFactory(flaggerClient, noResyncPeriodFunc())
@@ -91,7 +92,7 @@ func SetupMocks(abtest bool) Mocks {
 		canaries:      new(sync.Map),
 		flaggerWindow: time.Second,
 		deployer:      deployer,
-		observer:      metrics.NewObserver("fake"),
+		observer:      observer,
 		recorder:      metrics.NewRecorder(controllerAgentName, false),
 	}
 	ctrl.flaggerSynced = alwaysReady

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -35,7 +35,7 @@ type Mocks struct {
 	meshClient    clientset.Interface
 	flaggerClient clientset.Interface
 	deployer      CanaryDeployer
-	observer      metrics.CanaryObserver
+	observer      metrics.Observer
 	ctrl          *Controller
 	logger        *zap.SugaredLogger
 	router        router.Interface
@@ -92,7 +92,7 @@ func SetupMocks(abtest bool) Mocks {
 		flaggerWindow: time.Second,
 		deployer:      deployer,
 		observer:      metrics.NewObserver("fake"),
-		recorder:      metrics.NewCanaryRecorder(controllerAgentName, false),
+		recorder:      metrics.NewRecorder(controllerAgentName, false),
 	}
 	ctrl.flaggerSynced = alwaysReady
 

--- a/pkg/controller/scheduler.go
+++ b/pkg/controller/scheduler.go
@@ -501,7 +501,7 @@ func (c *Controller) analyseCanary(r *flaggerv1.Canary) bool {
 					c.recordEventWarningf(r, "Halt advancement no values found for metric %s probably %s.%s is not receiving traffic",
 						metric.Name, r.Spec.TargetRef.Name, r.Namespace)
 				} else {
-					c.recordEventErrorf(r, "Metrics server %s query failed: %v", c.observer.metricsServer, err)
+					c.recordEventErrorf(r, "Metrics server %s query failed: %v", c.observer.GetMetricsServer(), err)
 				}
 				return false
 			}
@@ -519,7 +519,7 @@ func (c *Controller) analyseCanary(r *flaggerv1.Canary) bool {
 					c.recordEventWarningf(r, "Halt advancement no values found for metric %s probably %s.%s is not receiving traffic",
 						metric.Name, r.Spec.TargetRef.Name, r.Namespace)
 				} else {
-					c.recordEventErrorf(r, "Metrics server %s query failed: %v", c.observer.metricsServer, err)
+					c.recordEventErrorf(r, "Metrics server %s query failed: %v", c.observer.GetMetricsServer(), err)
 				}
 				return false
 			}
@@ -533,7 +533,7 @@ func (c *Controller) analyseCanary(r *flaggerv1.Canary) bool {
 		if metric.Name == "istio_request_duration_seconds_bucket" {
 			val, err := c.observer.GetDeploymentHistogram(r.Spec.TargetRef.Name, r.Namespace, metric.Name, metric.Interval)
 			if err != nil {
-				c.recordEventErrorf(r, "Metrics server %s query failed: %v", c.observer.metricsServer, err)
+				c.recordEventErrorf(r, "Metrics server %s query failed: %v", c.observer.GetMetricsServer(), err)
 				return false
 			}
 			t := time.Duration(metric.Threshold) * time.Millisecond
@@ -551,7 +551,7 @@ func (c *Controller) analyseCanary(r *flaggerv1.Canary) bool {
 					c.recordEventWarningf(r, "Halt advancement no values found for metric %s probably %s.%s is not receiving traffic",
 						metric.Name, r.Spec.TargetRef.Name, r.Namespace)
 				} else {
-					c.recordEventErrorf(r, "Metrics server %s query failed: %v", c.observer.metricsServer, err)
+					c.recordEventErrorf(r, "Metrics server %s query failed: %v", c.observer.GetMetricsServer(), err)
 				}
 				return false
 			}

--- a/pkg/controller/scheduler.go
+++ b/pkg/controller/scheduler.go
@@ -513,7 +513,7 @@ func (c *Controller) analyseCanary(r *flaggerv1.Canary) bool {
 		}
 
 		if metric.Name == "istio_requests_total" {
-			val, err := c.observer.GetDeploymentCounter(r.Spec.TargetRef.Name, r.Namespace, metric.Name, metric.Interval)
+			val, err := c.observer.GetIstioSuccessRate(r.Spec.TargetRef.Name, r.Namespace, metric.Name, metric.Interval)
 			if err != nil {
 				if strings.Contains(err.Error(), "no values found") {
 					c.recordEventWarningf(r, "Halt advancement no values found for metric %s probably %s.%s is not receiving traffic",
@@ -531,7 +531,7 @@ func (c *Controller) analyseCanary(r *flaggerv1.Canary) bool {
 		}
 
 		if metric.Name == "istio_request_duration_seconds_bucket" {
-			val, err := c.observer.GetDeploymentHistogram(r.Spec.TargetRef.Name, r.Namespace, metric.Name, metric.Interval)
+			val, err := c.observer.GetIstioRequestDuration(r.Spec.TargetRef.Name, r.Namespace, metric.Name, metric.Interval)
 			if err != nil {
 				c.recordEventErrorf(r, "Metrics server %s query failed: %v", c.observer.GetMetricsServer(), err)
 				return false

--- a/pkg/metrics/envoy.go
+++ b/pkg/metrics/envoy.go
@@ -1,0 +1,65 @@
+package metrics
+
+import (
+	"fmt"
+	"net/url"
+	"strconv"
+)
+
+const envoySuccessRateQuery = `
+sum(rate(
+envoy_cluster_upstream_rq{kubernetes_namespace="{{ .Namespace }}",
+kubernetes_pod_name=~"{{ .Name }}-[0-9a-zA-Z]+(-[0-9a-zA-Z]+)",
+envoy_response_code!~"5.*"}
+[{{ .Interval }}])) 
+/ 
+sum(rate(
+envoy_cluster_upstream_rq{kubernetes_namespace="{{ .Namespace }}",
+kubernetes_pod_name=~"{{ .Name }}-[0-9a-zA-Z]+(-[0-9a-zA-Z]+)"}
+[{{ .Interval }}])) 
+* 100
+`
+
+func (c *Observer) GetEnvoySuccessRate(name string, namespace string, metric string, interval string) (float64, error) {
+	if c.metricsServer == "fake" {
+		return 100, nil
+	}
+
+	meta := struct {
+		Name      string
+		Namespace string
+		Interval  string
+	}{
+		name,
+		namespace,
+		interval,
+	}
+
+	query, err := render(meta, envoySuccessRateQuery)
+	if err != nil {
+		return 0, err
+	}
+
+	var rate *float64
+	querySt := url.QueryEscape(query)
+	result, err := c.queryMetric(querySt)
+	if err != nil {
+		return 0, err
+	}
+
+	for _, v := range result.Data.Result {
+		metricValue := v.Value[1]
+		switch metricValue.(type) {
+		case string:
+			f, err := strconv.ParseFloat(metricValue.(string), 64)
+			if err != nil {
+				return 0, err
+			}
+			rate = &f
+		}
+	}
+	if rate == nil {
+		return 0, fmt.Errorf("no values found for metric %s", metric)
+	}
+	return *rate, nil
+}

--- a/pkg/metrics/envoy_test.go
+++ b/pkg/metrics/envoy_test.go
@@ -1,0 +1,28 @@
+package metrics
+
+import (
+	"testing"
+)
+
+func Test_EnvoySuccessRateQueryRender(t *testing.T) {
+	meta := struct {
+		Name      string
+		Namespace string
+		Interval  string
+	}{
+		"podinfo",
+		"default",
+		"1m",
+	}
+
+	query, err := render(meta, envoySuccessRateQuery)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected := `sum(rate(envoy_cluster_upstream_rq{kubernetes_namespace="default",kubernetes_pod_name=~"podinfo-[0-9a-zA-Z]+(-[0-9a-zA-Z]+)",envoy_response_code!~"5.*"}[1m])) / sum(rate(envoy_cluster_upstream_rq{kubernetes_namespace="default",kubernetes_pod_name=~"podinfo-[0-9a-zA-Z]+(-[0-9a-zA-Z]+)"}[1m])) * 100`
+
+	if query != expected {
+		t.Errorf("\nGot %s \nWanted %s", query, expected)
+	}
+}

--- a/pkg/metrics/istio.go
+++ b/pkg/metrics/istio.go
@@ -1,0 +1,123 @@
+package metrics
+
+import (
+	"fmt"
+	"net/url"
+	"strconv"
+	"time"
+)
+
+const istioSuccessRateQuery = `
+sum(rate(
+istio_requests_total{reporter="destination",
+destination_workload_namespace="{{ .Namespace }}",
+destination_workload=~"{{ .Name }}",
+response_code!~"5.*"}
+[{{ .Interval }}])) 
+/ 
+sum(rate(
+istio_requests_total{reporter="destination",
+destination_workload_namespace="{{ .Namespace }}",
+destination_workload=~"{{ .Name }}"}
+[{{ .Interval }}])) 
+* 100
+`
+
+// GetIstioSuccessRate returns the requests success rate (non 5xx) using istio_requests_total metric
+func (c *Observer) GetIstioSuccessRate(name string, namespace string, metric string, interval string) (float64, error) {
+	if c.metricsServer == "fake" {
+		return 100, nil
+	}
+
+	meta := struct {
+		Name      string
+		Namespace string
+		Interval  string
+	}{
+		name,
+		namespace,
+		interval,
+	}
+
+	query, err := render(meta, istioSuccessRateQuery)
+	if err != nil {
+		return 0, err
+	}
+
+	var rate *float64
+	querySt := url.QueryEscape(query)
+	result, err := c.queryMetric(querySt)
+	if err != nil {
+		return 0, err
+	}
+
+	for _, v := range result.Data.Result {
+		metricValue := v.Value[1]
+		switch metricValue.(type) {
+		case string:
+			f, err := strconv.ParseFloat(metricValue.(string), 64)
+			if err != nil {
+				return 0, err
+			}
+			rate = &f
+		}
+	}
+	if rate == nil {
+		return 0, fmt.Errorf("no values found for metric %s", metric)
+	}
+	return *rate, nil
+}
+
+const istioRequestDurationQuery = `
+histogram_quantile(0.99, sum(rate(
+istio_request_duration_seconds_bucket{reporter="destination",
+destination_workload_namespace="{{ .Namespace }}",
+destination_workload=~"{{ .Name }}"}
+[{{ .Interval }}])) by (le))
+`
+
+// GetIstioRequestDuration returns the 99P requests delay using istio_request_duration_seconds_bucket metrics
+func (c *Observer) GetIstioRequestDuration(name string, namespace string, metric string, interval string) (time.Duration, error) {
+	if c.metricsServer == "fake" {
+		return 1, nil
+	}
+
+	meta := struct {
+		Name      string
+		Namespace string
+		Interval  string
+	}{
+		name,
+		namespace,
+		interval,
+	}
+
+	query, err := render(meta, istioRequestDurationQuery)
+	if err != nil {
+		return 0, err
+	}
+
+	var rate *float64
+	querySt := url.QueryEscape(query)
+	result, err := c.queryMetric(querySt)
+	if err != nil {
+		return 0, err
+	}
+
+	for _, v := range result.Data.Result {
+		metricValue := v.Value[1]
+		switch metricValue.(type) {
+		case string:
+			f, err := strconv.ParseFloat(metricValue.(string), 64)
+			if err != nil {
+				return 0, err
+			}
+			rate = &f
+		}
+	}
+	if rate == nil {
+		return 0, fmt.Errorf("no values found for metric %s", metric)
+	}
+	ms := time.Duration(int64(*rate*1000)) * time.Millisecond
+	return ms, nil
+}

--- a/pkg/metrics/istio_test.go
+++ b/pkg/metrics/istio_test.go
@@ -1,0 +1,51 @@
+package metrics
+
+import (
+	"testing"
+)
+
+func Test_IstioSuccessRateQueryRender(t *testing.T) {
+	meta := struct {
+		Name      string
+		Namespace string
+		Interval  string
+	}{
+		"podinfo",
+		"default",
+		"1m",
+	}
+
+	query, err := render(meta, istioSuccessRateQuery)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected := `sum(rate(istio_requests_total{reporter="destination",destination_workload_namespace="default",destination_workload=~"podinfo",response_code!~"5.*"}[1m])) / sum(rate(istio_requests_total{reporter="destination",destination_workload_namespace="default",destination_workload=~"podinfo"}[1m])) * 100`
+
+	if query != expected {
+		t.Errorf("\nGot %s \nWanted %s", query, expected)
+	}
+}
+
+func Test_IstioRequestDurationQueryRender(t *testing.T) {
+	meta := struct {
+		Name      string
+		Namespace string
+		Interval  string
+	}{
+		"podinfo",
+		"default",
+		"1m",
+	}
+
+	query, err := render(meta, istioRequestDurationQuery)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected := `histogram_quantile(0.99, sum(rate(istio_request_duration_seconds_bucket{reporter="destination",destination_workload_namespace="default",destination_workload=~"podinfo"}[1m])) by (le))`
+
+	if query != expected {
+		t.Errorf("\nGot %s \nWanted %s", query, expected)
+	}
+}

--- a/pkg/metrics/observer.go
+++ b/pkg/metrics/observer.go
@@ -12,8 +12,8 @@ import (
 	"time"
 )
 
-// CanaryObserver is used to query the Istio Prometheus db
-type CanaryObserver struct {
+// Observer is used to query Prometheus
+type Observer struct {
 	metricsServer string
 }
 
@@ -29,17 +29,17 @@ type vectorQueryResponse struct {
 	}
 }
 
-func NewObserver(metricsServer string) CanaryObserver {
-	return CanaryObserver{
+func NewObserver(metricsServer string) Observer {
+	return Observer{
 		metricsServer: metricsServer,
 	}
 }
 
-func (c *CanaryObserver) GetMetricsServer() string {
+func (c *Observer) GetMetricsServer() string {
 	return c.metricsServer
 }
 
-func (c *CanaryObserver) queryMetric(query string) (*vectorQueryResponse, error) {
+func (c *Observer) queryMetric(query string) (*vectorQueryResponse, error) {
 	promURL, err := url.Parse(c.metricsServer)
 	if err != nil {
 		return nil, err
@@ -85,7 +85,7 @@ func (c *CanaryObserver) queryMetric(query string) (*vectorQueryResponse, error)
 }
 
 // GetScalar runs the promql query and returns the first value found
-func (c *CanaryObserver) GetScalar(query string) (float64, error) {
+func (c *Observer) GetScalar(query string) (float64, error) {
 	if c.metricsServer == "fake" {
 		return 100, nil
 	}
@@ -116,7 +116,7 @@ func (c *CanaryObserver) GetScalar(query string) (float64, error) {
 	return *value, nil
 }
 
-func (c *CanaryObserver) GetEnvoySuccessRate(name string, namespace string, metric string, interval string) (float64, error) {
+func (c *Observer) GetEnvoySuccessRate(name string, namespace string, metric string, interval string) (float64, error) {
 	if c.metricsServer == "fake" {
 		return 100, nil
 	}
@@ -154,7 +154,7 @@ func (c *CanaryObserver) GetEnvoySuccessRate(name string, namespace string, metr
 }
 
 // GetDeploymentCounter returns the requests success rate using istio_requests_total metric
-func (c *CanaryObserver) GetDeploymentCounter(name string, namespace string, metric string, interval string) (float64, error) {
+func (c *Observer) GetDeploymentCounter(name string, namespace string, metric string, interval string) (float64, error) {
 	if c.metricsServer == "fake" {
 		return 100, nil
 	}
@@ -192,7 +192,7 @@ func (c *CanaryObserver) GetDeploymentCounter(name string, namespace string, met
 }
 
 // GetDeploymentHistogram returns the 99P requests delay using istio_request_duration_seconds_bucket metrics
-func (c *CanaryObserver) GetDeploymentHistogram(name string, namespace string, metric string, interval string) (time.Duration, error) {
+func (c *Observer) GetDeploymentHistogram(name string, namespace string, metric string, interval string) (time.Duration, error) {
 	if c.metricsServer == "fake" {
 		return 1, nil
 	}

--- a/pkg/metrics/observer.go
+++ b/pkg/metrics/observer.go
@@ -1,4 +1,4 @@
-package controller
+package metrics
 
 import (
 	"context"
@@ -27,6 +27,16 @@ type vectorQueryResponse struct {
 			Value []interface{} `json:"value"`
 		}
 	}
+}
+
+func NewObserver(metricsServer string) CanaryObserver {
+	return CanaryObserver{
+		metricsServer: metricsServer,
+	}
+}
+
+func (c *CanaryObserver) GetMetricsServer() string {
+	return c.metricsServer
 }
 
 func (c *CanaryObserver) queryMetric(query string) (*vectorQueryResponse, error) {

--- a/pkg/metrics/observer_test.go
+++ b/pkg/metrics/observer_test.go
@@ -14,7 +14,7 @@ func TestCanaryObserver_GetDeploymentCounter(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	observer := CanaryObserver{
+	observer := Observer{
 		metricsServer: ts.URL,
 	}
 
@@ -36,7 +36,7 @@ func TestCanaryObserver_GetDeploymentHistogram(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	observer := CanaryObserver{
+	observer := Observer{
 		metricsServer: ts.URL,
 	}
 

--- a/pkg/metrics/observer_test.go
+++ b/pkg/metrics/observer_test.go
@@ -7,16 +7,34 @@ import (
 	"time"
 )
 
-func TestCanaryObserver_GetDeploymentCounter(t *testing.T) {
+func TestCanaryObserver_GetEnvoySuccessRate(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		json := `{"status":"success","data":{"resultType":"vector","result":[{"metric":{},"value":[1545905245.458,"100"]}]}}`
 		w.Write([]byte(json))
 	}))
 	defer ts.Close()
 
-	observer := Observer{
-		metricsServer: ts.URL,
+	observer := NewObserver(ts.URL)
+
+	val, err := observer.GetEnvoySuccessRate("podinfo", "default", "envoy_cluster_upstream_rq", "1m")
+	if err != nil {
+		t.Fatal(err.Error())
 	}
+
+	if val != 100 {
+		t.Errorf("Got %v wanted %v", val, 100)
+	}
+
+}
+
+func TestCanaryObserver_GetIstioSuccessRate(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json := `{"status":"success","data":{"resultType":"vector","result":[{"metric":{},"value":[1545905245.458,"100"]}]}}`
+		w.Write([]byte(json))
+	}))
+	defer ts.Close()
+
+	observer := NewObserver(ts.URL)
 
 	val, err := observer.GetIstioSuccessRate("podinfo", "default", "istio_requests_total", "1m")
 	if err != nil {
@@ -29,16 +47,14 @@ func TestCanaryObserver_GetDeploymentCounter(t *testing.T) {
 
 }
 
-func TestCanaryObserver_GetDeploymentHistogram(t *testing.T) {
+func TestCanaryObserver_GetIstioRequestDuration(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		json := `{"status":"success","data":{"resultType":"vector","result":[{"metric":{},"value":[1545905245.596,"0.2"]}]}}`
 		w.Write([]byte(json))
 	}))
 	defer ts.Close()
 
-	observer := Observer{
-		metricsServer: ts.URL,
-	}
+	observer := NewObserver(ts.URL)
 
 	val, err := observer.GetIstioRequestDuration("podinfo", "default", "istio_request_duration_seconds_bucket", "1m")
 	if err != nil {

--- a/pkg/metrics/observer_test.go
+++ b/pkg/metrics/observer_test.go
@@ -1,4 +1,4 @@
-package controller
+package metrics
 
 import (
 	"net/http"

--- a/pkg/metrics/observer_test.go
+++ b/pkg/metrics/observer_test.go
@@ -18,7 +18,7 @@ func TestCanaryObserver_GetDeploymentCounter(t *testing.T) {
 		metricsServer: ts.URL,
 	}
 
-	val, err := observer.GetDeploymentCounter("podinfo", "default", "istio_requests_total", "1m")
+	val, err := observer.GetIstioSuccessRate("podinfo", "default", "istio_requests_total", "1m")
 	if err != nil {
 		t.Fatal(err.Error())
 	}
@@ -40,7 +40,7 @@ func TestCanaryObserver_GetDeploymentHistogram(t *testing.T) {
 		metricsServer: ts.URL,
 	}
 
-	val, err := observer.GetDeploymentHistogram("podinfo", "default", "istio_request_duration_seconds_bucket", "1m")
+	val, err := observer.GetIstioRequestDuration("podinfo", "default", "istio_request_duration_seconds_bucket", "1m")
 	if err != nil {
 		t.Fatal(err.Error())
 	}

--- a/pkg/metrics/recorder.go
+++ b/pkg/metrics/recorder.go
@@ -8,8 +8,8 @@ import (
 	flaggerv1 "github.com/weaveworks/flagger/pkg/apis/flagger/v1alpha3"
 )
 
-// CanaryRecorder records the canary analysis as Prometheus metrics
-type CanaryRecorder struct {
+// Recorder records the canary analysis as Prometheus metrics
+type Recorder struct {
 	info     *prometheus.GaugeVec
 	duration *prometheus.HistogramVec
 	total    *prometheus.GaugeVec
@@ -17,8 +17,8 @@ type CanaryRecorder struct {
 	weight   *prometheus.GaugeVec
 }
 
-// NewCanaryRecorder creates a new recorder and registers the Prometheus metrics
-func NewCanaryRecorder(controller string, register bool) CanaryRecorder {
+// NewRecorder creates a new recorder and registers the Prometheus metrics
+func NewRecorder(controller string, register bool) Recorder {
 	info := prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Subsystem: controller,
 		Name:      "info",
@@ -59,7 +59,7 @@ func NewCanaryRecorder(controller string, register bool) CanaryRecorder {
 		prometheus.MustRegister(weight)
 	}
 
-	return CanaryRecorder{
+	return Recorder{
 		info:     info,
 		duration: duration,
 		total:    total,
@@ -69,22 +69,22 @@ func NewCanaryRecorder(controller string, register bool) CanaryRecorder {
 }
 
 // SetInfo sets the version and mesh provider labels
-func (cr *CanaryRecorder) SetInfo(version string, meshProvider string) {
+func (cr *Recorder) SetInfo(version string, meshProvider string) {
 	cr.info.WithLabelValues(version, meshProvider).Set(1)
 }
 
 // SetDuration sets the time spent in seconds performing canary analysis
-func (cr *CanaryRecorder) SetDuration(cd *flaggerv1.Canary, duration time.Duration) {
+func (cr *Recorder) SetDuration(cd *flaggerv1.Canary, duration time.Duration) {
 	cr.duration.WithLabelValues(cd.Spec.TargetRef.Name, cd.Namespace).Observe(duration.Seconds())
 }
 
 // SetTotal sets the total number of canaries per namespace
-func (cr *CanaryRecorder) SetTotal(namespace string, total int) {
+func (cr *Recorder) SetTotal(namespace string, total int) {
 	cr.total.WithLabelValues(namespace).Set(float64(total))
 }
 
 // SetStatus sets the last known canary analysis status
-func (cr *CanaryRecorder) SetStatus(cd *flaggerv1.Canary, phase flaggerv1.CanaryPhase) {
+func (cr *Recorder) SetStatus(cd *flaggerv1.Canary, phase flaggerv1.CanaryPhase) {
 	status := 1
 	switch phase {
 	case flaggerv1.CanaryProgressing:
@@ -98,7 +98,7 @@ func (cr *CanaryRecorder) SetStatus(cd *flaggerv1.Canary, phase flaggerv1.Canary
 }
 
 // SetWeight sets the weight values for primary and canary destinations
-func (cr *CanaryRecorder) SetWeight(cd *flaggerv1.Canary, primary int, canary int) {
+func (cr *Recorder) SetWeight(cd *flaggerv1.Canary, primary int, canary int) {
 	cr.weight.WithLabelValues(fmt.Sprintf("%s-primary", cd.Spec.TargetRef.Name), cd.Namespace).Set(float64(primary))
 	cr.weight.WithLabelValues(cd.Spec.TargetRef.Name, cd.Namespace).Set(float64(canary))
 }

--- a/test/e2e-istio-values.yaml
+++ b/test/e2e-istio-values.yaml
@@ -6,6 +6,10 @@
 pilot:
   enabled: true
   sidecar: true
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
 
 gateways:
   enabled: false

--- a/test/e2e-istio-values.yaml
+++ b/test/e2e-istio-values.yaml
@@ -12,10 +12,6 @@ gateways:
   istio-ingressgateway:
     autoscaleMax: 1
 
-# citadel configuration
-security:
-  enabled: true
-
 # sidecar-injector webhook configuration
 sidecarInjectorWebhook:
   enabled: true
@@ -55,8 +51,8 @@ global:
     resources:
       requests:
         cpu: 100m
-        memory: 128Mi
+        memory: 64Mi
       limits:
         cpu: 2000m
-        memory: 128Mi
+        memory: 256Mi
   useMCP: false

--- a/test/e2e-istio-values.yaml
+++ b/test/e2e-istio-values.yaml
@@ -8,7 +8,7 @@ pilot:
   sidecar: true
   resources:
     requests:
-      cpu: 100m
+      cpu: 10m
       memory: 128Mi
 
 gateways:
@@ -36,7 +36,7 @@ mixer:
     autoscaleEnabled: false
   resources:
     requests:
-      cpu: 100m
+      cpu: 10m
       memory: 128Mi
 
 # addon prometheus configuration
@@ -54,9 +54,9 @@ global:
     # Resources for the sidecar.
     resources:
       requests:
-        cpu: 100m
+        cpu: 10m
         memory: 64Mi
       limits:
-        cpu: 2000m
+        cpu: 1000m
         memory: 256Mi
   useMCP: false

--- a/test/e2e-istio.sh
+++ b/test/e2e-istio.sh
@@ -2,7 +2,7 @@
 
 set -o errexit
 
-ISTIO_VER="1.1.0-rc.0"
+ISTIO_VER="1.1.1"
 REPO_ROOT=$(git rev-parse --show-toplevel)
 export KUBECONFIG="$(kind get kubeconfig-path --name="kind")"
 

--- a/test/e2e-istio.sh
+++ b/test/e2e-istio.sh
@@ -25,13 +25,6 @@ kubectl -n istio-system wait --for=condition=complete job/istio-init-crd-10
 kubectl -n istio-system wait --for=condition=complete job/istio-init-crd-11
 
 echo '>>> Installing Istio control plane'
-helm upgrade -i istio istio.io/istio --namespace istio-system -f ${REPO_ROOT}/test/e2e-istio-values.yaml
-
-kubectl -n istio-system rollout status deployment/prometheus
+helm upgrade -i istio istio.io/istio --wait --namespace istio-system -f ${REPO_ROOT}/test/e2e-istio-values.yaml
 
 kubectl -n istio-system get all
-
-kubectl -n istio-system describe deployment/istio-pilot
-kubectl -n istio-system describe deployment/istio-telemetry
-kubectl -n istio-system describe deployment/istio-citadel
-kubectl -n istio-system describe deployment/prometheus

--- a/test/e2e-istio.sh
+++ b/test/e2e-istio.sh
@@ -27,11 +27,11 @@ kubectl -n istio-system wait --for=condition=complete job/istio-init-crd-11
 echo '>>> Installing Istio control plane'
 helm upgrade -i istio istio.io/istio --namespace istio-system -f ${REPO_ROOT}/test/e2e-istio-values.yaml
 
+kubectl -n istio-system rollout status deployment/prometheus
+
 kubectl -n istio-system get all
 
 kubectl -n istio-system describe deployment/istio-pilot
 kubectl -n istio-system describe deployment/istio-telemetry
 kubectl -n istio-system describe deployment/istio-citadel
 kubectl -n istio-system describe deployment/prometheus
-
-kubectl -n istio-system rollout status deployment/prometheus

--- a/test/e2e-istio.sh
+++ b/test/e2e-istio.sh
@@ -2,7 +2,7 @@
 
 set -o errexit
 
-ISTIO_VER="1.1.1"
+ISTIO_VER="1.1.0-rc.0"
 REPO_ROOT=$(git rev-parse --show-toplevel)
 export KUBECONFIG="$(kind get kubeconfig-path --name="kind")"
 

--- a/test/e2e-istio.sh
+++ b/test/e2e-istio.sh
@@ -25,4 +25,13 @@ kubectl -n istio-system wait --for=condition=complete job/istio-init-crd-10
 kubectl -n istio-system wait --for=condition=complete job/istio-init-crd-11
 
 echo '>>> Installing Istio control plane'
-helm upgrade -i istio istio.io/istio --wait --namespace istio-system -f ${REPO_ROOT}/test/e2e-istio-values.yaml
+helm upgrade -i istio istio.io/istio --namespace istio-system -f ${REPO_ROOT}/test/e2e-istio-values.yaml
+
+kubectl -n istio-system get all
+
+kubectl -n istio-system describe deployment/istio-pilot
+kubectl -n istio-system describe deployment/istio-telemetry
+kubectl -n istio-system describe deployment/istio-citadel
+kubectl -n istio-system describe deployment/prometheus
+
+kubectl -n istio-system rollout status deployment/prometheus

--- a/test/e2e-kind.sh
+++ b/test/e2e-kind.sh
@@ -3,21 +3,19 @@
 set -o errexit
 
 REPO_ROOT=$(git rev-parse --show-toplevel)
+KIND_VERSION=0.2.1
 
 echo ">>> Installing kubectl"
 curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl && \
 chmod +x kubectl && \
 sudo mv kubectl /usr/local/bin/
 
-echo ">>> Building sigs.k8s.io/kind"
-docker build -t kind:src . -f ${REPO_ROOT}/test/Dockerfile.kind
-docker create -ti --name dummy kind:src sh
-docker cp dummy:/go/bin/kind ./kind
-docker rm -f dummy
-
 echo ">>> Installing kind"
+curl -sSLo kind "https://github.com/kubernetes-sigs/kind/releases/download/$KIND_VERSION/kind-linux-amd64"
 chmod +x kind
-sudo mv kind /usr/local/bin/
+sudo mv kind /usr/local/bin/kind
+
+echo ">>> Creating kind cluster"
 kind create cluster --wait 5m
 
 export KUBECONFIG="$(kind get kubeconfig-path --name="kind")"

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -14,6 +14,11 @@ kubectl label namespace test istio-injection=enabled
 
 echo '>>> Installing the load tester'
 kubectl -n test apply -f ${REPO_ROOT}/artifacts/loadtester/
+
+sleep 30
+
+kubectl -n test describe deployment/flagger-loadtester
+
 kubectl -n test rollout status deployment/flagger-loadtester
 
 echo '>>> Initialising canary'

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -14,11 +14,6 @@ kubectl label namespace test istio-injection=enabled
 
 echo '>>> Installing the load tester'
 kubectl -n test apply -f ${REPO_ROOT}/artifacts/loadtester/
-
-sleep 30
-
-kubectl -n test describe deployment/flagger-loadtester
-
 kubectl -n test rollout status deployment/flagger-loadtester
 
 echo '>>> Initialising canary'


### PR DESCRIPTION
- move observer to metrics package
- use go templates to render the builtin promql queries
- upgrade Isto e2e to v1.1.1 Fix: #131 