### PR TITLE
Update e2e tests to Kubernetes 1.14

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,7 +96,7 @@ jobs:
       - attach_workspace:
           at: /tmp/bin
       - run: test/container-build.sh
-      - run: test/e2e-kind.sh
+      - run: test/e2e-kind.sh 0.2.1
       - run: test/e2e-supergloo.sh
       - run: test/e2e-tests.sh canary
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,7 +107,7 @@ jobs:
       - attach_workspace:
           at: /tmp/bin
       - run: test/container-build.sh
-      - run: test/e2e-kind.sh
+      - run: test/e2e-kind.sh 0.2.1
       - run: test/e2e-gloo.sh
       - run: test/e2e-gloo-tests.sh
 

--- a/test/e2e-istio-values.yaml
+++ b/test/e2e-istio-values.yaml
@@ -22,7 +22,7 @@ sidecarInjectorWebhook:
 
 # galley configuration
 galley:
-  enabled: false
+  enabled: true
 
 # mixer configuration
 mixer:
@@ -59,4 +59,4 @@ global:
       limits:
         cpu: 1000m
         memory: 256Mi
-  useMCP: false
+  useMCP: true

--- a/test/e2e-istio.sh
+++ b/test/e2e-istio.sh
@@ -15,6 +15,7 @@ helm upgrade -i istio-init istio.io/istio-init --wait --namespace istio-system
 echo '>>> Waiting for Istio CRDs to be ready'
 kubectl -n istio-system wait --for=condition=complete job/istio-init-crd-10
 kubectl -n istio-system wait --for=condition=complete job/istio-init-crd-11
+kubectl -n istio-system wait --for=condition=complete job/istio-init-crd-12
 
 echo '>>> Installing Istio control plane'
 helm upgrade -i istio istio.io/istio --wait --namespace istio-system -f ${REPO_ROOT}/test/e2e-istio-values.yaml

--- a/test/e2e-kind.sh
+++ b/test/e2e-kind.sh
@@ -3,7 +3,7 @@
 set -o errexit
 
 REPO_ROOT=$(git rev-parse --show-toplevel)
-KIND_VERSION=0.2.1
+KIND_VERSION=v0.3.0
 
 echo ">>> Installing kubectl"
 curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl && \

--- a/test/e2e-kind.sh
+++ b/test/e2e-kind.sh
@@ -3,7 +3,7 @@
 set -o errexit
 
 REPO_ROOT=$(git rev-parse --show-toplevel)
-KIND_VERSION=v0.3.0
+KIND_VERSION=0.2.1
 
 echo ">>> Installing kubectl"
 curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl && \

--- a/test/e2e-kind.sh
+++ b/test/e2e-kind.sh
@@ -3,7 +3,7 @@
 set -o errexit
 
 REPO_ROOT=$(git rev-parse --show-toplevel)
-KIND_VERSION=0.3.0
+KIND_VERSION=v0.3.0
 
 echo ">>> Installing kubectl"
 curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl && \

--- a/test/e2e-kind.sh
+++ b/test/e2e-kind.sh
@@ -5,6 +5,10 @@ set -o errexit
 REPO_ROOT=$(git rev-parse --show-toplevel)
 KIND_VERSION=v0.3.0
 
+if [[ "$1" ]]; then
+  KIND_VERSION=$1
+fi
+
 echo ">>> Installing kubectl"
 curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl && \
 chmod +x kubectl && \

--- a/test/e2e-supergloo.sh
+++ b/test/e2e-supergloo.sh
@@ -18,11 +18,6 @@ kubectl create ns istio-system
 ./supergloo-cli install istio --name test --namespace supergloo-system --auto-inject=true --installation-namespace istio-system --mtls=false --prometheus=true --version ${ISTIO_VER}
 
 echo '>>> Waiting for Istio to be ready'
-until kubectl -n supergloo-system get mesh test
-do
-  sleep 2
-done
-
 retries=50
 count=0
 ok=false

