### PR TITLE
e2e testing: update providers

### DIFF
--- a/Dockerfile.loadtester
+++ b/Dockerfile.loadtester
@@ -14,7 +14,7 @@ chmod +x linux-amd64/helm && mv linux-amd64/helm /usr/local/bin/helm && \
 chmod +x linux-amd64/tiller && mv linux-amd64/tiller /usr/local/bin/tiller && \
 rm -rf linux-amd64
 
-RUN curl -sSL "https://get.helm.sh/helm-v3.0.0-beta.3-linux-amd64.tar.gz" | tar xvz && \
+RUN curl -sSL "https://get.helm.sh/helm-v3.0.0-beta.5-linux-amd64.tar.gz" | tar xvz && \
 chmod +x linux-amd64/helm && mv linux-amd64/helm /usr/local/bin/helmv3 && \
 rm -rf linux-amd64
 

--- a/artifacts/loadtester/deployment.yaml
+++ b/artifacts/loadtester/deployment.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
         - name: loadtester
-          image: weaveworks/flagger-loadtester:0.9.0
+          image: weaveworks/flagger-loadtester:0.10.0
           imagePullPolicy: IfNotPresent
           ports:
             - name: http

--- a/charts/loadtester/Chart.yaml
+++ b/charts/loadtester/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: loadtester
-version: 0.9.0
-appVersion: 0.9.0
+version: 0.10.0
+appVersion: 0.10.0
 kubeVersion: ">=1.11.0-0"
 engine: gotpl
 description: Flagger's load testing services based on rakyll/hey and bojand/ghz that generates traffic during canary analysis when configured as a webhook.

--- a/charts/loadtester/values.yaml
+++ b/charts/loadtester/values.yaml
@@ -2,7 +2,7 @@ replicaCount: 1
 
 image:
   repository: weaveworks/flagger-loadtester
-  tag: 0.9.0
+  tag: 0.10.0
   pullPolicy: IfNotPresent
 
 podAnnotations:

--- a/cmd/loadtester/main.go
+++ b/cmd/loadtester/main.go
@@ -10,7 +10,7 @@ import (
 	"time"
 )
 
