### PR TITLE
Add Kustomize installer for App Mesh

### DIFF
--- a/docs/gitbook/install/flagger-install-on-kubernetes.md
+++ b/docs/gitbook/install/flagger-install-on-kubernetes.md
@@ -153,6 +153,14 @@ Note that you'll need kubectl 1.14 to run the above the command or you can downl
 kustomize build github.com/weaveworks/flagger//kustomize/istio | kubectl apply -f -
 ```
 
+Install Flagger for AWS App Mesh:
+
+```bash
+kubectl apply -k github.com/weaveworks/flagger//kustomize/appmesh
+```
+
+This deploys Flagger and Prometheus (configured to scrape the App Mesh Envoy sidecars) in the `appmesh-system` namespace.
+
 Install Flagger for Linkerd:
 
 ```bash

--- a/kustomize/README.md
+++ b/kustomize/README.md
@@ -19,6 +19,14 @@ Note that you'll need kubectl 1.14 to run the above the command or you can downl
 kustomize build github.com/weaveworks/flagger//kustomize/istio | kubectl apply -f -
 ```
 
+Install Flagger for AWS App Mesh:
+
+```bash
+kubectl apply -k github.com/weaveworks/flagger//kustomize/appmesh
+```
+
+This deploys Flagger and Prometheus (configured to scrape the App Mesh Envoy sidecars) in the `appmesh-system` namespace.
+
 Install Flagger for Linkerd:
 
 ```bash

--- a/kustomize/appmesh/kustomization.yaml
+++ b/kustomize/appmesh/kustomization.yaml
@@ -1,0 +1,6 @@
+namespace: appmesh-system
+bases:
+  - ../base/flagger
+  - ../base/prometheus
+patchesStrategicMerge:
+  - patch.yaml

--- a/kustomize/appmesh/patch.yaml
+++ b/kustomize/appmesh/patch.yaml
@@ -1,0 +1,16 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: flagger
+spec:
+  template:
+    spec:
+      containers:
+        - name: flagger
+          args:
+            - -log-level=info
+            - -mesh-provider=appmesh
+            - -metrics-server=http://flagger-prometheus:9090
+            - -slack-user=flagger
+            - -slack-channel=
+            - -slack-url=


### PR DESCRIPTION
Install Flagger and Prometheus (configured to scrape the App Mesh Envoy sidecars) in the `appmesh-system`:

```sh
kubectl apply -k github.com/weaveworks/flagger//kustomize/appmesh
```