### PR TITLE
Update Grafana and Kubernetes Kind

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: grafana
-version: 1.2.0
-appVersion: 5.4.3
+version: 1.3.0
+appVersion: 6.2.5
 description: Grafana dashboards for monitoring Flagger canary deployments
 icon: https://raw.githubusercontent.com/weaveworks/flagger/master/docs/logo/flagger-icon.png
 home: https://flagger.app

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: grafana/grafana
-  tag: 5.4.3
+  tag: 6.2.5
   pullPolicy: IfNotPresent
 
 service:

--- a/charts/podinfo/Chart.yaml
+++ b/charts/podinfo/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-version: 2.1.0
+version: 2.2.0
 appVersion: 1.4.0
 name: podinfo
 engine: gotpl

--- a/charts/podinfo/templates/canary.yaml
+++ b/charts/podinfo/templates/canary.yaml
@@ -26,6 +26,9 @@ spec:
     hosts:
     - {{ .Values.canary.istioIngress.host }}
     {{- end }}
+    trafficPolicy:
+      tls:
+        mode: {{ .Values.canary.istioTLS }}
   canaryAnalysis:
     interval: {{ .Values.canary.analysis.interval }}
     threshold: {{ .Values.canary.analysis.threshold }}

--- a/charts/podinfo/values.yaml
+++ b/charts/podinfo/values.yaml
@@ -17,6 +17,8 @@ hpa:
 
 canary:
   enabled: true
+  # Istio traffic policy tls can be DISABLE or ISTIO_MUTUAL
+  istioTLS: DISABLE
   istioIngress:
     enabled: false
     # Istio ingress gateway name

--- a/test/e2e-kind.sh
+++ b/test/e2e-kind.sh
@@ -3,7 +3,7 @@
 set -o errexit
 
 REPO_ROOT=$(git rev-parse --show-toplevel)
-KIND_VERSION=v0.3.0
+KIND_VERSION=v0.4.0
 
 if [[ "$1" ]]; then
   KIND_VERSION=$1


### PR DESCRIPTION
* update Grafana to v6.2.5 fix: #226 
* e2e testing: update Kubernetes Kind to v0.4.0
* add Istio TLS mode to podinfo chart