### PR TITLE
Parameterize image pull secrets for private docker repos

### DIFF
--- a/charts/flagger/templates/deployment.yaml
+++ b/charts/flagger/templates/deployment.yaml
@@ -32,6 +32,10 @@ spec:
                     app.kubernetes.io/name: {{ template "flagger.name" . }}
                     app.kubernetes.io/instance: {{ .Release.Name }}
                 topologyKey: kubernetes.io/hostname
+      {{- if .Values.image.pullSecret }}
+      imagePullSecrets:
+        - name: {{ .Values.image.pullSecret }}
+      {{- end }}
       containers:
         - name: flagger
           securityContext:

--- a/charts/flagger/values.yaml
+++ b/charts/flagger/values.yaml
@@ -4,6 +4,7 @@ image:
   repository: weaveworks/flagger
   tag: 0.18.1
   pullPolicy: IfNotPresent
+  pullSecret:
 
 metricsServer: "http://prometheus:9090"
 


### PR DESCRIPTION
This PR is to provide a capability to download flagger image from a private repository.
Fix: #265