### PR TITLE
Fix Port discovery with multiple port services

### DIFF
--- a/docs/gitbook/faq.md
+++ b/docs/gitbook/faq.md
@@ -232,8 +232,7 @@ spec:
         mode: ISTIO_MUTUAL
 ```
 
-Both port `8080` and `9090` will be added to the ClusterIP services but the virtual service
-will point to the port specified in `spec.service.port`.
+Both port `8080` and `9090` will be added to the ClusterIP services.
 
 ### Label selectors
 

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -33,6 +33,7 @@ spec:
   progressDeadlineSeconds: 60
   service:
     port: 9898
+    portDiscovery: true
     headers:
       request:
         add:
@@ -142,6 +143,7 @@ spec:
     name: podinfo
   progressDeadlineSeconds: 60
   service:
+    portDiscovery: true
     port: 9898
   canaryAnalysis:
     interval: 10s

--- a/test/e2e-workload.yaml
+++ b/test/e2e-workload.yaml
@@ -20,6 +20,7 @@ spec:
     metadata:
       annotations:
         prometheus.io/scrape: "true"
+        prometheus.io/port: "9797"
       labels:
         app: podinfo
     spec:
@@ -31,9 +32,13 @@ spec:
         - containerPort: 9898
           name: http
           protocol: TCP
+        - containerPort: 9797
+          name: http-prom
+          protocol: TCP
         command:
         - ./podinfo
         - --port=9898
+        - --port-metrics=9797
         - --level=info
         - --random-delay=false
         - --random-error=false


### PR DESCRIPTION
This fixes issue https://github.com/weaveworks/flagger/issues/263

We actually don't need to specify any ports in the VirtualService
and DestinationRules.
Istio will create clusters/listerners for each named port we have declared in
the kubernetes services and the router can be shared as it operates only on L7 criterias

Also contains a tiny clean-up of imports


k get canaries.flagger.app -o yaml places 
```  spec:
    autoscalerRef:
      apiVersion: autoscaling/v2beta1
      kind: HorizontalPodAutoscaler
      name: places
    canaryAnalysis:
      interval: 5s
      maxWeight: 50
      metrics:
      - interval: 1m
        name: request-success-rate
        threshold: 99
      - interval: 1m
        name: request-duration
        threshold: 500
      stepWeight: 10
      threshold: 10
      webhooks:
      - metadata:
          cmd: test places --cleanup
          type: helm
        name: helm test
        timeout: 3m
        type: pre-rollout
        url: http://flagger-helmtester.kube-system/
    progressDeadlineSeconds: 60
    service:
      port: 8080
      portDiscovery: true
      trafficPolicy:
        tls:
          mode: DISABLE
    skipAnalysis: true
    targetRef:
      apiVersion: apps/v1
      kind: Deployment
      name: places
```


k get destinationrules.networking.istio.io -o yaml
```
- apiVersion: networking.istio.io/v1alpha3
  kind: DestinationRule
  metadata:
    creationTimestamp: "2019-07-23T16:30:35Z"
    generation: 1
    name: places-canary
    namespace: trip
    ownerReferences:
    - apiVersion: flagger.app/v1alpha3
      blockOwnerDeletion: true
      controller: true
      kind: Canary
      name: places
      uid: 30d633f1-ad67-11e9-a8c3-4201c0a8800a
    resourceVersion: "65133888"
    selfLink: /apis/networking.istio.io/v1alpha3/namespaces/trip/destinationrules/places-canary
    uid: 32f65ab0-ad67-11e9-8566-4201c0a8800b
  spec:
    host: places-canary
    trafficPolicy:
      tls:
        mode: DISABLE
- apiVersion: networking.istio.io/v1alpha3
  kind: DestinationRule
  metadata:
    creationTimestamp: "2019-07-23T16:30:35Z"
    generation: 1
    name: places-primary
    namespace: trip
    ownerReferences:
    - apiVersion: flagger.app/v1alpha3
      blockOwnerDeletion: true
      controller: true
      kind: Canary
      name: places
      uid: 30d633f1-ad67-11e9-a8c3-4201c0a8800a
    resourceVersion: "65133889"
    selfLink: /apis/networking.istio.io/v1alpha3/namespaces/trip/destinationrules/places-primary
    uid: 32f916f2-ad67-11e9-8566-4201c0a8800b
  spec:
    host: places-primary
    trafficPolicy:
      tls:
        mode: DISABLE
```

k get virtualservices.networking.istio.io -o yaml places
```apiVersion: networking.istio.io/v1alpha3
kind: VirtualService
metadata:
  creationTimestamp: "2019-07-23T16:30:36Z"
  generation: 6
  name: places
  namespace: trip
  ownerReferences:
  - apiVersion: flagger.app/v1alpha3
    blockOwnerDeletion: true
    controller: true
    kind: Canary
    name: places
    uid: 30d633f1-ad67-11e9-a8c3-4201c0a8800a
  resourceVersion: "70400304"
  selfLink: /apis/networking.istio.io/v1alpha3/namespaces/trip/virtualservices/places
  uid: 32faef14-ad67-11e9-8566-4201c0a8800b
spec:
  gateways:
  - mesh
  hosts:
  - places
  http:
  - route:
    - destination:
        host: places-primary
      weight: 100
    - destination:
        host: places-canary
      weight: 0
```

istioctl pc route $(k get pods -l app=synapse-trip -o jsonpath='{.items[0].metadata.name}') --name 8080 -o json
```
...
                "name": "places.trip.svc.cluster.local:8080",
                "domains": [
                    "places.trip.svc.cluster.local",
                    "places.trip.svc.cluster.local:8080",
                    "places",
                    "places:8080",
                    "places.trip.svc.cluster",
                    "places.trip.svc.cluster:8080",
                    "places.trip.svc",
                    "places.trip.svc:8080",
                    "places.trip",
                    "places.trip:8080",
                    "10.250.134.101",
                    "10.250.134.101:8080"
                ],
                "routes": [
                    {
                        "match": {
                            "prefix": "/"
                        },
                        "route": {
                            "cluster": "outbound|8080||places-primary.trip.svc.cluster.local",
...
```


istioctl pc route $(k get pods -l app=synapse-trip -o jsonpath='{.items[0].metadata.name}') --name 6565 -o json

```
...
                "name": "places.trip.svc.cluster.local:6565",
                "domains": [
                    "places.trip.svc.cluster.local",
                    "places.trip.svc.cluster.local:6565",
                    "places",
                    "places:6565",
                    "places.trip.svc.cluster",
                    "places.trip.svc.cluster:6565",
                    "places.trip.svc",
                    "places.trip.svc:6565",
                    "places.trip",
                    "places.trip:6565",
                    "10.250.134.101",
                    "10.250.134.101:6565"
                ],
                "routes": [
                    {
                        "match": {
                            "prefix": "/"
                        },
                        "route": {
                            "cluster": "outbound|6565||places-primary.trip.svc.cluster.local",
...
```