### PR TITLE
Add pre and post rollout hooks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,6 +17,6 @@ workflows:
           filters:
             branches:
               ignore:
-                - gh-pages
+                - /gh-pages.*/
                 - /docs-.*/
                 - /release-.*/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,11 @@
 sudo: required
 language: go
 
+branches:
+  except:
+    - /gh-pages.*/
+    - /docs-.*/
+
 go:
 - 1.12.x
 
@@ -12,13 +17,7 @@ addons:
     packages:
     - docker-ce
 
-#before_script:
-#  - go get -u sigs.k8s.io/kind
-#  - curl https://raw.githubusercontent.com/kubernetes/helm/master/scripts/get | bash
-#  - curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl && chmod +x kubectl && sudo mv kubectl /usr/local/bin/
-
 script:
-  - set -e
   - make test-fmt
   - make test-codegen
   - go test -race -coverprofile=coverage.txt -covermode=atomic $(go list ./pkg/...)

--- a/artifacts/flagger/crd.yaml
+++ b/artifacts/flagger/crd.yaml
@@ -2,6 +2,8 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: canaries.flagger.app
+  annotations:
+    helm.sh/resource-policy: keep
 spec:
   group: flagger.app
   version: v1alpha3
@@ -39,9 +41,9 @@ spec:
       properties:
         spec:
           required:
-          - targetRef
-          - service
-          - canaryAnalysis
+            - targetRef
+            - service
+            - canaryAnalysis
           properties:
             progressDeadlineSeconds:
               type: number
@@ -119,9 +121,36 @@ spec:
                       properties:
                         name:
                           type: string
+                        type:
+                          type: string
+                          enum:
+                            - ""
+                            - pre-rollout
+                            - rollout
+                            - post-rollout
                         url:
                           type: string
                           format: url
                         timeout:
                           type: string
                           pattern: "^[0-9]+(m|s)"
+        status:
+          properties:
+            phase:
+              type: string
+              enum:
+                - ""
+                - Initialized
+                - Progressing
+                - Succeeded
+                - Failed
+            canaryWeight:
+              type: number
+            failedChecks:
+              type: number
+            iterations:
+              type: number
+            lastAppliedSpec:
+              type: string
+            lastTransitionTime:
+              type: string

--- a/charts/flagger/templates/crd.yaml
+++ b/charts/flagger/templates/crd.yaml
@@ -122,10 +122,37 @@ spec:
                       properties:
                         name:
                           type: string
+                        type:
+                          type: string
+                          enum:
+                            - ""
+                            - pre-rollout
+                            - rollout
+                            - post-rollout
                         url:
                           type: string
                           format: url
                         timeout:
                           type: string
                           pattern: "^[0-9]+(m|s)"
+        status:
+          properties:
+            phase:
+              type: string
+              enum:
+                - ""
+                - Initialized
+                - Progressing
+                - Succeeded
+                - Failed
+            canaryWeight:
+              type: number
+            failedChecks:
+              type: number
+            iterations:
+              type: number
+            lastAppliedSpec:
+              type: string
+            lastTransitionTime:
+              type: string
 {{- end }}

--- a/docs/gitbook/install/flagger-install-on-google-cloud.md
+++ b/docs/gitbook/install/flagger-install-on-google-cloud.md
@@ -186,7 +186,7 @@ Install cert-manager's CRDs:
 ```bash
 CERT_REPO=https://raw.githubusercontent.com/jetstack/cert-manager
 
-kubectl apply -f ${CERT_REPO}/release-0.6/deploy/manifests/00-crds.yaml
+kubectl apply -f ${CERT_REPO}/release-0.7/deploy/manifests/00-crds.yaml
 ```
 
 Create the cert-manager namespace and disable resource validation:
@@ -200,10 +200,12 @@ kubectl label namespace cert-manager certmanager.k8s.io/disable-validation=true
 Install cert-manager with Helm:
 
 ```bash
-helm repo update && helm upgrade -i cert-manager \
+helm repo add jetstack https://charts.jetstack.io && \
+helm repo update && \
+helm upgrade -i cert-manager \
 --namespace cert-manager \
---version v0.6.0 \
-stable/cert-manager
+--version v0.7.0 \
+jetstack/cert-manager
 ```
 
 ### Istio Gateway TLS setup

