### PR TITLE
Upgrade e2e tests to Istio v1.2.0

### DIFF
--- a/test/e2e-istio.sh
+++ b/test/e2e-istio.sh
@@ -2,7 +2,7 @@
 
 set -o errexit
 
-ISTIO_VER="1.1.9"
+ISTIO_VER="1.2.0"
 REPO_ROOT=$(git rev-parse --show-toplevel)
 export KUBECONFIG="$(kind get kubeconfig-path --name="kind")"
 


### PR DESCRIPTION
There was a new Istio release earlier today. Don't know if its too soon to be bumping the version for the e2e tests.