### PR TITLE
Enforce blue/green when using kubernetes networking

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,16 +87,8 @@ spec:
   service:
     # container port
     port: 9898
-    # Istio gateways (optional)
-    gateways:
-    - public-gateway.istio-system.svc.cluster.local
-    # Istio virtual service host names (optional)
-    hosts:
-    - podinfo.example.com
-    # Istio traffic policy (optional)
-    trafficPolicy:
-      tls:
-        mode: ISTIO_MUTUAL
+    # port name can be http or grpc (default http)
+    portName: http
     # HTTP match conditions (optional)
     match:
       - uri:
@@ -104,10 +96,6 @@ spec:
     # HTTP rewrite (optional)
     rewrite:
       uri: /
-    # cross-origin resource sharing policy (optional)
-    corsPolicy:
-      allowOrigin:
-        - example.com
     # request timeout (optional)
     timeout: 5s
   # promote the canary without analysing it (default false)
@@ -160,15 +148,17 @@ For more details on how the canary analysis and promotion works please [read the
 
 ## Features
 
-| Feature                                      | Istio              | Linkerd            | App Mesh           | NGINX              | Gloo               |
-| -------------------------------------------- | ------------------ | ------------------ |------------------  |------------------  |------------------  |
-| Canary deployments (weighted traffic)        | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
-| A/B testing (headers and cookies filters)    | :heavy_check_mark: | :heavy_minus_sign: | :heavy_minus_sign: | :heavy_check_mark: | :heavy_minus_sign: |
-| Webhooks (acceptance/load testing)           | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
-| Request success rate check (L7 metric)       | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
-| Request duration check (L7 metric)           | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
-| Custom promql checks                         | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
-| Traffic policy, CORS, retries and timeouts   | :heavy_check_mark: | :heavy_minus_sign: | :heavy_minus_sign: | :heavy_minus_sign: | :heavy_minus_sign: |
+| Feature                                      | Istio              | Linkerd            | App Mesh           | NGINX              | Gloo               | Kubernetes CNI     |
+| -------------------------------------------- | ------------------ | ------------------ |------------------  |------------------  |------------------  |------------------  |
+| Canary deployments (weighted traffic)        | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_minus_sign: |
+| A/B testing (headers and cookies routing)    | :heavy_check_mark: | :heavy_minus_sign: | :heavy_minus_sign: | :heavy_check_mark: | :heavy_minus_sign: | :heavy_minus_sign: |
+| Blue/Green deployments (traffic switch)      | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
+| Webhooks (acceptance/load testing)           | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
+| Manual gating (approve/pause/resume)         | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
+| Request success rate check (L7 metric)       | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_minus_sign: |
+| Request duration check (L7 metric)           | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_minus_sign: |
+| Custom promql checks                         | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
+| Traffic policy, CORS, retries and timeouts   | :heavy_check_mark: | :heavy_minus_sign: | :heavy_minus_sign: | :heavy_minus_sign: | :heavy_minus_sign: | :heavy_minus_sign: |
 
 ## Roadmap
 

--- a/docs/gitbook/usage/progressive-delivery.md
+++ b/docs/gitbook/usage/progressive-delivery.md
@@ -115,6 +115,8 @@ kubectl apply -f ./podinfo-canary.yaml
 When the canary analysis starts, Flagger will call the pre-rollout webhooks before routing traffic to the canary.
 The canary analysis will run for five minutes while validating the HTTP metrics and rollout hooks every minute.
 
+![Flagger Canary Process](https://raw.githubusercontent.com/weaveworks/flagger/master/docs/diagrams/flagger-canary-hpa.png)
+
 After a couple of seconds Flagger will create the canary objects:
 
 ```bash
@@ -250,10 +252,10 @@ Events:
 
 ![Flagger Canary Traffic Shadowing](https://raw.githubusercontent.com/weaveworks/flagger/master/docs/diagrams/flagger-canary-traffic-mirroring.png)
 
-For applications that perform read operations, Flagger can be configured to drive a canary release with traffic mirroring.
+For applications that perform read operations, Flagger can be configured to drive canary releases with traffic mirroring.
 Istio traffic mirroring will copy each incoming request, sending one request to the primary and one to the canary service.
 The response from the primary is sent back to the user and the response from the canary is discarded.
-Metrics are collected on both requests so that the deployment will only proceed if the canary metrics are healthy.
+Metrics are collected on both requests so that the deployment will only proceed if the canary metrics are within the threshold values.
 
 Note that mirroring should be used for requests that are **idempotent** or capable of being processed twice
 (once by the primary and once by the canary).
@@ -324,9 +326,3 @@ The above procedure can be extended with [custom metrics](https://docs.flagger.a
 [webhooks](https://docs.flagger.app/how-it-works#webhooks),
 [manual promotion](https://docs.flagger.app/how-it-works#manual-gating) approval and
 [Slack or MS Teams](https://docs.flagger.app/usage/alerting) notifications.
-
-
-
-
-
-

--- a/pkg/controller/scheduler.go
+++ b/pkg/controller/scheduler.go
@@ -325,6 +325,19 @@ func (c *Controller) advanceCanary(name string, namespace string, skipLivenessCh
 		}
 	}
 
+	// use blue/green strategy for kubernetes provider
+	if provider == "kubernetes" {
+		if len(cd.Spec.CanaryAnalysis.Match) > 0 {
+			c.recordEventWarningf(cd, "A/B testing is not supported when using the kubernetes provider")
+			cd.Spec.CanaryAnalysis.Match = nil
+		}
+		if cd.Spec.CanaryAnalysis.Iterations < 1 {
+			c.recordEventWarningf(cd, "Progressive traffic is not supported when using the kubernetes provider")
+			c.recordEventWarningf(cd, "Setting canaryAnalysis.iterations: 10")
+			cd.Spec.CanaryAnalysis.Iterations = 10
+		}
+	}
+
 	// strategy: A/B testing
 	if len(cd.Spec.CanaryAnalysis.Match) > 0 && cd.Spec.CanaryAnalysis.Iterations > 0 {
 		// route traffic to canary and increment iterations


### PR DESCRIPTION
Use the blue/green deployment strategy with ten iterations and warn that progressive traffic shifting and HTTP headers routing are not compatible with Kubernetes L4 networking.