### PR TITLE
Add support for acceptance testing when using App Mesh

### DIFF
--- a/artifacts/appmesh/canary.yaml
+++ b/artifacts/appmesh/canary.yaml
@@ -48,6 +48,13 @@ spec:
       interval: 30s
     # testing (optional)
     webhooks:
+      - name: acceptance-test
+        type: pre-rollout
+        url: http://flagger-loadtester.test/
+        timeout: 30s
+        metadata:
+          type: bash
+          cmd: "curl -sd 'test' http://podinfo-canary.test:9898/token | grep token"
       - name: load-test
         url: http://flagger-loadtester.test/
         timeout: 5s

--- a/artifacts/appmesh/canary.yaml
+++ b/artifacts/appmesh/canary.yaml
@@ -41,7 +41,12 @@ spec:
       # percentage (0-100)
       threshold: 99
       interval: 1m
-    # external checks (optional)
+    - name: request-duration
+      # maximum req duration P99
+      # milliseconds
+      threshold: 500
+      interval: 30s
+    # testing (optional)
     webhooks:
       - name: load-test
         url: http://flagger-loadtester.test/

--- a/artifacts/appmesh/deployment.yaml
+++ b/artifacts/appmesh/deployment.yaml
@@ -25,7 +25,7 @@ spec:
     spec:
       containers:
       - name: podinfod
-        image: quay.io/stefanprodan/podinfo:2.0.0
+        image: stefanprodan/podinfo:3.1.0
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9898


### PR DESCRIPTION
Allow the canary pods to be accessed from inside the mesh during the canary analysis for conformance and load testing by creating the canary virtual service during App Mesh reconciliation.

Docs changes:
* add App Mesh acceptance tests example Fix: #321
* add App Mesh request duration metric check example Fix: #143
