### PR TITLE
Canary promotion improvements

### DIFF
--- a/artifacts/flagger/crd.yaml
+++ b/artifacts/flagger/crd.yaml
@@ -254,6 +254,7 @@ spec:
                 - Initialized
                 - Waiting
                 - Progressing
+                - Promoting
                 - Finalising
                 - Succeeded
                 - Failed

--- a/charts/flagger/templates/crd.yaml
+++ b/charts/flagger/templates/crd.yaml
@@ -255,6 +255,7 @@ spec:
                 - Initialized
                 - Waiting
                 - Progressing
+                - Promoting
                 - Finalising
                 - Succeeded
                 - Failed

--- a/kustomize/base/flagger/crd.yaml
+++ b/kustomize/base/flagger/crd.yaml
@@ -254,6 +254,7 @@ spec:
                 - Initialized
                 - Waiting
                 - Progressing
+                - Promoting
                 - Finalising
                 - Succeeded
                 - Failed

--- a/pkg/apis/flagger/v1alpha3/status.go
+++ b/pkg/apis/flagger/v1alpha3/status.go
@@ -47,7 +47,9 @@ const (
 	CanaryPhaseWaiting CanaryPhase = "Waiting"
 	// CanaryPhaseProgressing means the canary analysis is underway
 	CanaryPhaseProgressing CanaryPhase = "Progressing"
-	// CanaryPhaseProgressing means the canary analysis is finished and traffic has been routed back to primary
+	// CanaryPhasePromoting means the canary analysis is finished and the primary spec has been updated
+	CanaryPhasePromoting CanaryPhase = "Promoting"
+	// CanaryPhaseProgressing means the canary promotion is finished and traffic has been routed back to primary
 	CanaryPhaseFinalising CanaryPhase = "Finalising"
 	// CanaryPhaseSucceeded means the canary analysis has been successful
 	// and the canary deployment has been promoted

--- a/pkg/canary/status.go
+++ b/pkg/canary/status.go
@@ -211,6 +211,9 @@ func (c *Deployer) MakeStatusConditions(canaryStatus flaggerv1.CanaryStatus,
 	case flaggerv1.CanaryPhaseProgressing:
 		status = corev1.ConditionUnknown
 		message = "New revision detected, starting canary analysis."
+	case flaggerv1.CanaryPhasePromoting:
+		status = corev1.ConditionUnknown
+		message = "Canary analysis completed, starting primary rolling update."
 	case flaggerv1.CanaryPhaseFinalising:
 		status = corev1.ConditionUnknown
 		message = "Canary analysis completed, routing all traffic to primary."

--- a/pkg/controller/scheduler.go
+++ b/pkg/controller/scheduler.go
@@ -434,8 +434,8 @@ func (c *Controller) advanceCanary(name string, namespace string, skipLivenessCh
 				primaryWeight = 0
 			}
 			canaryWeight += cd.Spec.CanaryAnalysis.StepWeight
-			if primaryWeight > 100 {
-				primaryWeight = 100
+			if canaryWeight > 100 {
+				canaryWeight = 100
 			}
 
 			if err := meshRouter.SetRoutes(cd, primaryWeight, canaryWeight); err != nil {


### PR DESCRIPTION
This PR makes the canary promotion reliable for apps that don't implement graceful shutdown on Kubernetes `SIGTERM`. After the analysis finishes, Flagger will do the promotion and wait for the primary rollout to finish before routing traffic back to it. This ensures a smooth transition to the new version avoiding dropping in-flight requests when pods are being terminated.
