### PR TITLE
Kustomize will not build patches when namespace is declared

### DIFF
--- a/kustomize/base/flagger/account.yaml
+++ b/kustomize/base/flagger/account.yaml
@@ -2,5 +2,3 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: flagger
-  namespace: flagger-system
-

--- a/kustomize/base/flagger/deployment.yaml
+++ b/kustomize/base/flagger/deployment.yaml
@@ -2,7 +2,6 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: flagger
-  namespace: flagger-system
 spec:
   replicas: 1
   strategy:
@@ -20,30 +19,20 @@ spec:
       serviceAccountName: flagger
       containers:
       - name: flagger
-        image: weaveworks/flagger:0.16.0
+        image: weaveworks/flagger:0.17.0
         imagePullPolicy: IfNotPresent
         ports:
         - name: http
           containerPort: 8080
         livenessProbe:
-          exec:
-            command:
-            - wget
-            - --quiet
-            - --tries=1
-            - --timeout=2
-            - --spider
-            - http://localhost:8080/healthz
+          httpGet:
+            path: /healthz
+            port: http
           timeoutSeconds: 5
         readinessProbe:
-          exec:
-            command:
-            - wget
-            - --quiet
-            - --tries=1
-            - --timeout=2
-            - --spider
-            - http://localhost:8080/healthz
+          httpGet:
+            path: /healthz
+            port: http
           timeoutSeconds: 5
         resources:
           limits:


### PR DESCRIPTION
## Kustomize

will not build patches when namespace is declared on base resources.  
Running `kustomize  build` on one of the patches directory will spit this error out

```
Error: no matches for OriginalId apps_v1_Deployment|~X|flagger; no matches for CurrentId apps_v1_Deployment|~X|flagger; failed to find unique target for patch apps_v1_Deployment|flagger
```

Kustomize version:

```
Version: {KustomizeVersion:3.0.2 GitCommit:aa2313c2825a7712b12309c1cd7798f371a0bb18 BuildDate:2019-07-13T02:15:03+01:00 GoOs:darwin GoArch:amd64}
```

Removing the namespace from resources and letting kustomize apply those lets me build the manifest successfully.

> Note: I changed the healthz checks to use http probe instead of exec, please let me know if that's ok or there is some logic to the `wget` method.