### PR TITLE
Skip primary check for appmesh

### DIFF
--- a/pkg/controller/scheduler.go
+++ b/pkg/controller/scheduler.go
@@ -99,7 +99,7 @@ func (c *Controller) advanceCanary(name string, namespace string, skipLivenessCh
 	// create primary deployment and hpa if needed
 	// skip primary check for Istio since the deployment will become ready after the ClusterIP are created
 	skipPrimaryCheck := false
-	if skipLivenessChecks || strings.Contains(provider, "istio") {
+	if skipLivenessChecks || strings.Contains(provider, "istio") || strings.Contains(provider, "appmesh") {
 		skipPrimaryCheck = true
 	}
 	label, ports, err := c.deployer.Initialize(cd, skipPrimaryCheck)


### PR DESCRIPTION
Not sure if this is the right way to fix it but it worked for me (I'm not familiar with Istio but I suspect that the exception in the code has been added for similar reasons).

The problem is that when creating a new canary resource, Flagger waits for the primary pod to be ready before creating the Appmesh VirtualNode. If the deployment has an http readyness probe configured, it will always fail because Envoy can't get its config (as the VirtualNode doesn't exist yet) and rejects all connections.

We basically end up in the following state:

```
NAME                                        READY   STATUS             RESTARTS   AGE
test-canary-tuto-66cd89fd7b-98dnf           1/2     CrashLoopBackOff   6          4m39s
test-canary-tuto-66cd89fd7b-df9w7           1/2     CrashLoopBackOff   6          4m39s
test-canary-tuto-primary-597f6bf797-5jpfp   1/2     CrashLoopBackOff            1          47s
test-canary-tuto-primary-597f6bf797-q2995   1/2     CrashLoopBackOff            1          47s
```

And flagger the flagger logs shows a bunch of:

```
{"level":"info","ts":"2019-10-02T14:26:50.855+1300","caller":"controller/controller.go:271","msg":"Halt advancement test-canary-tuto-primary.test waiting for rollout to finish: 0 of 2 updated replicas are available","canary":"test-canary-tuto.test"}
```