-var VERSION = "0.9.0"
+var VERSION = "0.10.0"
 var (
 	logLevel          string
 	port              string

--- a/kustomize/tester/deployment.yaml
+++ b/kustomize/tester/deployment.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
         - name: loadtester
-          image: weaveworks/flagger-loadtester:0.9.0
+          image: weaveworks/flagger-loadtester:0.10.0
           imagePullPolicy: IfNotPresent
           ports:
             - name: http

--- a/pkg/controller/scheduler.go
+++ b/pkg/controller/scheduler.go
@@ -751,7 +751,6 @@ func (c *Controller) analyseCanary(r *flaggerv1.Canary) bool {
 
 	// create observer based on the mesh provider
 	observerFactory := c.observerFactory
-	observer := observerFactory.Observer(metricsProvider)
 
 	// override the global metrics server if one is specified in the canary spec
 	metricsServer := c.observerFactory.Client.GetMetricsServer()
@@ -763,8 +762,8 @@ func (c *Controller) analyseCanary(r *flaggerv1.Canary) bool {
 			c.recordEventErrorf(r, "Error building Prometheus client for %s %v", r.Spec.MetricsServer, err)
 			return false
 		}
-		observer = observerFactory.Observer(metricsProvider)
 	}
+	observer := observerFactory.Observer(metricsProvider)
 
 	// run metrics checks
 	for _, metric := range r.Spec.CanaryAnalysis.Metrics {

--- a/test/container-push.sh
+++ b/test/container-push.sh
@@ -13,9 +13,6 @@ push () {
     else
         docker tag test/flagger:latest weaveworks/flagger:${CIRCLE_TAG};
         docker push weaveworks/flagger:${CIRCLE_TAG};
-        LT_VERSION=$(grep 'VERSION' cmd/loadtester/main.go | awk '{ print $4 }' | tr -d '"' | head -n1);
-        docker tag test/flagger-loadtester:latest weaveworks/flagger-loadtester:${LT_VERSION};
-        docker push weaveworks/flagger-loadtester:${LT_VERSION};
     fi
 }
 

--- a/test/e2e-gloo-tests.sh
+++ b/test/e2e-gloo-tests.sh
@@ -36,9 +36,6 @@ spec:
           upstreamGroup:
             name: podinfo
             namespace: test
-        routePlugins:
-          prefixRewrite:
-            prefixRewrite: "/"
 EOF
 
 cat <<EOF | kubectl apply -f -

--- a/test/e2e-istio.sh
+++ b/test/e2e-istio.sh
@@ -2,7 +2,7 @@
 
 set -o errexit
 
-ISTIO_VER="1.3.0"
+ISTIO_VER="1.3.3"
 REPO_ROOT=$(git rev-parse --show-toplevel)
 export KUBECONFIG="$(kind get kubeconfig-path --name="kind")"
 

--- a/test/e2e-kind.sh
+++ b/test/e2e-kind.sh
@@ -3,7 +3,7 @@
 set -o errexit
 
 REPO_ROOT=$(git rev-parse --show-toplevel)
-HELM_VERSION=v2.14.3
+HELM_VERSION=v2.15.1
 KIND_VERSION=v0.5.1
 
 if [[ "$1" ]]; then

--- a/test/e2e-kind.sh
+++ b/test/e2e-kind.sh
@@ -21,7 +21,7 @@ chmod +x kind
 sudo mv kind /usr/local/bin/kind
 
 echo ">>> Creating kind cluster"
-kind create cluster --wait 5m
+kind create cluster --wait 5m #--image kindest/node:v1.16.2
 
 export KUBECONFIG="$(kind get kubeconfig-path --name="kind")"
 kubectl get pods --all-namespaces

--- a/test/e2e-linkerd.sh
+++ b/test/e2e-linkerd.sh
@@ -2,7 +2,7 @@
 
 set -o errexit
 
-LINKERD_VER="stable-2.5.0"
+LINKERD_VER="stable-2.6.0"
 REPO_ROOT=$(git rev-parse --show-toplevel)
 export KUBECONFIG="$(kind get kubeconfig-path --name="kind")"
 

--- a/test/e2e-nginx-custom-annotations.sh
+++ b/test/e2e-nginx-custom-annotations.sh
@@ -4,7 +4,7 @@ set -o errexit
 
 REPO_ROOT=$(git rev-parse --show-toplevel)
 export KUBECONFIG="$(kind get kubeconfig-path --name="kind")"
-NGINX_VERSION=1.12.1
+NGINX_VERSION=1.24.4
 
 echo '>>> Installing NGINX Ingress'
 helm upgrade -i nginx-ingress stable/nginx-ingress --version=${NGINX_VERSION} \

--- a/test/e2e-nginx-tests.sh
+++ b/test/e2e-nginx-tests.sh
@@ -122,7 +122,7 @@ failed=false
 until ${ok}; do
     kubectl -n test get canary/podinfo | grep 'Failed' && failed=true || failed=false
     if ${failed}; then
-        kubectl -n ingress-nginx logs deployment/test-flagger
+        kubectl -n ingress-nginx logs deployment/flagger
         echo "Canary failed!"
         exit 1
     fi

--- a/test/e2e-nginx.sh
+++ b/test/e2e-nginx.sh
@@ -4,7 +4,7 @@ set -o errexit
 
 REPO_ROOT=$(git rev-parse --show-toplevel)
 export KUBECONFIG="$(kind get kubeconfig-path --name="kind")"
-NGINX_VERSION=1.12.1
+NGINX_VERSION=1.24.4
 
 echo '>>> Installing NGINX Ingress'
 helm upgrade -i nginx-ingress stable/nginx-ingress --version=${NGINX_VERSION} \


### PR DESCRIPTION
Updates:
* Helm 2.15.1
* Istio 1.3.3
* Linkerd 2.6.0
* NGINX Ingress 1.24.4

Release loadtester 0.10.0 with Helm v3.0.0-beta.5
