### PR TITLE
Implement confirm-promotion hook

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,15 +7,8 @@ LT_VERSION?=$(shell grep 'VERSION' cmd/loadtester/main.go | awk '{ print $$4 }' 
 TS=$(shell date +%Y-%m-%d_%H-%M-%S)
 
 run:
-	GO111MODULE=on go run cmd/flagger/* -kubeconfig=$$HOME/.kube/config -log-level=info -mesh-provider=istio -namespace=test \
-	-metrics-server=https://prometheus.istio.weavedx.com \
-	-enable-leader-election=true
-
-run2:
-	GO111MODULE=on go run cmd/flagger/* -kubeconfig=$$HOME/.kube/config -log-level=info -mesh-provider=istio -namespace=test \
-	-metrics-server=https://prometheus.istio.weavedx.com \
-	-enable-leader-election=true \
-	-port=9092
+	GO111MODULE=on go run cmd/flagger/* -kubeconfig=$$HOME/.kube/config -log-level=info -mesh-provider=istio -namespace=test-istio \
+	-metrics-server=https://prometheus.istio.flagger.dev
 
 run-appmesh:
 	GO111MODULE=on go run cmd/flagger/* -kubeconfig=$$HOME/.kube/config -log-level=info -mesh-provider=appmesh \

--- a/artifacts/flagger/crd.yaml
+++ b/artifacts/flagger/crd.yaml
@@ -215,7 +215,7 @@ spec:
                   properties:
                     items:
                       type: object
-                      required: ["name", "url", "timeout"]
+                      required: ["name", "url"]
                       properties:
                         name:
                           description: Name of the webhook
@@ -228,6 +228,7 @@ spec:
                             - confirm-rollout
                             - pre-rollout
                             - rollout
+                            - confirm-promotion
                             - post-rollout
                         url:
                           description: URL address of this webhook

--- a/charts/flagger/templates/crd.yaml
+++ b/charts/flagger/templates/crd.yaml
@@ -216,7 +216,7 @@ spec:
                   properties:
                     items:
                       type: object
-                      required: ['name', 'url', 'timeout']
+                      required: ["name", "url"]
                       properties:
                         name:
                           description: Name of the webhook
@@ -229,6 +229,7 @@ spec:
                             - confirm-rollout
                             - pre-rollout
                             - rollout
+                            - confirm-promotion
                             - post-rollout
                         url:
                           description: URL address of this webhook

--- a/kustomize/base/flagger/crd.yaml
+++ b/kustomize/base/flagger/crd.yaml
@@ -215,7 +215,7 @@ spec:
                   properties:
                     items:
                       type: object
-                      required: ["name", "url", "timeout"]
+                      required: ["name", "url"]
                       properties:
                         name:
                           description: Name of the webhook
@@ -228,6 +228,7 @@ spec:
                             - confirm-rollout
                             - pre-rollout
                             - rollout
+                            - confirm-promotion
                             - post-rollout
                         url:
                           description: URL address of this webhook

--- a/pkg/apis/flagger/v1alpha3/types.go
+++ b/pkg/apis/flagger/v1alpha3/types.go
@@ -139,6 +139,8 @@ const (
 	PostRolloutHook HookType = "post-rollout"
 	// ConfirmRolloutHook halt canary analysis until webhook returns HTTP 200
 	ConfirmRolloutHook HookType = "confirm-rollout"
+	// ConfirmPromotionHook halt canary promotion until webhook returns HTTP 200
+	ConfirmPromotionHook HookType = "confirm-promotion"
 )
 
 // CanaryWebhook holds the reference to external checks used for canary analysis

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -257,6 +257,9 @@ spec:
           type: cmd
           cmd: "hey -z 10m -q 10 -c 2 -H 'Cookie: type=insider' http://podinfo-canary.test:9898/"
           logCmdOutput: "true"
+      - name: promote-gate
+        type: confirm-promotion
+        url: http://flagger-loadtester.test/gate/approve
       - name: post
         type: post-rollout
         url: http://flagger-loadtester.test/


### PR DESCRIPTION
This PR implements the `confirm-promotion` webhook type for canaries, A/B testing and Blue/Green deployments. The confirm promotion hooks are executed right before the promotion step. The canary promotion is paused until the hooks return HTTP 200. While the promotion is paused, Flagger will continue to run the metrics checks and load tests. If you have notifications enabled, Flagger will post a message to Slack or MS Teams when a canary promotion is waiting for approval.

Example:

```yaml
    webhooks:
      - name: "start analysis gate"
        type: confirm-rollout
        url: http://flagger-loadtester.test/gate/approve
      - name: "load testing"
        type: rollout
        url: http://flagger-loadtester.test/
        timeout: 5s
        metadata:
          cmd: "hey -z 1m -q 10 -c 2 http://podinfo-canary.test:9898/"
      - name: "promote gate"
        type: confirm-promotion
        url: http://flagger-loadtester.test/gate/approve
```

Fix: #299

Flagger image: `weaveworks/flagger:confirm-promotion-8282f86`