### PR TITLE
 Implement promotion finalising state

### DIFF
--- a/artifacts/flagger/crd.yaml
+++ b/artifacts/flagger/crd.yaml
@@ -176,6 +176,7 @@ spec:
                 - Initialized
                 - Waiting
                 - Progressing
+                - Finalising
                 - Succeeded
                 - Failed
             canaryWeight:

--- a/charts/flagger/templates/crd.yaml
+++ b/charts/flagger/templates/crd.yaml
@@ -177,6 +177,7 @@ spec:
                 - Initialized
                 - Waiting
                 - Progressing
+                - Finalising
                 - Succeeded
                 - Failed
             canaryWeight:

--- a/kustomize/base/flagger/crd.yaml
+++ b/kustomize/base/flagger/crd.yaml
@@ -176,6 +176,7 @@ spec:
                 - Initialized
                 - Waiting
                 - Progressing
+                - Finalising
                 - Succeeded
                 - Failed
             canaryWeight:

--- a/pkg/apis/flagger/v1alpha3/status.go
+++ b/pkg/apis/flagger/v1alpha3/status.go
@@ -47,6 +47,8 @@ const (
 	CanaryPhaseWaiting CanaryPhase = "Waiting"
 	// CanaryPhaseProgressing means the canary analysis is underway
 	CanaryPhaseProgressing CanaryPhase = "Progressing"
+	// CanaryPhaseProgressing means the canary analysis is finished and traffic has been routed back to primary
+	CanaryPhaseFinalising CanaryPhase = "Finalising"
 	// CanaryPhaseSucceeded means the canary analysis has been successful
 	// and the canary deployment has been promoted
 	CanaryPhaseSucceeded CanaryPhase = "Succeeded"

--- a/pkg/canary/status.go
+++ b/pkg/canary/status.go
@@ -211,6 +211,9 @@ func (c *Deployer) MakeStatusConditions(canaryStatus flaggerv1.CanaryStatus,
 	case flaggerv1.CanaryPhaseProgressing:
 		status = corev1.ConditionUnknown
 		message = "New revision detected, starting canary analysis."
+	case flaggerv1.CanaryPhaseFinalising:
+		status = corev1.ConditionUnknown
+		message = "Canary analysis completed, routing all traffic to primary."
 	case flaggerv1.CanaryPhaseSucceeded:
 		status = corev1.ConditionTrue
 		message = "Canary analysis completed successfully, promotion finished."


### PR DESCRIPTION
This PR adds a new canary phase named `Finalising`. Flagger sets the canary status to finalising after routing the traffic back to the primary and runs one final loop before scaling the canary to zero so that the canary pods have a chance to process all inflight requests.

Fix: #256 