### PR TITLE
Support non `$GOPATH/src` location for codegen

### DIFF
--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -1,23 +1,38 @@
 #!/usr/bin/env bash
 
 set -o errexit
+set -o nounset
 set -o pipefail
 
-REPO_ROOT=$(git rev-parse --show-toplevel)
-CODEGEN_VERSION="@v0.0.0-20190620073620-d55040311883"
-CODEGEN_PKG=${CODEGEN_PKG:-$(echo `go env GOPATH`"/pkg/mod/k8s.io/code-generator${CODEGEN_VERSION}")}
+SCRIPT_ROOT=$(realpath $(dirname ${BASH_SOURCE})/..)
 
-if [[ "$CIRCLECI" ]]; then
-    ls $(echo `go env GOPATH`'/pkg/mod/k8s.io/');
-    mkdir -p ${REPO_ROOT}/bin;
-    cp -r ${CODEGEN_PKG} ${REPO_ROOT}/bin/;
-    CODEGEN_PKG=${REPO_ROOT}/bin/code-generator${CODEGEN_VERSION};
-    echo ">> $CODEGEN_PKG";
-fi
+# Grab code-generator version from go.sum.
+CODEGEN_VERSION=$(grep 'k8s.io/code-generator' go.sum | awk '{print $2}' | head -1)
+CODEGEN_PKG=$(echo `go env GOPATH`"/pkg/mod/k8s.io/code-generator@${CODEGEN_VERSION}")
 
+echo ">> Using ${CODEGEN_PKG}"
+
+# code-generator does work with go.mod but makes assumptions about
+# the project living in `$GOPATH/src`. To work around this and support
+# any location; create a temporary directory, use this as an output
+# base, and copy everything back once generated.
+TEMP_DIR=$(mktemp -d)
+cleanup() {
+    echo ">> Removing ${TEMP_DIR}"
+    rm -rf ${TEMP_DIR}
+}
+trap "cleanup" EXIT SIGINT
+
+echo ">> Temporary output directory ${TEMP_DIR}"
+
+# Ensure we can execute.
 chmod +x ${CODEGEN_PKG}/generate-groups.sh
 
 ${CODEGEN_PKG}/generate-groups.sh all \
     github.com/weaveworks/flagger/pkg/client github.com/weaveworks/flagger/pkg/apis \
     "appmesh:v1beta1 istio:v1alpha3 flagger:v1alpha3 smi:v1alpha1" \
-    --go-header-file ${REPO_ROOT}/hack/boilerplate.go.txt
+    --output-base "${TEMP_DIR}" \
+    --go-header-file ${SCRIPT_ROOT}/hack/boilerplate.go.txt
+
+# Copy everything back.
+cp -r "${TEMP_DIR}/github.com/weaveworks/flagger/." "${SCRIPT_ROOT}/"


### PR DESCRIPTION
This commit fixes two things:

- it ensures the code generation works no matter the location of the
  project directory
- as a side effect; fixes the `hack/verify-codegen.sh` ran during CI

The previous script (or more specific: the `code-generator` library)
made the assumption during execution that the project was placed inside
`$GOPATH/src` and made the modifications there.

The idea of Go Modules is however that a project and/or package can be
placed anywhere, and this is also what the CI did, resulting in a
comparison of two identical `cp -r` copied directories. Giving a false
green light on every CI run.

To work around this limitation in `code-generator`: create a temporary
directory, use this as an output base and copy everything back once
generated.