### PR TITLE
Release v0.20.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,6 +11,9 @@ jobs:
           keys:
             - go-mod-v3-{{ checksum "go.sum" }}
       - run:
+          name: Run go mod download
+          command: go mod download
+      - run:
           name: Run go fmt
           command: make test-fmt
       - run:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 All notable changes to this project are documented in this file.
 
+## 0.20.0 (2019-10-21) 
+
+Adds support for [A/B Testing](https://docs.flagger.app/usage/progressive-delivery#traffic-mirroring) and retry policies when using App Mesh
+
+#### Features
+
+- Implement App Mesh A/B testing based on HTTP headers match conditions [#340](https://github.com/weaveworks/flagger/pull/340)
+- Implement App Mesh HTTP retry policy [#338](https://github.com/weaveworks/flagger/pull/338)
+- Implement metrics server override [#342](https://github.com/weaveworks/flagger/pull/342)
+
+#### Improvements 
+
+- Add the app/name label to services and primary deployment [#333](https://github.com/weaveworks/flagger/pull/333)
+- Allow setting Slack and Teams URLs with env vars [#334](https://github.com/weaveworks/flagger/pull/334)
+
+#### Fixes
+
+- Generate unique names for App Mesh virtual routers and routes [#336](https://github.com/weaveworks/flagger/pull/336)
+
 ## 0.19.0 (2019-10-08) 
 
 Adds support for canary and blue/green [traffic mirroring](https://docs.flagger.app/usage/progressive-delivery#traffic-mirroring)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Adds support for [A/B Testing](https://docs.flagger.app/usage/progressive-delive
 
 - Add the app/name label to services and primary deployment [#333](https://github.com/weaveworks/flagger/pull/333)
 - Allow setting Slack and Teams URLs with env vars [#334](https://github.com/weaveworks/flagger/pull/334)
+- Refactor Gloo integration [#344](https://github.com/weaveworks/flagger/pull/344)
 
 #### Fixes
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,6 @@ Flagger documentation can be found at [docs.flagger.app](https://docs.flagger.ap
   * [FAQ](https://docs.flagger.app/faq)
 * Usage
   * [Istio canary deployments](https://docs.flagger.app/usage/progressive-delivery)
-  * [Istio A/B testing](https://docs.flagger.app/usage/ab-testing)
   * [Linkerd canary deployments](https://docs.flagger.app/usage/linkerd-progressive-delivery)
   * [App Mesh canary deployments](https://docs.flagger.app/usage/appmesh-progressive-delivery)
   * [NGINX ingress controller canary deployments](https://docs.flagger.app/usage/nginx-progressive-delivery)
@@ -153,7 +152,7 @@ For more details on how the canary analysis and promotion works please [read the
 | Feature                                      | Istio              | Linkerd            | App Mesh           | NGINX              | Gloo               | Kubernetes CNI     |
 | -------------------------------------------- | ------------------ | ------------------ |------------------  |------------------  |------------------  |------------------  |
 | Canary deployments (weighted traffic)        | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_minus_sign: |
-| A/B testing (headers and cookies routing)    | :heavy_check_mark: | :heavy_minus_sign: | :heavy_minus_sign: | :heavy_check_mark: | :heavy_minus_sign: | :heavy_minus_sign: |
+| A/B testing (headers and cookies routing)    | :heavy_check_mark: | :heavy_minus_sign: | :heavy_check_mark: | :heavy_check_mark: | :heavy_minus_sign: | :heavy_minus_sign: |
 | Blue/Green deployments (traffic switch)      | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
 | Webhooks (acceptance/load testing)           | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
 | Manual gating (approve/pause/resume)         | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |

--- a/artifacts/flagger/deployment.yaml
+++ b/artifacts/flagger/deployment.yaml
@@ -22,7 +22,7 @@ spec:
       serviceAccountName: flagger
       containers:
       - name: flagger
-        image: weaveworks/flagger:0.19.0
+        image: weaveworks/flagger:0.20.0
         imagePullPolicy: IfNotPresent
         ports:
         - name: http

--- a/charts/flagger/Chart.yaml
+++ b/charts/flagger/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: flagger
-version: 0.19.0
-appVersion: 0.19.0
+version: 0.20.0
+appVersion: 0.20.0
 kubeVersion: ">=1.11.0-0"
 engine: gotpl
 description: Flagger is a Kubernetes operator that automates the promotion of canary deployments using Istio, Linkerd, App Mesh, Gloo or NGINX routing for traffic shifting and Prometheus metrics for canary analysis.

--- a/charts/flagger/values.yaml
+++ b/charts/flagger/values.yaml
@@ -2,7 +2,7 @@
 
 image:
   repository: weaveworks/flagger
-  tag: 0.19.0
+  tag: 0.20.0
   pullPolicy: IfNotPresent
   pullSecret:
 

--- a/docs/gitbook/faq.md
+++ b/docs/gitbook/faq.md
@@ -10,7 +10,7 @@ Flagger can run automated application analysis, promotion and rollback for the f
 * Canary (traffic mirroring)
     * Istio
 * A/B Testing (HTTP headers and cookies traffic routing)
-    * Istio, NGINX
+    * Istio, App Mesh, NGINX
 * Blue/Green (traffic switch)
     * Kubernetes CNI, Istio, Linkerd, App Mesh, NGINX, Gloo
 
@@ -42,6 +42,21 @@ Istio example:
           cookie:
             regex: "^(.*?;)?(canary=always)(;.*)?$"
 ```
+
+App Mesh example:
+
+```yaml
+  canaryAnalysis:
+    interval: 1m
+    threshold: 10
+    iterations: 2
+    match:
+      - headers:
+          user-agent:
+            regex: ".*Chrome.*"
+```
+
+Note that App Mesh supports a single condition.
 
 NGINX example:
 

--- a/docs/gitbook/how-it-works.md
+++ b/docs/gitbook/how-it-works.md
@@ -327,6 +327,22 @@ With the above configuration Flagger will run conformance and load tests on the 
 If the metrics analysis succeeds, live traffic will be switched from the old version to the new one when the
 canary is promoted.
 
+The blue/green deployment strategy is supported for all service mesh providers.
+
+Blue/Green rollout steps for service mesh:
+* scale up the canary (green)
+* run conformance tests for the canary pods
+* run load tests and metric checks for the canary pods
+* route traffic to canary
+* promote canary spec over primary (blue)
+* wait for primary rollout
+* route traffic to primary
+* scale down canary
+
+After the analysis finishes, the traffic is routed to the canary (green) before triggering the primary (blue)
+rolling update, this ensures a smooth transition to the new version avoiding dropping in-flight requests during
+the Kubernetes deployment rollout.
+
 ### HTTP Metrics
 
 The canary analysis is using the following Prometheus queries:

--- a/docs/gitbook/install/flagger-install-on-eks-appmesh.md
+++ b/docs/gitbook/install/flagger-install-on-eks-appmesh.md
@@ -113,7 +113,7 @@ Install the App Mesh CRD controller:
 
 ```sh
 helm upgrade -i appmesh-controller eks/appmesh-controller \
---wait --namespace appmesh-system
+--wait --namespace appmesh-system --version 0.2.0
 ```
 
 Install the App Mesh admission controller:

--- a/docs/gitbook/usage/blue-green.md
+++ b/docs/gitbook/usage/blue-green.md
@@ -4,6 +4,7 @@ This guide shows you how to automate Blue/Green deployments with Flagger and Kub
 
 For applications that are not deployed on a service mesh, Flagger can orchestrate Blue/Green style deployments 
 with Kubernetes L4 networking.
+When using a service mesh blue/green can be used as specified [here](https://docs.flagger.app/how-it-works#blue-green-deployments).
 
 ![Flagger Blue/Green Stages](https://raw.githubusercontent.com/weaveworks/flagger/master/docs/diagrams/flagger-bluegreen-steps.png)
 

--- a/kustomize/base/flagger/kustomization.yaml
+++ b/kustomize/base/flagger/kustomization.yaml
@@ -8,4 +8,4 @@ resources:
   - deployment.yaml
 images:
   - name: weaveworks/flagger
-    newTag: 0.19.0
+    newTag: 0.20.0

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,4 +1,4 @@
 package version
 
-var VERSION = "0.19.0"
+var VERSION = "0.20.0"
 var REVISION = "unknown"


### PR DESCRIPTION
Version 0.20.0 adds support for [A/B Testing](https://docs.flagger.app/usage/progressive-delivery#traffic-mirroring) and retry policies when using App Mesh.

#### Features

- Implement App Mesh A/B testing based on HTTP headers match conditions [#340](https://github.com/weaveworks/flagger/pull/340)
- Implement App Mesh HTTP retry policy [#338](https://github.com/weaveworks/flagger/pull/338)
- Implement metrics server override [#342](https://github.com/weaveworks/flagger/pull/342)

#### Improvements 

- Add the app/name label to services and primary deployment [#333](https://github.com/weaveworks/flagger/pull/333)
- Allow setting Slack and Teams URLs with env vars [#334](https://github.com/weaveworks/flagger/pull/334)

#### Fixes

- Generate unique names for App Mesh virtual routers and routes [#336](https://github.com/weaveworks/flagger/pull/336)