### PR TITLE
Enhanced error logging

### DIFF
--- a/pkg/loadtester/bash.go
+++ b/pkg/loadtester/bash.go
@@ -24,7 +24,7 @@ func (task *BashTask) Run(ctx context.Context) (bool, error) {
 
 	if err != nil {
 		task.logger.With("canary", task.canary).Errorf("command failed %s %v %s", task.command, err, out)
-		return false, fmt.Errorf(" %v %v", err, out)
+		return false, fmt.Errorf(" %v %s", err, out)
 	} else {
 		if task.logCmdOutput {
 			fmt.Printf("%s\n", out)


### PR DESCRIPTION
Updated the error that is returned to format `out` as a string rather than a byte slice to be consistent with what is logged on [the previous line](https://github.com/jwenz723/flagger/blob/0421b328341e83c27c31a4c8edfb74d9f8b71a09/pkg/loadtester/bash.go#L26) as well as to make the http response body readable.

Here is an example of what would be returned when an error is encountered:

An example curl request triggering an error response **before** this PR:
```
$ curl -X POST -d '{"name": "podinfo","namespace": "test","phase": "Progressing", "metadata": {"type":  "bash","cmd":  "cd /a/non/existant/directory"}}' http://localhost:9090
 exit status 1 [98 97 115 104 58 32 108 105 110 101 32 48 58 32 99 100 58 32 47 97 47 110 111 110 47 101 120 105 115 116 97 110 116 47 100 105 114 101 99 116 111 114 121 58 32 78 111 32 115 117 99 104 32 102 105 108 101 32 111 114 32 100 105 114 101 99 116 111 114 121 10]
```

An example curl request triggering an error response **after** this PR:
```
$ curl -X POST -d '{"name": "podinfo","namespace": "test","phase": "Progressing", "metadata": {"type":  "bash","cmd":  "cd /a/non/existant/directory"}}' http://localhost:9090
 exit status 1 bash: line 0: cd: /a/non/existant/directory: No such file or directory
```