### PR TITLE
Add the service mesh provider to the canary spec

### DIFF
--- a/artifacts/flagger/crd.yaml
+++ b/artifacts/flagger/crd.yaml
@@ -45,6 +45,8 @@ spec:
             - service
             - canaryAnalysis
           properties:
+            provider:
+              type: string
             progressDeadlineSeconds:
               type: number
             targetRef:

--- a/charts/flagger/templates/crd.yaml
+++ b/charts/flagger/templates/crd.yaml
@@ -46,6 +46,8 @@ spec:
             - service
             - canaryAnalysis
           properties:
+            provider:
+              type: string
             progressDeadlineSeconds:
               type: number
             targetRef:

--- a/pkg/apis/flagger/v1alpha3/types.go
+++ b/pkg/apis/flagger/v1alpha3/types.go
@@ -45,6 +45,10 @@ type Canary struct {
 
 // CanarySpec is the spec for a Canary resource
 type CanarySpec struct {
+	// if specified overwrites the -mesh-provider flag for this particular canary
+	// +optional
+	Provider string `json:"provider,omitempty"`
+
 	// reference to target resource
 	TargetRef hpav1.CrossVersionObjectReference `json:"targetRef"`
 

--- a/pkg/router/factory.go
+++ b/pkg/router/factory.go
@@ -47,6 +47,8 @@ func (factory *Factory) MeshRouter(provider string) Interface {
 	switch {
 	case provider == "none":
 		return &NopRouter{}
+	case provider == "kubernetes":
+		return &NopRouter{}
 	case provider == "nginx":
 		return &IngressRouter{
 			logger:     factory.logger,


### PR DESCRIPTION
This PR adds the `provider` optional field to the canary spec. When specified it will override the global provider set with `-mesh-provider` flag. This allows running canaries on the same cluster that target different providers e.g. A/B testing with `provider: nginx` and Blue/Green with `provider: kubernetes`.

Fix: #215 