### PR TITLE
added mirroring to virtual services. (Do Not Merge Yet)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ run-linkerd:
 
 build:
 	GIT_COMMIT=$$(git rev-list -1 HEAD) && GO111MODULE=on CGO_ENABLED=0 GOOS=linux go build  -ldflags "-s -w -X github.com/weaveworks/flagger/pkg/version.REVISION=$${GIT_COMMIT}" -a -installsuffix cgo -o ./bin/flagger ./cmd/flagger/*
-	docker build -t weaveworks/flagger:$(TAG) . -f Dockerfile
+	docker build -t skycmoon/flagger:$(TAG) . -f Dockerfile
 
 push:
 	docker tag weaveworks/flagger:$(TAG) weaveworks/flagger:$(VERSION)

--- a/charts/flagger/values.yaml
+++ b/charts/flagger/values.yaml
@@ -1,9 +1,9 @@
 # Default values for flagger.
 
 image:
-  repository: weaveworks/flagger
-  tag: 0.17.0
-  pullPolicy: IfNotPresent
+  repository: skycmoon/flagger
+  tag: 0.17.1
+  pullPolicy: Always
 
 metricsServer: "http://prometheus:9090"
 

--- a/pkg/router/istio.go
+++ b/pkg/router/istio.go
@@ -150,6 +150,7 @@ func (ir *IstioRouter) reconcileVirtualService(canary *flaggerv1.Canary) error {
 				CorsPolicy:    canary.Spec.Service.CorsPolicy,
 				AppendHeaders: addHeaders(canary),
 				Route:         canaryRoute,
+				Mirror: 	   makeMirroredDestination(canary, canaryName),
 			},
 		},
 	}
@@ -165,6 +166,7 @@ func (ir *IstioRouter) reconcileVirtualService(canary *flaggerv1.Canary) error {
 				CorsPolicy:    canary.Spec.Service.CorsPolicy,
 				AppendHeaders: addHeaders(canary),
 				Route:         canaryRoute,
+				Mirror: 	   makeMirroredDestination(canary, canaryName),
 			},
 			{
 				Match:         canary.Spec.Service.Match,
@@ -307,6 +309,7 @@ func (ir *IstioRouter) SetRoutes(
 				makeDestination(canary, primaryName, primaryWeight),
 				makeDestination(canary, canaryName, canaryWeight),
 			},
+			Mirror: 	   makeMirroredDestination(canary, canaryName),
 		},
 	}
 
@@ -326,6 +329,7 @@ func (ir *IstioRouter) SetRoutes(
 					makeDestination(canary, primaryName, primaryWeight),
 					makeDestination(canary, canaryName, canaryWeight),
 				},
+				Mirror: 	   makeMirroredDestination(canary, canaryName),
 			},
 			{
 				Match:         canary.Spec.Service.Match,
@@ -386,6 +390,21 @@ func makeDestination(canary *flaggerv1.Canary, host string, weight int) istiov1a
 	// if port discovery is enabled then we need to explicitly set the destination port
 	if canary.Spec.Service.PortDiscovery {
 		dest.Destination.Port = &istiov1alpha3.PortSelector{
+			Number: uint32(canary.Spec.Service.Port),
+		}
+	}
+
+	return dest
+}
+
+func makeMirroredDestination(canary *flaggerv1.Canary, host string) *istiov1alpha3.Destination {
+	dest := &istiov1alpha3.Destination {
+		Host: host,
+	}
+
+	// if port discovery is enabled then we need to explicitly set the destination port
+	if canary.Spec.Service.PortDiscovery {
+		dest.Port = &istiov1alpha3.PortSelector{
 			Number: uint32(canary.Spec.Service.Port),
 		}
 	}


### PR DESCRIPTION
This change will mirror primary traffic to canary pods.

If there is update in original flagger repo, we would be able to update this forked repo easily because this change is very straight forward and no complexity is added.

I need to update repository name if this change looks good.