### PR TITLE
Allow setting Slack and Teams URLs with env vars

### DIFF
--- a/charts/flagger/templates/deployment.yaml
+++ b/charts/flagger/templates/deployment.yaml
@@ -102,6 +102,10 @@ spec:
               - --spider
               - http://localhost:8080/healthz
             timeoutSeconds: 5
+          {{- if .Values.env }}
+          env:
+{{ toYaml .Values.env | indent 12 }}
+          {{- end }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}
     {{- with .Values.nodeSelector }}

--- a/charts/flagger/values.yaml
+++ b/charts/flagger/values.yaml
@@ -32,6 +32,19 @@ msteams:
   # MS Teams incoming webhook URL
   url:
 
+#env:
+#- name: SLACK_URL
+#  valueFrom:
+#    secretKeyRef:
+#      name: slack
+#      key: url
+#- name: MSTEAMS_URL
+#  valueFrom:
+#    secretKeyRef:
+#      name: msteams
+#      key: url
+env: []
+
 leaderElection:
   enabled: false
   replicaCount: 1

--- a/cmd/flagger/main.go
+++ b/cmd/flagger/main.go
@@ -286,10 +286,10 @@ func startLeaderElection(ctx context.Context, run func(), ns string, kubeClient 
 
 func initNotifier(logger *zap.SugaredLogger) (client notifier.Interface) {
 	provider := "slack"
-	notifierURL := slackURL
+	notifierURL := fromEnv("SLACK_URL", slackURL)
 	if msteamsURL != "" {
 		provider = "msteams"
-		notifierURL = msteamsURL
+		notifierURL = fromEnv("MSTEAMS_URL", msteamsURL)
 	}
 	notifierFactory := notifier.NewFactory(notifierURL, slackUser, slackChannel)
 
@@ -303,4 +303,11 @@ func initNotifier(logger *zap.SugaredLogger) (client notifier.Interface) {
 		}
 	}
 	return
+}
+
+func fromEnv(envVar string, defaultVal string) string {
+	if os.Getenv(envVar) != "" {
+		return os.Getenv(envVar)
+	}
+	return defaultVal
 }

--- a/cmd/flagger/main.go
+++ b/cmd/flagger/main.go
@@ -287,7 +287,7 @@ func startLeaderElection(ctx context.Context, run func(), ns string, kubeClient 
 func initNotifier(logger *zap.SugaredLogger) (client notifier.Interface) {
 	provider := "slack"
 	notifierURL := fromEnv("SLACK_URL", slackURL)
-	if msteamsURL != "" {
+	if msteamsURL != "" || os.Getenv("MSTEAMS_URL") != "" {
 		provider = "msteams"
 		notifierURL = fromEnv("MSTEAMS_URL", msteamsURL)
 	}


### PR DESCRIPTION
* overwrite Slack and Teams command args with `SLACK_URL` and `MSTEAMS_URL` env variables
* add `env` to Helm chart options to be used for Slack and Teams URLs

Fix: #332 

