### PR TITLE
Update Gloo and Prometheus

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,7 +107,7 @@ jobs:
       - attach_workspace:
           at: /tmp/bin
       - run: test/container-build.sh
-      - run: test/e2e-kind.sh 0.2.1
+      - run: test/e2e-kind.sh
       - run: test/e2e-gloo.sh
       - run: test/e2e-gloo-tests.sh
 

--- a/charts/flagger/templates/prometheus.yaml
+++ b/charts/flagger/templates/prometheus.yaml
@@ -238,10 +238,10 @@ spec:
       serviceAccountName: {{ template "flagger.serviceAccountName" . }}-prometheus
       containers:
         - name: prometheus
-          image: "docker.io/prom/prometheus:v2.7.1"
+          image: "docker.io/prom/prometheus:v2.10.0"
           imagePullPolicy: IfNotPresent
           args:
-            - '--storage.tsdb.retention=6h'
+            - '--storage.tsdb.retention=2h'
             - '--config.file=/etc/prometheus/prometheus.yml'
           ports:
             - containerPort: 9090

--- a/test/e2e-gloo.sh
+++ b/test/e2e-gloo.sh
@@ -2,7 +2,7 @@
 
 set -o errexit
 
-GLOO_VER="0.14.0"
+GLOO_VER="0.14.2"
 REPO_ROOT=$(git rev-parse --show-toplevel)
 export KUBECONFIG="$(kind get kubeconfig-path --name="kind")"
 


### PR DESCRIPTION
- e2e testing: update Gloo to 0.14.2
- e2e testing: use Kind 0.3.0 for Gloo e2e
- helm chart: update Prometheus to v2.10.0 and set retention to 2h