### PR TITLE
Allow blue/green deployments without a service mesh provider

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,33 +8,27 @@ TS=$(shell date +%Y-%m-%d_%H-%M-%S)
 
 run:
 	go run cmd/flagger/* -kubeconfig=$$HOME/.kube/config -log-level=info -mesh-provider=istio -namespace=test \
-	-metrics-server=https://prometheus.istio.weavedx.com \
-	-slack-url=https://hooks.slack.com/services/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 \
-	-slack-channel="devops-alerts"
+	-metrics-server=https://prometheus.istio.weavedx.com
 
 run-appmesh:
 	go run cmd/flagger/* -kubeconfig=$$HOME/.kube/config -log-level=info -mesh-provider=appmesh \
-	-metrics-server=http://acfc235624ca911e9a94c02c4171f346-1585187926.us-west-2.elb.amazonaws.com:9090 \
-	-slack-url=https://hooks.slack.com/services/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 \
-	-slack-channel="devops-alerts"
+	-metrics-server=http://acfc235624ca911e9a94c02c4171f346-1585187926.us-west-2.elb.amazonaws.com:9090
 
 run-nginx:
 	go run cmd/flagger/* -kubeconfig=$$HOME/.kube/config -log-level=info -mesh-provider=nginx -namespace=nginx \
-	-metrics-server=http://prometheus-weave.istio.weavedx.com \
-	-slack-url=https://hooks.slack.com/services/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 \
-	-slack-channel="devops-alerts"
+	-metrics-server=http://prometheus-weave.istio.weavedx.com
 
 run-smi:
 	go run cmd/flagger/* -kubeconfig=$$HOME/.kube/config -log-level=info -mesh-provider=smi:istio -namespace=smi \
-	-metrics-server=https://prometheus.istio.weavedx.com \
-	-slack-url=https://hooks.slack.com/services/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 \
-	-slack-channel="devops-alerts"
+	-metrics-server=https://prometheus.istio.weavedx.com
 
 run-gloo:
 	go run cmd/flagger/* -kubeconfig=$$HOME/.kube/config -log-level=info -mesh-provider=gloo -namespace=gloo \
-	-metrics-server=https://prometheus.istio.weavedx.com \
-	-slack-url=https://hooks.slack.com/services/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 \
-	-slack-channel="devops-alerts"
+	-metrics-server=https://prometheus.istio.weavedx.com
+
+run-nop:
+	go run cmd/flagger/* -kubeconfig=$$HOME/.kube/config -log-level=info -mesh-provider=none -namespace=bg \
+	-metrics-server=https://prometheus.istio.weavedx.com
 
 build:
 	docker build -t weaveworks/flagger:$(TAG) . -f Dockerfile

--- a/artifacts/loadtester/deployment.yaml
+++ b/artifacts/loadtester/deployment.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
         - name: loadtester
-          image: weaveworks/flagger-loadtester:0.3.0
+          image: weaveworks/flagger-loadtester:0.4.0
           imagePullPolicy: IfNotPresent
           ports:
             - name: http

--- a/pkg/metrics/factory.go
+++ b/pkg/metrics/factory.go
@@ -24,6 +24,10 @@ func NewFactory(metricsServer string, meshProvider string, timeout time.Duration
 
 func (factory Factory) Observer() Interface {
 	switch {
+	case factory.MeshProvider == "none":
+		return &HttpObserver{
+			client: factory.Client,
+		}
 	case factory.MeshProvider == "appmesh":
 		return &EnvoyObserver{
 			client: factory.Client,

--- a/pkg/metrics/http.go
+++ b/pkg/metrics/http.go
@@ -1,0 +1,71 @@
+package metrics
+
+import "time"
+
+var httpQueries = map[string]string{
+	"request-success-rate": `
+	sum(
+		rate(
+			http_request_duration_seconds_count{
+				kubernetes_namespace="{{ .Namespace }}",
+				kubernetes_pod_name=~"{{ .Name }}-[0-9a-zA-Z]+(-[0-9a-zA-Z]+)",
+				status!~"5.*"
+			}[{{ .Interval }}]
+		)
+	) 
+	/ 
+	sum(
+		rate(
+			http_request_duration_seconds_count{
+				kubernetes_namespace="{{ .Namespace }}",
+				kubernetes_pod_name=~"{{ .Name }}-[0-9a-zA-Z]+(-[0-9a-zA-Z]+)"
+			}[{{ .Interval }}]
+		)
+	) 
+	* 100`,
+	"request-duration": `
+	histogram_quantile(
+		0.99,
+		sum(
+			rate(
+				http_request_duration_seconds_bucket{
+					kubernetes_namespace="{{ .Namespace }}",
+					kubernetes_pod_name=~"{{ .Name }}-[0-9a-zA-Z]+(-[0-9a-zA-Z]+)"
+				}[{{ .Interval }}]
+			)
+		) by (le)
+	)`,
+}
+
+type HttpObserver struct {
+	client *PrometheusClient
+}
+
+func (ob *HttpObserver) GetRequestSuccessRate(name string, namespace string, interval string) (float64, error) {
+	query, err := ob.client.RenderQuery(name, namespace, interval, httpQueries["request-success-rate"])
+	if err != nil {
+		return 0, err
+	}
+
+	value, err := ob.client.RunQuery(query)
+	if err != nil {
+		return 0, err
+	}
+
+	return value, nil
+}
+
+func (ob *HttpObserver) GetRequestDuration(name string, namespace string, interval string) (time.Duration, error) {
+	query, err := ob.client.RenderQuery(name, namespace, interval, httpQueries["request-duration"])
+	if err != nil {
+		return 0, err
+	}
+
+	value, err := ob.client.RunQuery(query)
+	if err != nil {
+		return 0, err
+	}
+
+	ms := time.Duration(int64(value*1000)) * time.Millisecond
+	return ms, nil
+}

--- a/pkg/metrics/http_test.go
+++ b/pkg/metrics/http_test.go
@@ -1,0 +1,74 @@
+package metrics
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestHttpObserver_GetRequestSuccessRate(t *testing.T) {
+	expected := `sum(rate(http_request_duration_seconds_count{kubernetes_namespace="default",kubernetes_pod_name=~"podinfo-[0-9a-zA-Z]+(-[0-9a-zA-Z]+)",status!~"5.*"}[1m]))/sum(rate(http_request_duration_seconds_count{kubernetes_namespace="default",kubernetes_pod_name=~"podinfo-[0-9a-zA-Z]+(-[0-9a-zA-Z]+)"}[1m]))*100`
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		promql := r.URL.Query()["query"][0]
+		if promql != expected {
+			t.Errorf("\nGot %s \nWanted %s", promql, expected)
+		}
+
+		json := `{"status":"success","data":{"resultType":"vector","result":[{"metric":{},"value":[1,"100"]}]}}`
+		w.Write([]byte(json))
+	}))
+	defer ts.Close()
+
+	client, err := NewPrometheusClient(ts.URL, time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	observer := &HttpObserver{
+		client: client,
+	}
+
+	val, err := observer.GetRequestSuccessRate("podinfo", "default", "1m")
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+
+	if val != 100 {
+		t.Errorf("Got %v wanted %v", val, 100)
+	}
+}
+
+func TestHttpObserver_GetRequestDuration(t *testing.T) {
+	expected := `histogram_quantile(0.99,sum(rate(http_request_duration_seconds_bucket{kubernetes_namespace="default",kubernetes_pod_name=~"podinfo-[0-9a-zA-Z]+(-[0-9a-zA-Z]+)"}[1m]))by(le))`
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		promql := r.URL.Query()["query"][0]
+		if promql != expected {
+			t.Errorf("\nGot %s \nWanted %s", promql, expected)
+		}
+
+		json := `{"status":"success","data":{"resultType":"vector","result":[{"metric":{},"value":[1,"0.100"]}]}}`
+		w.Write([]byte(json))
+	}))
+	defer ts.Close()
+
+	client, err := NewPrometheusClient(ts.URL, time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	observer := &HttpObserver{
+		client: client,
+	}
+
+	val, err := observer.GetRequestDuration("podinfo", "default", "1m")
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+
+	if val != 100*time.Millisecond {
+		t.Errorf("Got %v wanted %v", val, 100*time.Millisecond)
+	}
+}

--- a/pkg/router/factory.go
+++ b/pkg/router/factory.go
@@ -45,6 +45,8 @@ func (factory *Factory) KubernetesRouter(label string, ports *map[string]int32) 
 // MeshRouter returns a service mesh router
 func (factory *Factory) MeshRouter(provider string) Interface {
 	switch {
+	case provider == "none":
+		return &NopRouter{}
 	case provider == "nginx":
 		return &IngressRouter{
 			logger:     factory.logger,

--- a/pkg/router/nop.go
+++ b/pkg/router/nop.go
@@ -1,0 +1,24 @@
+package router
+
+import (
+	flaggerv1 "github.com/weaveworks/flagger/pkg/apis/flagger/v1alpha3"
+)
+
+// NopRouter no-operation router
+type NopRouter struct {
+}
+
+func (*NopRouter) Reconcile(canary *flaggerv1.Canary) error {
+	return nil
+}
+
+func (*NopRouter) SetRoutes(canary *flaggerv1.Canary, primaryWeight int, canaryWeight int) error {
+	return nil
+}
+
+func (*NopRouter) GetRoutes(canary *flaggerv1.Canary) (primaryWeight int, canaryWeight int, err error) {
+	if canary.Status.Iterations > 0 {
+		return 0, 100, nil
+	}
+	return 100, 0, nil
+}


### PR DESCRIPTION
This PR adds a no-operation router that can be activated with `-mesh-provider=none` command flag. This allows blue/green deployments to be performed without a service mesh or ingress controller. Fix: #209 

For the non service mesh promotions, the two builtin metrics are based on `http_request_duration_seconds` histogram that your app should expose or you can use custom promql queries like in the example below.

Blue/Green example:

```yaml
apiVersion: flagger.app/v1alpha3
kind: Canary
metadata:
  name: podinfo
  namespace: test
spec:
  targetRef:
    apiVersion: apps/v1
    kind: Deployment
    name: podinfo
  service:
    port: 9898
  canaryAnalysis:
    # schedule interval (default 60s)
    interval: 10s
    # max number of failed checks before rollback
    threshold: 10
    # number of checks to run before blue/green promotion
    iterations: 10
    # Prometheus checks
    metrics:
      - name: "tolerate 5% error rate"
        threshold: 5
        query: |
          100 - sum(
              rate(
                  http_request_duration_seconds_count{
                    namespace="test",
                    pod_name=~"podinfo-[0-9a-zA-Z]+(-[0-9a-zA-Z]+)",
                    status!~"5.*"
                  }[1m]
              )
          )
          /
          sum(
              rate(
                  http_request_duration_seconds_count{
                    namespace="test",
                    pod_name=~"podinfo-[0-9a-zA-Z]+(-[0-9a-zA-Z]+)"
                  }[1m]
              )
          ) * 100
      - name: "tolerate 500 milliseconds latency"
        threshold: 500
        interval: 1m
        query: |
          histogram_quantile(0.99,
            sum(
              rate(
                http_request_duration_seconds_bucket{
                  namespace="bg",
                  pod_name=~"podinfo-[0-9a-zA-Z]+(-[0-9a-zA-Z]+)"
                }[1m]
              )
            ) by (le)
          )
    webhooks:
      - name: smoke-test
        type: pre-rollout
        timeout: 15s
        url: https://tester.istio.weavedx.com/
        metadata:
          type: bash
          cmd: "curl -sd 'anon' http://podinfo-canary.bg:9898/token | grep token"
      - name: load-test
        url: https://flagger-loadtester.test/
        metadata:
          type: cmd
          cmd: "hey -z 1m -q 10 -c 2 http://podinfo-canary.test:9898/"
```