--- a/pkg/apis/flagger/v1alpha3/types.go
+++ b/pkg/apis/flagger/v1alpha3/types.go
@@ -148,11 +148,24 @@ type CanaryMetric struct {
 	Query string `json:"query,omitempty"`
 }
 
+// HookType can be pre, post or during rollout
+type HookType string
+
+const (
+	// RolloutHook execute webhook during the canary analysis
+	RolloutHook HookType = "rollout"
+	// PreRolloutHook execute webhook before routing traffic to canary
+	PreRolloutHook HookType = "pre-rollout"
+	// PreRolloutHook execute webhook after the canary analysis
+	PostRolloutHook HookType = "post-rollout"
+)
+
 // CanaryWebhook holds the reference to external checks used for canary analysis
 type CanaryWebhook struct {
-	Name    string `json:"name"`
-	URL     string `json:"url"`
-	Timeout string `json:"timeout"`
+	Type    HookType `json:"type"`
+	Name    string   `json:"name"`
+	URL     string   `json:"url"`
+	Timeout string   `json:"timeout"`
 	// +optional
 	Metadata *map[string]string `json:"metadata,omitempty"`
 }
@@ -161,6 +174,7 @@ type CanaryWebhook struct {
 type CanaryWebhookPayload struct {
 	Name      string            `json:"name"`
 	Namespace string            `json:"namespace"`
+	Phase     CanaryPhase       `json:"phase"`
 	Metadata  map[string]string `json:"metadata,omitempty"`
 }
 

--- a/pkg/controller/webhook.go
+++ b/pkg/controller/webhook.go
@@ -15,10 +15,11 @@ import (
 
 // CallWebhook does a HTTP POST to an external service and
 // returns an error if the response status code is non-2xx
-func CallWebhook(name string, namespace string, w flaggerv1.CanaryWebhook) error {
+func CallWebhook(name string, namespace string, phase flaggerv1.CanaryPhase, w flaggerv1.CanaryWebhook) error {
 	payload := flaggerv1.CanaryWebhookPayload{
 		Name:      name,
 		Namespace: namespace,
+		Phase:     phase,
 	}
 
 	if w.Metadata != nil {

--- a/pkg/controller/webhook_test.go
+++ b/pkg/controller/webhook_test.go
@@ -19,7 +19,7 @@ func TestCallWebhook(t *testing.T) {
 		Metadata: &map[string]string{"key1": "val1"},
 	}
 
-	err := CallWebhook("podinfo", "default", hook)
+	err := CallWebhook("podinfo", "default", flaggerv1.CanaryProgressing, hook)
 	if err != nil {
 		t.Fatal(err.Error())
 	}
@@ -35,7 +35,7 @@ func TestCallWebhook_StatusCode(t *testing.T) {
 		URL:  ts.URL,
 	}
 
-	err := CallWebhook("podinfo", "default", hook)
+	err := CallWebhook("podinfo", "default", flaggerv1.CanaryProgressing, hook)
 	if err == nil {
 		t.Errorf("Got no error wanted %v", http.StatusInternalServerError)
 	}


### PR DESCRIPTION
This PR introduces two types of web hooks:
- `pre-rollout` hooks are executed before routing traffic to canary. The canary advancement is paused if a pre-rollout hook fails and if the number of failures reach the threshold the canary will be rollback.
- `post-rollout` hooks are executed after the canary has been promoted or rolled back. If a post rollout  hook fails the error is logged.

Example:

```yaml
apiVersion: flagger.app/v1alpha3
kind: Canary
spec:
  canaryAnalysis:
    webhooks:
      - name: "smoke test"
        type: pre-rollout
        url: http://some.service:8080/
        timeout: 5s
        metadata:
          some: "data"
      - name: "load test"
        type: rollout
        url: http://flagger-loadtester.test/
        timeout: 5s
        metadata:
          cmd: "hey -z 1m -q 5 -c 2 http://podinfo-canary.test:9898/"
      - name: "notify"
        type: post-rollout
        url: http://telegram.bot:8888/
        timeout: 5s
        metadata:
          some: "message"
```

If the webhook type is not specified it will default to `rollout` making this change backwards compatible.

Fix: #117