### PR TITLE
Implement leader election

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,14 @@ TS=$(shell date +%Y-%m-%d_%H-%M-%S)
 
 run:
 	GO111MODULE=on go run cmd/flagger/* -kubeconfig=$$HOME/.kube/config -log-level=info -mesh-provider=istio -namespace=test \
-	-metrics-server=https://prometheus.istio.weavedx.com
+	-metrics-server=https://prometheus.istio.weavedx.com \
+	-enable-leader-election=true
+
+run2:
+	GO111MODULE=on go run cmd/flagger/* -kubeconfig=$$HOME/.kube/config -log-level=info -mesh-provider=istio -namespace=test \
+	-metrics-server=https://prometheus.istio.weavedx.com \
+	-enable-leader-election=true \
+	-port=9092
 
 run-appmesh:
 	GO111MODULE=on go run cmd/flagger/* -kubeconfig=$$HOME/.kube/config -log-level=info -mesh-provider=appmesh \

--- a/charts/flagger/README.md
+++ b/charts/flagger/README.md
@@ -64,6 +64,8 @@ Parameter | Description | Default
 `slack.channel` | Slack channel | None
 `slack.user` | Slack username | `flagger`
 `msteams.url` | Microsoft Teams incoming webhook | None
+`leaderElection.enabled` | leader election must be enabled when running more than one replica | `false`
+`leaderElection.replicaCount` | number of replicas | `1`
 `rbac.create` | if `true`, create and use RBAC resources | `true`
 `rbac.pspEnabled` | If `true`, create and use a restricted pod security policy | `false`
 `crd.create` | if `true`, create Flagger's CRDs | `true`

--- a/charts/flagger/templates/deployment.yaml
+++ b/charts/flagger/templates/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/instance: {{ .Release.Name }}
 spec:
-  replicas: 1
+  replicas: {{ .Values.leaderElection.replicaCount }}
   strategy:
     type: Recreate
   selector:
@@ -22,6 +22,16 @@ spec:
         app.kubernetes.io/instance: {{ .Release.Name }}
     spec:
       serviceAccountName: {{ template "flagger.serviceAccountName" . }}
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app.kubernetes.io/name: {{ template "flagger.name" . }}
+                    app.kubernetes.io/instance: {{ .Release.Name }}
+                topologyKey: kubernetes.io/hostname
       containers:
         - name: flagger
           securityContext:
@@ -54,6 +64,10 @@ spec:
           {{- if .Values.msteams.url }}
           - -msteams-url={{ .Values.msteams.url }}
           {{- end }}
+          {{- if .Values.leaderElection.enabled }}
+          - -enable-leader-election=true
+          - -leader-election-namespace={{ .Release.Namespace }}
+          {{- end }}
           livenessProbe:
             exec:
               command:
@@ -78,10 +92,6 @@ spec:
 {{ toYaml .Values.resources | indent 12 }}
     {{- with .Values.nodeSelector }}
       nodeSelector:
-{{ toYaml . | indent 8 }}
-    {{- end }}
-    {{- with .Values.affinity }}
-      affinity:
 {{ toYaml . | indent 8 }}
     {{- end }}
     {{- with .Values.tolerations }}

--- a/charts/flagger/values.yaml
+++ b/charts/flagger/values.yaml
@@ -23,6 +23,10 @@ msteams:
   # MS Teams incoming webhook URL
   url:
 
+leaderElection:
+  enabled: false
+  replicaCount: 1
+
 serviceAccount:
   # serviceAccount.create: Whether to create a service account or not
   create: true
@@ -53,8 +57,6 @@ resources:
 nodeSelector: {}
 
 tolerations: []
-
-affinity: {}
 
 prometheus:
   # to be used with AppMesh or nginx ingress

--- a/go.sum
+++ b/go.sum
@@ -154,6 +154,7 @@ github.com/google/gofuzz v1.0.0 h1:A8PeW59pxE9IoFRqBp37U+mSNaQoZ46F1f0f863XSXw=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
 github.com/google/pprof v0.0.0-20181206194817-3ea8567a2e57/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
+github.com/google/uuid v1.0.0 h1:b4Gk+7WdP/d3HZH8EJsZpvV7EtDOgaZLtnaNGIu1adA=
 github.com/google/uuid v1.0.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gnostic v0.0.0-20170426233943-68f4ded48ba9/go.mod h1:sJBsCZ4ayReDTBIg8b9dl28c5xFWyhBTVRp3pOg5EKY=

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -216,15 +216,6 @@ func (c *Controller) syncHandler(key string) error {
 	}
 
 	c.canaries.Store(fmt.Sprintf("%s.%s", cd.Name, cd.Namespace), cd)
-
-	//if cd.Spec.TargetRef.Kind == "Deployment" {
-	//	err = c.bootstrapDeployment(cd)
-	//	if err != nil {
-	//		c.logger.Warnf("%s.%s bootstrap error %v", cd.Name, cd.Namespace, err)
-	//		return err
-	//	}
-	//}
-
 	c.logger.Infof("Synced %s", key)
 
 	return nil

--- a/test/e2e-linkerd.sh
+++ b/test/e2e-linkerd.sh
@@ -22,6 +22,8 @@ kind load docker-image test/flagger:latest
 echo '>>> Installing Flagger'
 helm upgrade -i flagger ${REPO_ROOT}/charts/flagger \
 --namespace linkerd \
+--set leaderElection.enabled=true \
+--set leaderElection.replicaCount=2 \
 --set metricsServer=http://linkerd-prometheus:9090 \
 --set meshProvider=smi:linkerd
 


### PR DESCRIPTION
This PR adds leader election to Flagger and allows running multiple instances per cluster. 

Install Flagger HA with pod anti affinity:

```
helm upgrade -i flagger flagger/flagger \
--namespace flagger-system \
--set leaderElection.enabled=true \
--set leaderElection.replicaCount=2
```

Fix: #106 