### PR TITLE
Release v0.18.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to this project are documented in this file.
 
+## 0.18.6 (2019-10-03) 
+
+Adds support for App Mesh conformance tests and latency metric checks
+
+#### Improvements 
+
+- Add support for acceptance testing when using App Mesh [#322](https://github.com/weaveworks/flagger/pull/322)
+- Add Kustomize installer for App Mesh [#310](https://github.com/weaveworks/flagger/pull/310)
+- Update Linkerd to v2.5.0 and Prometheus to v2.12.0 [#323](https://github.com/weaveworks/flagger/pull/323)
+
+#### Fixes
+
+- Fix slack/teams notification fields mapping [#318](https://github.com/weaveworks/flagger/pull/318)
+
 ## 0.18.5 (2019-10-02) 
 
 Adds support for [confirm-promotion](https://docs.flagger.app/how-it-works#webhooks) webhooks and blue/green deployments when using a service mesh

--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ For more details on how the canary analysis and promotion works please [read the
 | A/B testing (headers and cookies filters)    | :heavy_check_mark: | :heavy_minus_sign: | :heavy_minus_sign: | :heavy_check_mark: | :heavy_minus_sign: |
 | Webhooks (acceptance/load testing)           | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
 | Request success rate check (L7 metric)       | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
-| Request duration check (L7 metric)           | :heavy_check_mark: | :heavy_check_mark: | :heavy_minus_sign: | :heavy_check_mark: | :heavy_check_mark: |
+| Request duration check (L7 metric)           | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
 | Custom promql checks                         | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
 | Traffic policy, CORS, retries and timeouts   | :heavy_check_mark: | :heavy_minus_sign: | :heavy_minus_sign: | :heavy_minus_sign: | :heavy_minus_sign: |
 

--- a/artifacts/flagger/deployment.yaml
+++ b/artifacts/flagger/deployment.yaml
@@ -22,7 +22,7 @@ spec:
       serviceAccountName: flagger
       containers:
       - name: flagger
-        image: weaveworks/flagger:0.18.5
+        image: weaveworks/flagger:0.18.6
         imagePullPolicy: IfNotPresent
         ports:
         - name: http

--- a/charts/flagger/Chart.yaml
+++ b/charts/flagger/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: flagger
-version: 0.18.5
-appVersion: 0.18.5
+version: 0.18.6
+appVersion: 0.18.6
 kubeVersion: ">=1.11.0-0"
 engine: gotpl
 description: Flagger is a Kubernetes operator that automates the promotion of canary deployments using Istio, Linkerd, App Mesh, Gloo or NGINX routing for traffic shifting and Prometheus metrics for canary analysis.

--- a/charts/flagger/templates/prometheus.yaml
+++ b/charts/flagger/templates/prometheus.yaml
@@ -238,7 +238,7 @@ spec:
       serviceAccountName: {{ template "flagger.serviceAccountName" . }}-prometheus
       containers:
         - name: prometheus
-          image: "docker.io/prom/prometheus:v2.10.0"
+          image: "docker.io/prom/prometheus:v2.12.0"
           imagePullPolicy: IfNotPresent
           args:
             - '--storage.tsdb.retention=2h'

--- a/charts/flagger/values.yaml
+++ b/charts/flagger/values.yaml
@@ -2,7 +2,7 @@
 
 image:
   repository: weaveworks/flagger
-  tag: 0.18.5
+  tag: 0.18.6
   pullPolicy: IfNotPresent
   pullSecret:
 

--- a/kustomize/base/flagger/kustomization.yaml
+++ b/kustomize/base/flagger/kustomization.yaml
@@ -8,4 +8,4 @@ resources:
   - deployment.yaml
 images:
   - name: weaveworks/flagger
-    newTag: 0.18.5
+    newTag: 0.18.6

--- a/kustomize/base/prometheus/deployment.yaml
+++ b/kustomize/base/prometheus/deployment.yaml
@@ -19,7 +19,7 @@ spec:
       serviceAccountName: flagger-prometheus
       containers:
           - name: prometheus
-            image: prom/prometheus:v2.10.0
+            image: prom/prometheus:v2.12.0
             imagePullPolicy: IfNotPresent
             args:
               - '--storage.tsdb.retention=2h'

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,4 +1,4 @@
 package version
 
-var VERSION = "0.18.5"
+var VERSION = "0.18.6"
 var REVISION = "unknown"

--- a/test/e2e-linkerd.sh
+++ b/test/e2e-linkerd.sh
@@ -2,7 +2,7 @@
 
 set -o errexit
 
-LINKERD_VER="stable-2.4.0"
+LINKERD_VER="stable-2.5.0"
 REPO_ROOT=$(git rev-parse --show-toplevel)
 export KUBECONFIG="$(kind get kubeconfig-path --name="kind")"
 


### PR DESCRIPTION
Version 0.18.6 adds support for App Mesh conformance tests and latency metric checks

#### Improvements 

- Add support for acceptance testing when using App Mesh [#322](https://github.com/weaveworks/flagger/pull/322)
- Add Kustomize installer for App Mesh [#310](https://github.com/weaveworks/flagger/pull/310)
- Update Linkerd to v2.5.0 and Prometheus to v2.12.0

#### Fixes

- Fix slack/teams notification fields mapping [#318](https://github.com/weaveworks/flagger/pull/318)