### PR TITLE
Add the app/name label to services and primary deployment

### DIFF
--- a/charts/flagger/README.md
+++ b/charts/flagger/README.md
@@ -68,6 +68,7 @@ Parameter | Description | Default
 `image.pullPolicy` | image pull policy | `IfNotPresent`
 `prometheus.install` | if `true`, installs Prometheus configured to scrape all pods in the custer including the App Mesh sidecar | `false`
 `metricsServer` | Prometheus URL, used when `prometheus.install` is `false` | `http://prometheus.istio-system:9090`
+`selectorLabels` | list of labels that Flagger uses to create pod selectors | `app,name,app.kubernetes.io/name`
 `slack.url` | Slack incoming webhook | None
 `slack.channel` | Slack channel | None
 `slack.user` | Slack username | `flagger`

--- a/charts/flagger/templates/deployment.yaml
+++ b/charts/flagger/templates/deployment.yaml
@@ -61,6 +61,9 @@ spec:
           {{- else }}
           - -metrics-server={{ .Values.metricsServer }}
           {{- end }}
+          {{- if .Values.selectorLabels }}
+          - -selector-labels={{ .Values.selectorLabels }}
+          {{- end }}
           {{- if .Values.namespace }}
           - -namespace={{ .Values.namespace }}
           {{- end }}

--- a/charts/flagger/values.yaml
+++ b/charts/flagger/values.yaml
@@ -12,11 +12,15 @@ podAnnotations:
 
 metricsServer: "http://prometheus:9090"
 
-# accepted values are istio, appmesh, nginx or supergloo:mesh.namespace (defaults to istio)
+# accepted values are kubernetes, istio, linkerd, appmesh, nginx, gloo or supergloo:mesh.namespace (defaults to istio)
 meshProvider: ""
 
 # single namespace restriction
 namespace: ""
+
+# list of pod labels that Flagger uses to create pod selectors
+# defaults to: app,name,app.kubernetes.io/name
+selectorLabels: ""
 
 slack:
   user: flagger

--- a/pkg/router/factory.go
+++ b/pkg/router/factory.go
@@ -36,12 +36,13 @@ func NewFactory(kubeConfig *restclient.Config, kubeClient kubernetes.Interface,
 }
 
 // KubernetesRouter returns a ClusterIP service router
-func (factory *Factory) KubernetesRouter(label string, ports *map[string]int32) *KubernetesRouter {
+func (factory *Factory) KubernetesRouter(labelSelector string, annotations map[string]string, ports map[string]int32) *KubernetesRouter {
 	return &KubernetesRouter{
 		logger:        factory.logger,
 		flaggerClient: factory.flaggerClient,
 		kubeClient:    factory.kubeClient,
-		label:         label,
+		labelSelector: labelSelector,
+		annotations:   annotations,
 		ports:         ports,
 	}
 }


### PR DESCRIPTION
This PR adds a label to the ClusterIP services and primary deployment metadata at bootstrap time. The label name is deduced from `-selector-labels` command flag, by default it will be `app`, `name` or `app.kubernetes.io/name`. 

The label value is set to the object name, for example:

```yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: podinfo-primary
  labels:
    app: podinfo-primary
---
apiVersion: v1
kind: Service
metadata:
  name: podinfo
  labels:
    app: podinfo
---
apiVersion: v1
kind: Service
metadata:
  name: podinfo-primary
  labels:
    app: podinfo-primary
---
apiVersion: v1
kind: Service
metadata:
  name: podinfo-canary
  labels:
    app: podinfo-canary
```

Ref: #329