### PR TITLE
Fix promoting canary when max weight is not a multiple of step

### DIFF
--- a/pkg/controller/scheduler.go
+++ b/pkg/controller/scheduler.go
@@ -360,7 +360,7 @@ func (c *Controller) advanceCanary(name string, namespace string, skipLivenessCh
 		c.recordEventInfof(cd, "Advance %s.%s canary weight %v", cd.Name, cd.Namespace, canaryWeight)
 
 		// promote canary
-		if canaryWeight == maxWeight {
+		if canaryWeight >= maxWeight {
 			c.recordEventInfof(cd, "Copying %s.%s template spec to %s.%s",
 				cd.Spec.TargetRef.Name, cd.Namespace, primaryName, cd.Namespace)
 			if err := c.deployer.Promote(cd); err != nil {


### PR DESCRIPTION
In canary scenario, if `maxWeight` is not exact multiple of `stepWeight` then during canary promotion flow the new spec will not be copied to primary. The canary will be reported successful, but the app version will be the old one. 

This solves https://github.com/weaveworks/flagger/issues/189