### PR TITLE
Add traffic mirroring for Istio service mesh

### DIFF
--- a/artifacts/flagger/crd.yaml
+++ b/artifacts/flagger/crd.yaml
@@ -41,6 +41,10 @@ spec:
       type: string
       JSONPath: .spec.canaryAnalysis.interval
       priority: 1
+    - name: Mirror
+      type: boolean
+      JSONPath: .spec.canaryAnalysis.mirror
+      priority: 1
     - name: StepWeight
       type: string
       JSONPath: .spec.canaryAnalysis.stepWeight
@@ -183,6 +187,9 @@ spec:
                 stepWeight:
                   description: Canary incremental traffic percentage step
                   type: number
+                mirror:
+                  description: Mirror traffic to canary before shifting
+                  type: boolean
                 match:
                   description: A/B testing match conditions
                   anyOf:

--- a/charts/flagger/templates/crd.yaml
+++ b/charts/flagger/templates/crd.yaml
@@ -42,6 +42,10 @@ spec:
       type: string
       JSONPath: .spec.canaryAnalysis.interval
       priority: 1
+    - name: Mirror
+      type: boolean
+      JSONPath: .spec.canaryAnalysis.mirror
+      priority: 1
     - name: StepWeight
       type: string
       JSONPath: .spec.canaryAnalysis.stepWeight
@@ -184,6 +188,9 @@ spec:
                 stepWeight:
                   description: Canary incremental traffic percentage step
                   type: number
+                mirror:
+                  description: Mirror traffic to canary before shifting
+                  type: boolean
                 match:
                   description: A/B testing match conditions
                   anyOf:

--- a/kustomize/base/flagger/crd.yaml
+++ b/kustomize/base/flagger/crd.yaml
@@ -41,6 +41,10 @@ spec:
       type: string
       JSONPath: .spec.canaryAnalysis.interval
       priority: 1
+    - name: Mirror
+      type: boolean
+      JSONPath: .spec.canaryAnalysis.mirror
+      priority: 1
     - name: StepWeight
       type: string
       JSONPath: .spec.canaryAnalysis.stepWeight
@@ -183,6 +187,9 @@ spec:
                 stepWeight:
                   description: Canary incremental traffic percentage step
                   type: number
+                mirror:
+                  description: Mirror traffic to canary before shifting
+                  type: boolean
                 match:
                   description: A/B testing match conditions
                   anyOf:

--- a/pkg/apis/flagger/v1alpha3/types.go
+++ b/pkg/apis/flagger/v1alpha3/types.go
@@ -111,6 +111,7 @@ type CanaryAnalysis struct {
 	Interval   string                           `json:"interval"`
 	Threshold  int                              `json:"threshold"`
 	MaxWeight  int                              `json:"maxWeight"`
+	Mirror     bool                             `json:"mirror,omitempty"`
 	StepWeight int                              `json:"stepWeight"`
 	Metrics    []CanaryMetric                   `json:"metrics"`
 	Webhooks   []CanaryWebhook                  `json:"webhooks,omitempty"`

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -267,6 +267,12 @@ func newTestCanary() *v1alpha3.Canary {
 	return cd
 }
 
+func newTestCanaryMirror() *v1alpha3.Canary {
+	cd := newTestCanary()
+	cd.Spec.CanaryAnalysis.Mirror = true
+	return cd
+}
+
 func newTestCanaryAB() *v1alpha3.Canary {
 	cd := &v1alpha3.Canary{
 		TypeMeta: metav1.TypeMeta{APIVersion: v1alpha3.SchemeGroupVersion.String()},

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -42,11 +42,9 @@ type Mocks struct {
 	router        router.Interface
 }
 
-func SetupMocks(abtest bool) Mocks {
-	// init canary
-	c := newTestCanary()
-	if abtest {
-		c = newTestCanaryAB()
+func SetupMocks(c *v1alpha3.Canary) Mocks {
+	if c == nil {
+		c = newTestCanary()
 	}
 	flaggerClient := fakeFlagger.NewSimpleClientset(c)
 

--- a/pkg/controller/scheduler.go
+++ b/pkg/controller/scheduler.go
@@ -155,7 +155,7 @@ func (c *Controller) advanceCanary(name string, namespace string, skipLivenessCh
 
 	// check if virtual service exists
 	// and if it contains weighted destination routes to the primary and canary services
-	primaryWeight, canaryWeight, err := meshRouter.GetRoutes(cd)
+	primaryWeight, canaryWeight, mirrored, err := meshRouter.GetRoutes(cd)
 	if err != nil {
 		c.recordEventWarningf(cd, "%v", err)
 		return
@@ -176,7 +176,7 @@ func (c *Controller) advanceCanary(name string, namespace string, skipLivenessCh
 		// route all traffic back to primary
 		primaryWeight = 100
 		canaryWeight = 0
-		if err := meshRouter.SetRoutes(cd, primaryWeight, canaryWeight); err != nil {
+		if err := meshRouter.SetRoutes(cd, primaryWeight, canaryWeight, false); err != nil {
 			c.recordEventWarningf(cd, "%v", err)
 			return
 		}
@@ -218,7 +218,7 @@ func (c *Controller) advanceCanary(name string, namespace string, skipLivenessCh
 	if cd.Status.Phase == flaggerv1.CanaryPhasePromoting {
 		if provider != "kubernetes" {
 			c.recordEventInfof(cd, "Routing all traffic to primary")
-			if err := meshRouter.SetRoutes(cd, 100, 0); err != nil {
+			if err := meshRouter.SetRoutes(cd, 100, 0, false); err != nil {
 				c.recordEventWarningf(cd, "%v", err)
 				return
 			}
@@ -275,7 +275,7 @@ func (c *Controller) advanceCanary(name string, namespace string, skipLivenessCh
 		// route all traffic back to primary
 		primaryWeight = 100
 		canaryWeight = 0
-		if err := meshRouter.SetRoutes(cd, primaryWeight, canaryWeight); err != nil {
+		if err := meshRouter.SetRoutes(cd, primaryWeight, canaryWeight, false); err != nil {
 			c.recordEventWarningf(cd, "%v", err)
 			return
 		}
@@ -328,7 +328,7 @@ func (c *Controller) advanceCanary(name string, namespace string, skipLivenessCh
 	if len(cd.Spec.CanaryAnalysis.Match) > 0 && cd.Spec.CanaryAnalysis.Iterations > 0 {
 		// route traffic to canary and increment iterations
 		if cd.Spec.CanaryAnalysis.Iterations > cd.Status.Iterations {
-			if err := meshRouter.SetRoutes(cd, 0, 100); err != nil {
+			if err := meshRouter.SetRoutes(cd, 0, 100, false); err != nil {
 				c.recordEventWarningf(cd, "%v", err)
 				return
 			}
@@ -390,7 +390,7 @@ func (c *Controller) advanceCanary(name string, namespace string, skipLivenessCh
 		if cd.Spec.CanaryAnalysis.Iterations == cd.Status.Iterations {
 			if provider != "kubernetes" {
 				c.recordEventInfof(cd, "Routing all traffic to canary")
-				if err := meshRouter.SetRoutes(cd, 0, 100); err != nil {
+				if err := meshRouter.SetRoutes(cd, 0, 100, false); err != nil {
 					c.recordEventWarningf(cd, "%v", err)
 					return
 				}
@@ -489,7 +489,7 @@ func (c *Controller) shouldSkipAnalysis(cd *flaggerv1.Canary, meshRouter router.
 	// route all traffic to primary
 	primaryWeight = 100
 	canaryWeight = 0
-	if err := meshRouter.SetRoutes(cd, primaryWeight, canaryWeight); err != nil {
+	if err := meshRouter.SetRoutes(cd, primaryWeight, canaryWeight, false); err != nil {
 		c.recordEventWarningf(cd, "%v", err)
 		return false
 	}

--- a/pkg/controller/scheduler_test.go
+++ b/pkg/controller/scheduler_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestScheduler_Init(t *testing.T) {
-	mocks := SetupMocks(false)
+	mocks := SetupMocks(nil)
 	mocks.ctrl.advanceCanary("podinfo", "default", true)
 
 	_, err := mocks.kubeClient.AppsV1().Deployments("default").Get("podinfo-primary", metav1.GetOptions{})
@@ -18,7 +18,7 @@ func TestScheduler_Init(t *testing.T) {
 }
 
 func TestScheduler_NewRevision(t *testing.T) {
-	mocks := SetupMocks(false)
+	mocks := SetupMocks(nil)
 	mocks.ctrl.advanceCanary("podinfo", "default", true)
 
 	// update
@@ -42,7 +42,7 @@ func TestScheduler_NewRevision(t *testing.T) {
 }
 
 func TestScheduler_Rollback(t *testing.T) {
-	mocks := SetupMocks(false)
+	mocks := SetupMocks(nil)
 	// init
 	mocks.ctrl.advanceCanary("podinfo", "default", true)
 
@@ -66,7 +66,7 @@ func TestScheduler_Rollback(t *testing.T) {
 }
 
 func TestScheduler_SkipAnalysis(t *testing.T) {
-	mocks := SetupMocks(false)
+	mocks := SetupMocks(nil)
 	// init
 	mocks.ctrl.advanceCanary("podinfo", "default", true)
 
@@ -107,7 +107,7 @@ func TestScheduler_SkipAnalysis(t *testing.T) {
 }
 
 func TestScheduler_NewRevisionReset(t *testing.T) {
-	mocks := SetupMocks(false)
+	mocks := SetupMocks(nil)
 	// init
 	mocks.ctrl.advanceCanary("podinfo", "default", true)
 
@@ -169,7 +169,7 @@ func TestScheduler_NewRevisionReset(t *testing.T) {
 }
 
 func TestScheduler_Promotion(t *testing.T) {
-	mocks := SetupMocks(false)
+	mocks := SetupMocks(nil)
 
 	// init
 	mocks.ctrl.advanceCanary("podinfo", "default", true)
@@ -320,7 +320,7 @@ func TestScheduler_Promotion(t *testing.T) {
 }
 
 func TestScheduler_ABTesting(t *testing.T) {
-	mocks := SetupMocks(true)
+	mocks := SetupMocks(newTestCanaryAB())
 	// init
 	mocks.ctrl.advanceCanary("podinfo", "default", true)
 
@@ -408,7 +408,7 @@ func TestScheduler_ABTesting(t *testing.T) {
 }
 
 func TestScheduler_PortDiscovery(t *testing.T) {
-	mocks := SetupMocks(false)
+	mocks := SetupMocks(nil)
 
 	// enable port discovery
 	cd, err := mocks.flaggerClient.FlaggerV1alpha3().Canaries("default").Get("podinfo", metav1.GetOptions{})

--- a/pkg/controller/scheduler_test.go
+++ b/pkg/controller/scheduler_test.go
@@ -123,7 +123,7 @@ func TestScheduler_NewRevisionReset(t *testing.T) {
 	// advance
 	mocks.ctrl.advanceCanary("podinfo", "default", true)
 
-	primaryWeight, canaryWeight, err := mocks.router.GetRoutes(mocks.canary)
+	primaryWeight, canaryWeight, mirrored, err := mocks.router.GetRoutes(mocks.canary)
 	if err != nil {
 		t.Fatal(err.Error())
 	}
@@ -136,6 +136,10 @@ func TestScheduler_NewRevisionReset(t *testing.T) {
 		t.Errorf("Got canary route %v wanted %v", canaryWeight, 10)
 	}
 
+	if mirrored != false {
+		t.Errorf("Got mirrored %v wanted %v", mirrored, false)
+	}
+
 	// second update
 	dep2.Spec.Template.Spec.ServiceAccountName = "test"
 	_, err = mocks.kubeClient.AppsV1().Deployments("default").Update(dep2)
@@ -146,7 +150,7 @@ func TestScheduler_NewRevisionReset(t *testing.T) {
 	// detect changes
 	mocks.ctrl.advanceCanary("podinfo", "default", true)
 
-	primaryWeight, canaryWeight, err = mocks.router.GetRoutes(mocks.canary)
+	primaryWeight, canaryWeight, mirrored, err = mocks.router.GetRoutes(mocks.canary)
 	if err != nil {
 		t.Fatal(err.Error())
 	}
@@ -157,6 +161,10 @@ func TestScheduler_NewRevisionReset(t *testing.T) {
 
 	if canaryWeight != 0 {
 		t.Errorf("Got canary route %v wanted %v", canaryWeight, 0)
+	}
+
+	if mirrored != false {
+		t.Errorf("Got mirrored %v wanted %v", mirrored, false)
 	}
 }
 
@@ -201,14 +209,14 @@ func TestScheduler_Promotion(t *testing.T) {
 	// detect configs changes
 	mocks.ctrl.advanceCanary("podinfo", "default", true)
 
-	primaryWeight, canaryWeight, err := mocks.router.GetRoutes(mocks.canary)
+	primaryWeight, canaryWeight, mirrored, err := mocks.router.GetRoutes(mocks.canary)
 	if err != nil {
 		t.Fatal(err.Error())
 	}
 
 	primaryWeight = 60
 	canaryWeight = 40
-	err = mocks.router.SetRoutes(mocks.canary, primaryWeight, canaryWeight)
+	err = mocks.router.SetRoutes(mocks.canary, primaryWeight, canaryWeight, mirrored)
 	if err != nil {
 		t.Fatal(err.Error())
 	}
@@ -242,7 +250,7 @@ func TestScheduler_Promotion(t *testing.T) {
 	// finalise
 	mocks.ctrl.advanceCanary("podinfo", "default", true)
 
-	primaryWeight, canaryWeight, err = mocks.router.GetRoutes(mocks.canary)
+	primaryWeight, canaryWeight, mirrored, err = mocks.router.GetRoutes(mocks.canary)
 	if err != nil {
 		t.Fatal(err.Error())
 	}
@@ -253,6 +261,10 @@ func TestScheduler_Promotion(t *testing.T) {
 
 	if canaryWeight != 0 {
 		t.Errorf("Got canary route %v wanted %v", canaryWeight, 0)
+	}
+
+	if mirrored != false {
+		t.Errorf("Got mirrored %v wanted %v", mirrored, false)
 	}
 
 	primaryDep, err := mocks.kubeClient.AppsV1().Deployments("default").Get("podinfo-primary", metav1.GetOptions{})
@@ -326,7 +338,7 @@ func TestScheduler_ABTesting(t *testing.T) {
 	mocks.ctrl.advanceCanary("podinfo", "default", true)
 
 	// check if traffic is routed to canary
-	primaryWeight, canaryWeight, err := mocks.router.GetRoutes(mocks.canary)
+	primaryWeight, canaryWeight, mirrored, err := mocks.router.GetRoutes(mocks.canary)
 	if err != nil {
 		t.Fatal(err.Error())
 	}
@@ -337,6 +349,10 @@ func TestScheduler_ABTesting(t *testing.T) {
 
 	if canaryWeight != 100 {
 		t.Errorf("Got canary route %v wanted %v", canaryWeight, 100)
+	}
+
+	if mirrored != false {
+		t.Errorf("Got mirrored %v wanted %v", mirrored, false)
 	}
 
 	cd, err := mocks.flaggerClient.FlaggerV1alpha3().Canaries("default").Get("podinfo", metav1.GetOptions{})

--- a/pkg/router/appmesh.go
+++ b/pkg/router/appmesh.go
@@ -252,6 +252,7 @@ func (ar *AppMeshRouter) reconcileVirtualService(canary *flaggerv1.Canary, name 
 func (ar *AppMeshRouter) GetRoutes(canary *flaggerv1.Canary) (
 	primaryWeight int,
 	canaryWeight int,
+	mirrored bool,
 	err error,
 ) {
 	targetName := canary.Spec.TargetRef.Name
@@ -286,6 +287,8 @@ func (ar *AppMeshRouter) GetRoutes(canary *flaggerv1.Canary) (
 			vsName, targetName, targetName)
 	}
 
+	mirrored = false
+
 	return
 }
 
@@ -294,6 +297,7 @@ func (ar *AppMeshRouter) SetRoutes(
 	canary *flaggerv1.Canary,
 	primaryWeight int,
 	canaryWeight int,
+	mirrored bool,
 ) error {
 	targetName := canary.Spec.TargetRef.Name
 	vsName := fmt.Sprintf("%s.%s", targetName, canary.Namespace)

--- a/pkg/router/appmesh_test.go
+++ b/pkg/router/appmesh_test.go
@@ -144,12 +144,12 @@ func TestAppmeshRouter_GetSetRoutes(t *testing.T) {
 		t.Fatal(err.Error())
 	}
 
-	err = router.SetRoutes(mocks.appmeshCanary, 60, 40)
+	err = router.SetRoutes(mocks.appmeshCanary, 60, 40, false)
 	if err != nil {
 		t.Fatal(err.Error())
 	}
 
-	p, c, err := router.GetRoutes(mocks.appmeshCanary)
+	p, c, m, err := router.GetRoutes(mocks.appmeshCanary)
 	if err != nil {
 		t.Fatal(err.Error())
 	}
@@ -160,5 +160,9 @@ func TestAppmeshRouter_GetSetRoutes(t *testing.T) {
 
 	if c != 40 {
 		t.Errorf("Got canary weight %v wanted %v", c, 40)
+	}
+
+	if m != false {
+		t.Errorf("Got mirror %v wanted %v", m, false)
 	}
 }

--- a/pkg/router/gloo.go
+++ b/pkg/router/gloo.go
@@ -63,11 +63,11 @@ func NewGlooRouterWithClient(ctx context.Context, routingRuleClient gloov1.Upstr
 // Reconcile creates or updates the Istio virtual service
 func (gr *GlooRouter) Reconcile(canary *flaggerv1.Canary) error {
 	// do we have routes already?
-	if _, _, err := gr.GetRoutes(canary); err == nil {
+	if _, _, _, err := gr.GetRoutes(canary); err == nil {
 		// we have routes, no need to do anything else
 		return nil
 	} else if solokiterror.IsNotExist(err) {
-		return gr.SetRoutes(canary, 100, 0)
+		return gr.SetRoutes(canary, 100, 0, false)
 	} else {
 		return err
 	}
@@ -77,6 +77,7 @@ func (gr *GlooRouter) Reconcile(canary *flaggerv1.Canary) error {
 func (gr *GlooRouter) GetRoutes(canary *flaggerv1.Canary) (
 	primaryWeight int,
 	canaryWeight int,
+	mirrored bool,
 	err error,
 ) {
 	targetName := canary.Spec.TargetRef.Name
@@ -101,6 +102,8 @@ func (gr *GlooRouter) GetRoutes(canary *flaggerv1.Canary) (
 			targetName, canary.Namespace, targetName, targetName)
 	}
 
+	mirrored = false
+
 	return
 }
 
@@ -109,6 +112,7 @@ func (gr *GlooRouter) SetRoutes(
 	canary *flaggerv1.Canary,
 	primaryWeight int,
 	canaryWeight int,
+	mirrored bool,
 ) error {
 	targetName := canary.Spec.TargetRef.Name
 

--- a/pkg/router/gloo_test.go
+++ b/pkg/router/gloo_test.go
@@ -68,15 +68,16 @@ func TestGlooRouter_SetRoutes(t *testing.T) {
 		t.Fatal(err.Error())
 	}
 
-	p, c, err := router.GetRoutes(mocks.canary)
+	p, c, m, err := router.GetRoutes(mocks.canary)
 	if err != nil {
 		t.Fatal(err.Error())
 	}
 
 	p = 50
 	c = 50
+	m = false
 
-	err = router.SetRoutes(mocks.canary, p, c)
+	err = router.SetRoutes(mocks.canary, p, c, m)
 	if err != nil {
 		t.Fatal(err.Error())
 	}
@@ -127,7 +128,7 @@ func TestGlooRouter_GetRoutes(t *testing.T) {
 		t.Fatal(err.Error())
 	}
 
-	p, c, err := router.GetRoutes(mocks.canary)
+	p, c, m, err := router.GetRoutes(mocks.canary)
 	if err != nil {
 		t.Fatal(err.Error())
 	}
@@ -138,5 +139,9 @@ func TestGlooRouter_GetRoutes(t *testing.T) {
 
 	if c != 0 {
 		t.Errorf("Got canary weight %v wanted %v", c, 0)
+	}
+
+	if m != false {
+		t.Errorf("Got mirror %v wanted %v", m, false)
 	}
 }

--- a/pkg/router/ingress_test.go
+++ b/pkg/router/ingress_test.go
@@ -56,15 +56,16 @@ func TestIngressRouter_GetSetRoutes(t *testing.T) {
 		t.Fatal(err.Error())
 	}
 
-	p, c, err := router.GetRoutes(mocks.ingressCanary)
+	p, c, m, err := router.GetRoutes(mocks.ingressCanary)
 	if err != nil {
 		t.Fatal(err.Error())
 	}
 
 	p = 50
 	c = 50
+	m = false
 
-	err = router.SetRoutes(mocks.ingressCanary, p, c)
+	err = router.SetRoutes(mocks.ingressCanary, p, c, m)
 	if err != nil {
 		t.Fatal(err.Error())
 	}
@@ -93,8 +94,9 @@ func TestIngressRouter_GetSetRoutes(t *testing.T) {
 
 	p = 100
 	c = 0
+	m = false
 
-	err = router.SetRoutes(mocks.ingressCanary, p, c)
+	err = router.SetRoutes(mocks.ingressCanary, p, c, m)
 	if err != nil {
 		t.Fatal(err.Error())
 	}

--- a/pkg/router/nop.go
+++ b/pkg/router/nop.go
@@ -12,13 +12,13 @@ func (*NopRouter) Reconcile(canary *flaggerv1.Canary) error {
 	return nil
 }
 
-func (*NopRouter) SetRoutes(canary *flaggerv1.Canary, primaryWeight int, canaryWeight int) error {
+func (*NopRouter) SetRoutes(canary *flaggerv1.Canary, primaryWeight int, canaryWeight int, mirror bool) error {
 	return nil
 }
 
-func (*NopRouter) GetRoutes(canary *flaggerv1.Canary) (primaryWeight int, canaryWeight int, err error) {
+func (*NopRouter) GetRoutes(canary *flaggerv1.Canary) (primaryWeight int, canaryWeight int, mirror bool, err error) {
 	if canary.Status.Iterations > 0 {
-		return 0, 100, nil
+		return 0, 100, false, nil
 	}
-	return 100, 0, nil
+	return 100, 0, false, nil
 }

--- a/pkg/router/router.go
+++ b/pkg/router/router.go
@@ -4,6 +4,6 @@ import flaggerv1 "github.com/weaveworks/flagger/pkg/apis/flagger/v1alpha3"
 
 type Interface interface {
 	Reconcile(canary *flaggerv1.Canary) error
-	SetRoutes(canary *flaggerv1.Canary, primaryWeight int, canaryWeight int) error
-	GetRoutes(canary *flaggerv1.Canary) (primaryWeight int, canaryWeight int, err error)
+	SetRoutes(canary *flaggerv1.Canary, primaryWeight int, canaryWeight int, mirrored bool) error
+	GetRoutes(canary *flaggerv1.Canary) (primaryWeight int, canaryWeight int, mirrored bool, err error)
 }

--- a/pkg/router/router_test.go
+++ b/pkg/router/router_test.go
@@ -137,6 +137,12 @@ func newMockCanary() *v1alpha3.Canary {
 	return cd
 }
 
+func newMockMirror() *v1alpha3.Canary {
+	cd := newMockCanary()
+	cd.Spec.CanaryAnalysis.Mirror = true
+	return cd
+}
+
 func newMockABTest() *v1alpha3.Canary {
 	cd := &v1alpha3.Canary{
 		TypeMeta: metav1.TypeMeta{APIVersion: v1alpha3.SchemeGroupVersion.String()},

--- a/pkg/router/smi.go
+++ b/pkg/router/smi.go
@@ -107,6 +107,7 @@ func (sr *SmiRouter) Reconcile(canary *flaggerv1.Canary) error {
 func (sr *SmiRouter) GetRoutes(canary *flaggerv1.Canary) (
 	primaryWeight int,
 	canaryWeight int,
+	mirrored bool,
 	err error,
 ) {
 	targetName := canary.Spec.TargetRef.Name
@@ -137,6 +138,8 @@ func (sr *SmiRouter) GetRoutes(canary *flaggerv1.Canary) (
 			targetName, canary.Namespace, primaryName, canaryName)
 	}
 
+	mirrored = false
+
 	return
 }
 
@@ -145,6 +148,7 @@ func (sr *SmiRouter) SetRoutes(
 	canary *flaggerv1.Canary,
 	primaryWeight int,
 	canaryWeight int,
+	mirrored bool,
 ) error {
 	targetName := canary.Spec.TargetRef.Name
 	canaryName := fmt.Sprintf("%s-canary", targetName)

--- a/pkg/router/supergloo.go
+++ b/pkg/router/supergloo.go
@@ -82,11 +82,11 @@ func (sr *SuperglooRouter) Reconcile(canary *flaggerv1.Canary) error {
 	}
 
 	// do we have routes already?
-	if _, _, err := sr.GetRoutes(canary); err == nil {
+	if _, _, _, err := sr.GetRoutes(canary); err == nil {
 		// we have routes, no need to do anything else
 		return nil
 	} else if solokiterror.IsNotExist(err) {
-		return sr.SetRoutes(canary, 100, 0)
+		return sr.SetRoutes(canary, 100, 0, false)
 	} else {
 		return err
 	}
@@ -219,6 +219,7 @@ func (sr *SuperglooRouter) createRule(canary *flaggerv1.Canary, namesuffix strin
 func (sr *SuperglooRouter) GetRoutes(canary *flaggerv1.Canary) (
 	primaryWeight int,
 	canaryWeight int,
+	mirrored bool,
 	err error,
 ) {
 	targetName := canary.Spec.TargetRef.Name
@@ -247,6 +248,8 @@ func (sr *SuperglooRouter) GetRoutes(canary *flaggerv1.Canary) (
 			targetName, canary.Namespace, targetName, targetName)
 	}
 
+	mirrored = false
+
 	return
 }
 
@@ -259,6 +262,7 @@ func (sr *SuperglooRouter) SetRoutes(
 	canary *flaggerv1.Canary,
 	primaryWeight int,
 	canaryWeight int,
+	mirrored bool,
 ) error {
 	// upstream name is
 	// in gloo-system

--- a/pkg/router/supergloo_test.go
+++ b/pkg/router/supergloo_test.go
@@ -71,15 +71,16 @@ func TestSuperglooRouter_SetRoutes(t *testing.T) {
 		t.Fatal(err.Error())
 	}
 
-	p, c, err := router.GetRoutes(mocks.canary)
+	p, c, m, err := router.GetRoutes(mocks.canary)
 	if err != nil {
 		t.Fatal(err.Error())
 	}
 
 	p = 50
 	c = 50
+	m = false
 
-	err = router.SetRoutes(mocks.canary, p, c)
+	err = router.SetRoutes(mocks.canary, p, c, m)
 	if err != nil {
 		t.Fatal(err.Error())
 	}
@@ -134,7 +135,7 @@ func TestSuperglooRouter_GetRoutes(t *testing.T) {
 		t.Fatal(err.Error())
 	}
 
-	p, c, err := router.GetRoutes(mocks.canary)
+	p, c, m, err := router.GetRoutes(mocks.canary)
 	if err != nil {
 		t.Fatal(err.Error())
 	}
@@ -145,5 +146,9 @@ func TestSuperglooRouter_GetRoutes(t *testing.T) {
 
 	if c != 0 {
 		t.Errorf("Got canary weight %v wanted %v", c, 0)
+	}
+
+	if m != false {
+		t.Errorf("Got mirror %v wanted %v", m, false)
 	}
 }


### PR DESCRIPTION
Traffic mirroring is a pre-stage for canary deployments.  When mirroring
is enabled, at the beginning of a canary deployment traffic is mirrored
to the canary instead of shifted for one canary period.  The service
mesh should mirror by copying the request and sending one copy to the
primary and one copy to the canary; only the response from the primary
is sent to the user.  The response from the canary is only used for
collecting metrics.

Once the mirror period is over, the canary proceeds as usual, shifting
traffic from primary to canary until complete.

Traffic mirroring can also be used for Blue/Green deployments Fix: #313 