--- a/test/e2e-supergloo.sh
+++ b/test/e2e-supergloo.sh
@@ -2,7 +2,7 @@
 
 set -o errexit
 
-ISTIO_VER="1.0.6"
+ISTIO_VER="1.1.3"
 SUPERGLOO_VER="v0.3.23"
 REPO_ROOT=$(git rev-parse --show-toplevel)
 export KUBECONFIG="$(kind get kubeconfig-path --name="kind")"
@@ -16,12 +16,6 @@ echo ">>> Installing Supergloo"
 echo ">>> Installing Istio ${ISTIO_VER}"
 kubectl create ns istio-system
 ./supergloo-cli install istio --name test --namespace supergloo-system --auto-inject=true --installation-namespace istio-system --mtls=false --prometheus=true --version ${ISTIO_VER}
-
-echo '>>> Waiting for Istio to be ready'
-until kubectl -n supergloo-system get mesh test
-do
-  sleep 2
-done
 
 kubectl -n istio-system rollout status deployment/istio-pilot
 kubectl -n istio-system rollout status deployment/istio-policy

--- a/test/e2e-supergloo.sh
+++ b/test/e2e-supergloo.sh
@@ -2,12 +2,13 @@
 
 set -o errexit
 
-ISTIO_VER="1.0.6"
+ISTIO_VER="1.1.6"
+SUPERGLOO_VER="v0.3.23"
 REPO_ROOT=$(git rev-parse --show-toplevel)
 export KUBECONFIG="$(kind get kubeconfig-path --name="kind")"
 
 echo ">>> Downloading Supergloo CLI"
-curl -SsL https://github.com/solo-io/supergloo/releases/download/v0.3.13/supergloo-cli-linux-amd64 > supergloo-cli
+curl -SsL https://github.com/solo-io/supergloo/releases/download/${SUPERGLOO_VER}/supergloo-cli-linux-amd64 > supergloo-cli
 chmod +x supergloo-cli
 
 echo ">>> Installing Supergloo"

--- a/test/e2e-supergloo.sh
+++ b/test/e2e-supergloo.sh
@@ -2,7 +2,7 @@
 
 set -o errexit
 
-ISTIO_VER="1.1.3"
+ISTIO_VER="1.0.6"
 SUPERGLOO_VER="v0.3.23"
 REPO_ROOT=$(git rev-parse --show-toplevel)
 export KUBECONFIG="$(kind get kubeconfig-path --name="kind")"

--- a/test/e2e-supergloo.sh
+++ b/test/e2e-supergloo.sh
@@ -2,7 +2,7 @@
 
 set -o errexit
 
-ISTIO_VER="1.1.6"
+ISTIO_VER="1.0.6"
 SUPERGLOO_VER="v0.3.23"
 REPO_ROOT=$(git rev-parse --show-toplevel)
 export KUBECONFIG="$(kind get kubeconfig-path --name="kind")"

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -125,7 +125,7 @@ done
 
 echo '✔ Canary promotion test passed'
 
-if [ "$1" = "canary" ]; then
+if [[ "$1" = "canary" ]]; then
   exit 0
 fi
 

--- a/test/e2e-workload.yaml
+++ b/test/e2e-workload.yaml
@@ -41,21 +41,15 @@ spec:
         - name: PODINFO_UI_COLOR
           value: blue
         livenessProbe:
-          exec:
-            command:
-            - podcli
-            - check
-            - http
-            - localhost:9898/healthz
+          httpGet:
+            port: 9898
+            path: /healthz
           initialDelaySeconds: 5
           timeoutSeconds: 5
         readinessProbe:
-          exec:
-            command:
-            - podcli
-            - check
-            - http
-            - localhost:9898/readyz
+          httpGet:
+            port: 9898
+            path: /readyz
           initialDelaySeconds: 5
           timeoutSeconds: 5
         resources:


### PR DESCRIPTION
- update istio, smi and nginx e2e to Kubernetes Kind v0.3.0
- pin Gloo and Supergloo e2e to Kind 0.2.1 as they don't seem to work on 0.3.0 and Kubernetes 1.14