### PR TITLE
Fix #177 Do not copy labels from canary to primary deployment

### DIFF
--- a/pkg/canary/deployer.go
+++ b/pkg/canary/deployer.go
@@ -214,7 +214,6 @@ func (c *Deployer) createPrimaryDeployment(cd *flaggerv1.Canary) (string, error)
 		primaryDep = &appsv1.Deployment{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      primaryName,
-				Labels:    canaryDep.Labels,
 				Namespace: cd.Namespace,
 				OwnerReferences: []metav1.OwnerReference{
 					*metav1.NewControllerRef(cd, schema.GroupVersionKind{


### PR DESCRIPTION
Initial draft of a solution for #177
It doesn't copy the labels and adds `canary.spec.deployment.labels`

I'm not sure how the client is generated from the spec, I ran `./hack/update-codegen.sh`