### PR TITLE
Add ability to set Prometheus url with custom path without trailing "/"

### DIFF
--- a/pkg/metrics/client.go
+++ b/pkg/metrics/client.go
@@ -9,6 +9,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
+	"path"
 	"strconv"
 	"strings"
 	"text/template"
@@ -84,6 +85,7 @@ func (p *PrometheusClient) RunQuery(query string) (float64, error) {
 	if err != nil {
 		return 0, err
 	}
+	u.Path = path.Join(p.url.Path, u.Path)
 
 	u = p.url.ResolveReference(u)
 
@@ -150,6 +152,7 @@ func (p *PrometheusClient) IsOnline() (bool, error) {
 	if err != nil {
 		return false, err
 	}
+	u.Path = path.Join(p.url.Path, u.Path)
 
 	u = p.url.ResolveReference(u)
 


### PR DESCRIPTION
Fixes #193.

## What

Join URL paths so that custom path is taken into account.

## Additional context

With this change, I was able to install Flagger like this:

```
helm upgrade -i flagger flagger/flagger \
--namespace=istio-system \
--set metricsServer=http://prometheus.istio-system.svc.cluster.local/prometheus
```

... and execute a canary deployment based on the [docs](https://docs.flagger.app/usage/progressive-delivery) successfully. 

*It seems to also work with custom paths with trailing slashes (`prometheus/`) or without setting any custom paths.*
