### PR TITLE
Implement helm and bash pre-rollout hooks

### DIFF
--- a/Dockerfile.loadtester
+++ b/Dockerfile.loadtester
@@ -21,6 +21,10 @@ WORKDIR /home/app
 RUN curl -sSLo hey "https://storage.googleapis.com/jblabs/dist/hey_linux_v0.1.2" && \
 chmod +x hey && mv hey /usr/local/bin/hey
 
+RUN curl -sSL "https://get.helm.sh/helm-v2.12.3-linux-amd64.tar.gz" | tar xvz && \
+chmod +x linux-amd64/helm && mv linux-amd64/helm /usr/local/bin/helm && \
+rm -rf linux-amd64
+
 COPY --from=builder /go/src/github.com/weaveworks/flagger/loadtester .
 
 RUN chown -R app:app ./

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ LT_VERSION?=$(shell grep 'VERSION' cmd/loadtester/main.go | awk '{ print $$4 }' 
 TS=$(shell date +%Y-%m-%d_%H-%M-%S)
 
 run:
-	go run cmd/flagger/* -kubeconfig=$$HOME/.kube/config -log-level=info \
+	go run cmd/flagger/* -kubeconfig=$$HOME/.kube/config -log-level=info -mesh-provider=istio -namespace=test \
 	-metrics-server=https://prometheus.istio.weavedx.com \
 	-slack-url=https://hooks.slack.com/services/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 \
 	-slack-channel="devops-alerts"
@@ -105,6 +105,11 @@ reset-test:
 	kubectl delete -f ./artifacts/namespaces
 	kubectl apply -f ./artifacts/namespaces
 	kubectl apply -f ./artifacts/canaries
+
+loadtester-run:
+	docker build -t weaveworks/flagger-loadtester:$(LT_VERSION) . -f Dockerfile.loadtester
+	docker rm -f tester || true
+	docker run -dp 8888:9090 --name tester weaveworks/flagger-loadtester:$(LT_VERSION)
 
 loadtester-push:
 	docker build -t weaveworks/flagger-loadtester:$(LT_VERSION) . -f Dockerfile.loadtester

--- a/artifacts/canaries/canary.yaml
+++ b/artifacts/canaries/canary.yaml
@@ -73,5 +73,5 @@ spec:
         timeout: 5s
         metadata:
           type: cmd
-          cmd: "hey -z 1m -q 10 -c 2 http://podinfo.test:9898/"
+          cmd: "hey -z 1m -q 10 -c 2 http://podinfo-canary.test:9898/"
           logCmdOutput: "true"

--- a/artifacts/helmtester/deployment.yaml
+++ b/artifacts/helmtester/deployment.yaml
@@ -18,7 +18,7 @@ spec:
       serviceAccountName: tiller
       containers:
         - name: helmtester
-          image: weaveworks/flagger-loadtester:0.4.0-beta.2
+          image: weaveworks/flagger-loadtester:0.4.0-beta.5
           imagePullPolicy: IfNotPresent
           ports:
             - name: http

--- a/artifacts/helmtester/deployment.yaml
+++ b/artifacts/helmtester/deployment.yaml
@@ -1,0 +1,57 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: flagger-helmtester
+  labels:
+    app: flagger-helmtester
+spec:
+  selector:
+    matchLabels:
+      app: flagger-helmtester
+  template:
+    metadata:
+      labels:
+        app: flagger-helmtester
+      annotations:
+        prometheus.io/scrape: "true"
+    spec:
+      serviceAccountName: tiller
+      containers:
+        - name: helmtester
+          image: weaveworks/flagger-loadtester:0.4.0-beta.2
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 8080
+          command:
+            - ./loadtester
+            - -port=8080
+            - -log-level=info
+            - -timeout=1h
+          livenessProbe:
+            exec:
+              command:
+                - wget
+                - --quiet
+                - --tries=1
+                - --timeout=4
+                - --spider
+                - http://localhost:8080/healthz
+            timeoutSeconds: 5
+          readinessProbe:
+            exec:
+              command:
+                - wget
+                - --quiet
+                - --tries=1
+                - --timeout=4
+                - --spider
+                - http://localhost:8080/healthz
+            timeoutSeconds: 5
+          resources:
+            limits:
+              memory: "512Mi"
+              cpu: "1000m"
+            requests:
+              memory: "32Mi"
+              cpu: "10m"

--- a/artifacts/helmtester/deployment.yaml
+++ b/artifacts/helmtester/deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: flagger-helmtester
+  namespace: kube-system
   labels:
     app: flagger-helmtester
 spec:
@@ -18,7 +19,7 @@ spec:
       serviceAccountName: tiller
       containers:
         - name: helmtester
-          image: weaveworks/flagger-loadtester:0.4.0-beta.5
+          image: weaveworks/flagger-loadtester:0.4.0
           imagePullPolicy: IfNotPresent
           ports:
             - name: http

--- a/artifacts/helmtester/service.yaml
+++ b/artifacts/helmtester/service.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: flagger-helmtester
+  namespace: kube-system
   labels:
     app: flagger-helmtester
 spec:

--- a/artifacts/helmtester/service.yaml
+++ b/artifacts/helmtester/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: flagger-helmtester
+  labels:
+    app: flagger-helmtester
+spec:
+  type: ClusterIP
+  selector:
+    app: flagger-helmtester
+  ports:
+    - name: http
+      port: 80
+      protocol: TCP
+      targetPort: http

--- a/charts/loadtester/Chart.yaml
+++ b/charts/loadtester/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: loadtester
-version: 0.4.0
-appVersion: 0.3.0
+version: 0.4.1
+appVersion: 0.4.0
 kubeVersion: ">=1.11.0-0"
 engine: gotpl
 description: Flagger's load testing services based on rakyll/hey that generates traffic during canary analysis when configured as a webhook.

--- a/charts/loadtester/README.md
+++ b/charts/loadtester/README.md
@@ -7,7 +7,6 @@ and can be used to generates traffic during canary analysis when configured as a
 ## Prerequisites
 
 * Kubernetes >= 1.11
-* Istio >= 1.0
 
 ## Installing the Chart
 
@@ -25,7 +24,7 @@ helm upgrade -i flagger-loadtester flagger/loadtester
 
 The command deploys Grafana on the Kubernetes cluster in the default namespace.
 
-> **Tip**: Note that the namespace where you deploy the load tester should have the Istio sidecar injection enabled
+> **Tip**: Note that the namespace where you deploy the load tester should have the Istio or App Mesh sidecar injection enabled
 
 The [configuration](#configuration) section lists the parameters that can be configured during installation.
 
@@ -48,13 +47,14 @@ Parameter | Description | Default
 `image.repository` | Image repository | `quay.io/stefanprodan/flagger-loadtester`
 `image.pullPolicy` | Image pull policy | `IfNotPresent`
 `image.tag` | Image tag | `<VERSION>`
-`replicaCount` | desired number of pods | `1`
+`replicaCount` | Desired number of pods | `1`
+`serviceAccountName` | Kubernetes service account name | `none` 
 `resources.requests.cpu` | CPU requests | `10m`
-`resources.requests.memory` | memory requests | `64Mi`
+`resources.requests.memory` | Memory requests | `64Mi`
 `tolerations` | List of node taints to tolerate | `[]`
 `affinity` | node/pod affinities | `node`
-`nodeSelector` | node labels for pod assignment | `{}`
-`service.type` | type of service | `ClusterIP`
+`nodeSelector` | Node labels for pod assignment | `{}`
+`service.type` | Type of service | `ClusterIP`
 `service.port` | ClusterIP port | `80`
 `cmd.timeout` | Command execution timeout | `1h`
 `logLevel` | Log level can be debug, info, warning, error or panic | `info`

--- a/charts/loadtester/templates/deployment.yaml
+++ b/charts/loadtester/templates/deployment.yaml
@@ -19,6 +19,9 @@ spec:
       annotations:
         appmesh.k8s.aws/ports: "444"
     spec:
+      {{- if .Values.serviceAccountName }}
+      serviceAccountName: {{ .Values.serviceAccountName }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/charts/loadtester/values.yaml
+++ b/charts/loadtester/values.yaml
@@ -2,7 +2,7 @@ replicaCount: 1
 
 image:
   repository: weaveworks/flagger-loadtester
-  tag: 0.3.0
+  tag: 0.4.0
   pullPolicy: IfNotPresent
 
 logLevel: info
@@ -26,6 +26,8 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+serviceAccountName: ""
 
 # App Mesh virtual node settings
 meshName: ""

--- a/charts/podinfo/Chart.yaml
+++ b/charts/podinfo/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-version: 2.0.1
+version: 2.1.0
 appVersion: 1.4.0
 name: podinfo
 engine: gotpl

--- a/charts/podinfo/templates/canary.yaml
+++ b/charts/podinfo/templates/canary.yaml
@@ -38,8 +38,17 @@ spec:
     - name: request-duration
       threshold: {{ .Values.canary.thresholds.latency }}
       interval: 1m
-    {{- if .Values.canary.loadtest.enabled }}
     webhooks:
+      {{- if .Values.canary.helmtest.enabled }}
+      - name: "helm test"
+        type: pre-rollout
+        url: {{ .Values.canary.helmtest.url }}
+        timeout: 3m
+        metadata:
+          type: "helm"
+          cmd: "test {{ .Release.Name }} --cleanup"
+      {{- end }}
+      {{- if .Values.canary.loadtest.enabled }}
       - name: load-test-get
         url: {{ .Values.canary.loadtest.url }}
         timeout: 5s
@@ -50,5 +59,5 @@ spec:
         timeout: 5s
         metadata:
           cmd: "hey -z 1m -q 5 -c 2 -m POST -d '{\"test\": true}' http://{{ template "podinfo.fullname" . }}.{{ .Release.Namespace }}:{{ .Values.service.port }}/echo"
-    {{- end }}
+      {{- end }}
 {{- end }}

--- a/charts/podinfo/values.yaml
+++ b/charts/podinfo/values.yaml
@@ -45,6 +45,10 @@ canary:
     enabled: false
     # load tester address
     url: http://flagger-loadtester.test/
+  helmtest:
+    enabled: false
+    # helm tester address
+    url: http://flagger-helmtester.kube-system/
 
 resources:
   limits:

--- a/cmd/loadtester/main.go
+++ b/cmd/loadtester/main.go
@@ -10,7 +10,7 @@ import (
 	"time"
 )
 
-var VERSION = "0.4.0-beta.2"
+var VERSION = "0.4.0-beta.5"
 var (
 	logLevel          string
 	port              string

--- a/cmd/loadtester/main.go
+++ b/cmd/loadtester/main.go
@@ -10,7 +10,7 @@ import (
 	"time"
 )
 
-var VERSION = "0.3.0"
+var VERSION = "0.4.0-beta.2"
 var (
 	logLevel          string
 	port              string

--- a/cmd/loadtester/main.go
+++ b/cmd/loadtester/main.go
@@ -10,7 +10,7 @@ import (
 	"time"
 )
 
-var VERSION = "0.4.0-beta.5"
+var VERSION = "0.4.0"
 var (
 	logLevel          string
 	port              string

--- a/docs/gitbook/how-it-works.md
+++ b/docs/gitbook/how-it-works.md
@@ -591,13 +591,13 @@ Spec:
 ```yaml
   canaryAnalysis:
     webhooks:
-      - name: "smoke test"
+      - name: "helm tests"
         type: pre-rollout
-        url: http://migration-check.db/query
-        timeout: 30s
+        url: http://flagger-helmtester.kube-system/
+        timeout: 3m
         metadata:
-          key1: "val1"
-          key2: "val2"
+          type: "helm"
+          cmd: "test podinfo --cleanup"
       - name: "load test"
         type: rollout
         url: http://flagger-loadtester.test/

--- a/docs/gitbook/tutorials/canary-helm-gitops.md
+++ b/docs/gitbook/tutorials/canary-helm-gitops.md
@@ -18,7 +18,11 @@ and the canary configuration file.
 │   ├── canary.yaml
 │   ├── configmap.yaml
 │   ├── deployment.yaml
-│   └── hpa.yaml
+│   ├── hpa.yaml
+│   ├── service.yaml
+│   └── tests
+│       ├── test-config.yaml
+│       └── test-pod.yaml
 └── values.yaml
 ```
 
@@ -47,7 +51,7 @@ helm upgrade -i frontend flagger/podinfo \
 --namespace test \
 --set nameOverride=frontend \
 --set backend=http://backend.test:9898/echo \
---set canary.enabled=true \
+--set canary.loadtest.enabled=true \
 --set canary.istioIngress.enabled=true \
 --set canary.istioIngress.gateway=public-gateway.istio-system.svc.cluster.local \
 --set canary.istioIngress.host=frontend.istio.example.com
@@ -87,7 +91,7 @@ Now let's install the `backend` release without exposing it outside the mesh:
 helm upgrade -i backend flagger/podinfo \
 --namespace test \
 --set nameOverride=backend \
---set canary.enabled=true \
+--set canary.loadtest.enabled=true \
 --set canary.istioIngress.enabled=false
 ```
 
@@ -118,17 +122,26 @@ helm upgrade -i flagger-loadtester flagger/loadtester \
 --namespace=test
 ```
 
-Enable the load tester and deploy a new `frontend` version:
+Install Flagger's helm test runner in the `kube-system` using `tiller` service account:
+
+```bash
+helm upgrade -i flagger-helmtester flagger/loadtester \
+--namespace=kube-system \
+--set serviceAccountName=tiller
+```
+
+Enable the load and helm tester and deploy a new `frontend` version:
 
 ```bash
 helm upgrade -i frontend flagger/podinfo/ \
 --namespace test \
 --reuse-values \
 --set canary.loadtest.enabled=true \
+--set canary.helmtest.enabled=true \
 --set image.tag=1.4.1
 ```
 
-Flagger detects that the deployment revision changed and starts the canary analysis along with the load test:
+Flagger detects that the deployment revision changed and starts the canary analysis:
 
 ```
 kubectl -n istio-system logs deployment/flagger -f | jq .msg
@@ -136,6 +149,7 @@ kubectl -n istio-system logs deployment/flagger -f | jq .msg
 New revision detected! Scaling up frontend.test
 Halt advancement frontend.test waiting for rollout to finish: 0 of 2 updated replicas are available
 Starting canary analysis for frontend.test
+Pre-rollout check helm test passed
 Advance frontend.test canary weight 5
 Advance frontend.test canary weight 10
 Advance frontend.test canary weight 15
@@ -163,7 +177,7 @@ Now trigger a canary deployment for the `backend` app, but this time you'll chan
 helm upgrade -i backend flagger/podinfo/ \
 --namespace test \
 --reuse-values \
---set canary.loadtest.enabled=true \
+--set canary.helmtest.enabled=true \
 --set httpServer.timeout=25s
 ```
 
@@ -288,6 +302,8 @@ spec:
           host: frontend.istio.example.com
         loadtest:
           enabled: true
+        helmtest:
+          enabled: true
 ```
 
 In the `chart` section I've defined the release source by specifying the Helm repository (hosted on GitHub Pages), chart name and version.
@@ -333,6 +349,7 @@ A CI/CD pipeline for the `frontend` release could look like this:
 * Flux applies the updated Helm release on the cluster
 * Flux Helm Operator picks up the change and calls Tiller to upgrade the release
 * Flagger detects a revision change and scales up the `frontend` deployment
+* Flagger runs the helm test before routing traffic to the canary service
 * Flagger starts the load test and runs the canary analysis 
 * Based on the analysis result the canary deployment is promoted to production or rolled back
 * Flagger sends a Slack notification with the canary result
@@ -343,7 +360,7 @@ A canary deployment can fail due to any of the following reasons:
 
 * the container image can't be downloaded 
 * the deployment replica set is stuck for more then ten minutes (eg. due to a container crash loop)
-* the webooks (acceptance tests, load tests, etc) are returning a non 2xx response
+* the webooks (acceptance tests, helm tests, load tests, etc) are returning a non 2xx response
 * the HTTP success rate (non 5xx responses) metric drops under the threshold
 * the HTTP average duration metric goes over the threshold
 * the Istio telemetry service is unable to collect traffic metrics

--- a/docs/gitbook/tutorials/canary-helm-gitops.md
+++ b/docs/gitbook/tutorials/canary-helm-gitops.md
@@ -267,7 +267,8 @@ Create a git repository with the following content:
     └── test
         ├── backend.yaml
         ├── frontend.yaml
-        └── loadtester.yaml
+        ├── loadtester.yaml
+        └── helmtester.yaml
 ``` 
 
 You can find the git source [here](https://github.com/stefanprodan/flagger/tree/master/artifacts/cluster).
@@ -366,5 +367,6 @@ A canary deployment can fail due to any of the following reasons:
 * the Istio telemetry service is unable to collect traffic metrics
 * the metrics server (Prometheus) can't be reached
 
-If you want to find out more about managing Helm releases with Flux here is an in-depth guide 
-[github.com/stefanprodan/gitops-helm](https://github.com/stefanprodan/gitops-helm).
+If you want to find out more about managing Helm releases with Flux here are two in-depth guides: 
+[gitops-helm](https://github.com/stefanprodan/gitops-helm) and
+[gitops-istio](https://github.com/stefanprodan/gitops-istio).

--- a/docs/gitbook/usage/progressive-delivery.md
+++ b/docs/gitbook/usage/progressive-delivery.md
@@ -85,7 +85,7 @@ spec:
         url: http://flagger-loadtester.test/
         timeout: 5s
         metadata:
-          cmd: "hey -z 1m -q 10 -c 2 http://podinfo.test:9898/"
+          cmd: "hey -z 1m -q 10 -c 2 http://podinfo-canary.test:9898/"
 ```
 
 Save the above resource as podinfo-canary.yaml and then apply it:

--- a/pkg/loadtester/bash.go
+++ b/pkg/loadtester/bash.go
@@ -6,19 +6,19 @@ import (
 	"os/exec"
 )
 
-const TaskTypeBats = "bats"
+const TaskTypeBash = "bash"
 
-type BatsTask struct {
+type BashTask struct {
 	TaskBase
 	command      string
 	logCmdOutput bool
 }
 
-func (task *BatsTask) Hash() string {
+func (task *BashTask) Hash() string {
 	return hash(task.canary + task.command)
 }
 
-func (task *BatsTask) Run(ctx context.Context) (bool, error) {
+func (task *BashTask) Run(ctx context.Context) (bool, error) {
 	cmd := exec.CommandContext(ctx, "bash", "-c", task.command)
 	out, err := cmd.CombinedOutput()
 
@@ -34,6 +34,6 @@ func (task *BatsTask) Run(ctx context.Context) (bool, error) {
 	return true, nil
 }
 
-func (task *BatsTask) String() string {
+func (task *BashTask) String() string {
 	return task.command
 }

--- a/pkg/loadtester/helm.go
+++ b/pkg/loadtester/helm.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os/exec"
+	"strings"
 )
 
 const TaskTypeHelm = "helm"
@@ -22,7 +23,7 @@ func (task *HelmTask) Run(ctx context.Context) (bool, error) {
 	helmCmd := fmt.Sprintf("helm %s", task.command)
 	task.logger.With("canary", task.canary).Infof("running command %v", helmCmd)
 
-	cmd := exec.CommandContext(ctx, "bash", "-c", helmCmd)
+	cmd := exec.CommandContext(ctx, "helm", strings.Fields(task.command)...)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		task.logger.With("canary", task.canary).Errorf("command failed %s %v %s", task.command, err, out)

--- a/pkg/loadtester/helm.go
+++ b/pkg/loadtester/helm.go
@@ -1,0 +1,39 @@
+package loadtester
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+)
+
+const TaskTypeHelm = "helm"
+
+type HelmTask struct {
+	TaskBase
+	command      string
+	logCmdOutput bool
+}
+
+func (task *HelmTask) Hash() string {
+	return hash(task.canary + task.command)
+}
+
+func (task *HelmTask) Run(ctx context.Context) (bool, error) {
+	cmd := exec.CommandContext(ctx, "bash", "-c", task.command)
+	out, err := cmd.CombinedOutput()
+
+	if err != nil {
+		task.logger.With("canary", task.canary).Errorf("command failed %s %v %s", task.command, err, out)
+		return false, fmt.Errorf(" %v %v", err, out)
+	} else {
+		if task.logCmdOutput {
+			fmt.Printf("%s\n", out)
+		}
+		task.logger.With("canary", task.canary).Infof("command finished %s", task.command)
+	}
+	return true, nil
+}
+
+func (task *HelmTask) String() string {
+	return task.command
+}

--- a/pkg/loadtester/helm.go
+++ b/pkg/loadtester/helm.go
@@ -19,9 +19,11 @@ func (task *HelmTask) Hash() string {
 }
 
 func (task *HelmTask) Run(ctx context.Context) (bool, error) {
-	cmd := exec.CommandContext(ctx, "bash", "-c", "helm "+task.command)
-	out, err := cmd.CombinedOutput()
+	helmCmd := fmt.Sprintf("helm %s", task.command)
+	task.logger.With("canary", task.canary).Infof("running command %v", helmCmd)
 
+	cmd := exec.CommandContext(ctx, "bash", "-c", helmCmd)
+	out, err := cmd.CombinedOutput()
 	if err != nil {
 		task.logger.With("canary", task.canary).Errorf("command failed %s %v %s", task.command, err, out)
 		return false, fmt.Errorf(" %v %v", err, out)
@@ -29,7 +31,7 @@ func (task *HelmTask) Run(ctx context.Context) (bool, error) {
 		if task.logCmdOutput {
 			fmt.Printf("%s\n", out)
 		}
-		task.logger.With("canary", task.canary).Infof("command finished %v", cmd.Args)
+		task.logger.With("canary", task.canary).Infof("command finished %v", helmCmd)
 	}
 	return true, nil
 }

--- a/pkg/loadtester/helm.go
+++ b/pkg/loadtester/helm.go
@@ -19,7 +19,7 @@ func (task *HelmTask) Hash() string {
 }
 
 func (task *HelmTask) Run(ctx context.Context) (bool, error) {
-	cmd := exec.CommandContext(ctx, "bash", "-c", task.command)
+	cmd := exec.CommandContext(ctx, "bash", "-c", "helm "+task.command)
 	out, err := cmd.CombinedOutput()
 
 	if err != nil {
@@ -29,7 +29,7 @@ func (task *HelmTask) Run(ctx context.Context) (bool, error) {
 		if task.logCmdOutput {
 			fmt.Printf("%s\n", out)
 		}
-		task.logger.With("canary", task.canary).Infof("command finished %s", task.command)
+		task.logger.With("canary", task.canary).Infof("command finished %v", cmd.Args)
 	}
 	return true, nil
 }

--- a/pkg/loadtester/server.go
+++ b/pkg/loadtester/server.go
@@ -46,10 +46,12 @@ func ListenAndServe(port string, timeout time.Duration, logger *zap.SugaredLogge
 			}
 
 			// run bats command (blocking task)
-			if typ == TaskTypeBats {
-				bats := BatsTask{
+			if typ == TaskTypeBash {
+				logger.With("canary", payload.Name).Infof("bats command %s", payload.Metadata["cmd"])
+
+				bats := BashTask{
 					command:      payload.Metadata["cmd"],
-					logCmdOutput: taskRunner.logCmdOutput,
+					logCmdOutput: true,
 					TaskBase: TaskBase{
 						canary: fmt.Sprintf("%s.%s", payload.Name, payload.Namespace),
 						logger: logger,
@@ -63,6 +65,7 @@ func ListenAndServe(port string, timeout time.Duration, logger *zap.SugaredLogge
 				if !ok {
 					w.WriteHeader(http.StatusInternalServerError)
 					w.Write([]byte(err.Error()))
+					return
 				}
 
 				w.WriteHeader(http.StatusOK)
@@ -73,7 +76,7 @@ func ListenAndServe(port string, timeout time.Duration, logger *zap.SugaredLogge
 			if typ == TaskTypeHelm {
 				helm := HelmTask{
 					command:      payload.Metadata["cmd"],
-					logCmdOutput: taskRunner.logCmdOutput,
+					logCmdOutput: true,
 					TaskBase: TaskBase{
 						canary: fmt.Sprintf("%s.%s", payload.Name, payload.Namespace),
 						logger: logger,
@@ -87,6 +90,7 @@ func ListenAndServe(port string, timeout time.Duration, logger *zap.SugaredLogge
 				if !ok {
 					w.WriteHeader(http.StatusInternalServerError)
 					w.Write([]byte(err.Error()))
+					return
 				}
 
 				w.WriteHeader(http.StatusOK)


### PR DESCRIPTION
This PR adds two blocking commands to Flagger's test runner:
- `type: helm` intended for running helm tests
- `type: bash` intended for running bats tests 

**Usage**

Deploy the helm test runner in the `kube-system` namespace using the `tiller` service account:

```bash
kubectl apply -f artifacts/helmtester
```

Run helm and bats tests before the canary starts receiving traffic:

```yaml
  canaryAnalysis:
    webhooks:
      - name: "helm tests"
        type: pre-rollout
        url: http://flagger-helmtester.kube-system/
        timeout: 3m
        metadata:
          type: "helm"
          cmd: "test podinfo --cleanup"
      - name: "bats tests"
        type: pre-rollout
        url: http://flagger-batstester.istio-system/
        timeout: 5m
        metadata:
          type: "bash"
          cmd: "bats /tests/integration-test.bats"
```

Note that you should create a ConfigMap with your bats tests and mount it inside the tester container.
