### PR TITLE
Release v0.20.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to this project are documented in this file.
 
+## 0.20.1 (2019-11-03) 
+
+Fixes promql execution and updates the load testing tools
+
+#### Improvements 
+
+- Update load tester Helm tools [#8349dd1](https://github.com/weaveworks/flagger/commit/8349dd1cda59a741c7bed9a0f67c0fc0fbff4635)
+- e2e testing: update providers [#346](https://github.com/weaveworks/flagger/pull/346)
+
+#### Fixes
+
+- Fix Prometheus query escape [#353](https://github.com/weaveworks/flagger/pull/353)
+- Updating hey release link [#350](https://github.com/weaveworks/flagger/pull/350)
+
 ## 0.20.0 (2019-10-21) 
 
 Adds support for [A/B Testing](https://docs.flagger.app/usage/progressive-delivery#traffic-mirroring) and retry policies when using App Mesh

--- a/Dockerfile.loadtester
+++ b/Dockerfile.loadtester
@@ -9,16 +9,19 @@ WORKDIR /home/app
 RUN curl -sSLo hey "https://storage.googleapis.com/hey-release/hey_linux_amd64" && \
 chmod +x hey && mv hey /usr/local/bin/hey
 
-RUN curl -sSL "https://get.helm.sh/helm-v2.14.3-linux-amd64.tar.gz" | tar xvz && \
+# verify hey works
+RUN hey -n 1 -c 1 https://flagger.app > /dev/null && echo $? | grep 0
+
+RUN curl -sSL "https://get.helm.sh/helm-v2.15.1-linux-amd64.tar.gz" | tar xvz && \
 chmod +x linux-amd64/helm && mv linux-amd64/helm /usr/local/bin/helm && \
 chmod +x linux-amd64/tiller && mv linux-amd64/tiller /usr/local/bin/tiller && \
 rm -rf linux-amd64
 
-RUN curl -sSL "https://get.helm.sh/helm-v3.0.0-beta.5-linux-amd64.tar.gz" | tar xvz && \
+RUN curl -sSL "https://get.helm.sh/helm-v3.0.0-rc.2-linux-amd64.tar.gz" | tar xvz && \
 chmod +x linux-amd64/helm && mv linux-amd64/helm /usr/local/bin/helmv3 && \
 rm -rf linux-amd64
 
-RUN GRPC_HEALTH_PROBE_VERSION=v0.3.0 && \
+RUN GRPC_HEALTH_PROBE_VERSION=v0.3.1 && \
 wget -qO /usr/local/bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-amd64 && \
 chmod +x /usr/local/bin/grpc_health_probe
 
@@ -35,7 +38,7 @@ RUN chown -R app:app ./
 
 USER app
 
-RUN curl -sSL "https://github.com/rimusz/helm-tiller/archive/v0.8.3.tar.gz" | tar xvz && \
-helm init --client-only && helm plugin install helm-tiller-0.8.3 && helm plugin list
+RUN curl -sSL "https://github.com/rimusz/helm-tiller/archive/v0.9.3.tar.gz" | tar xvz && \
+helm init --client-only && helm plugin install helm-tiller-0.9.3 && helm plugin list
 
 ENTRYPOINT ["./loadtester"]

--- a/artifacts/flagger/deployment.yaml
+++ b/artifacts/flagger/deployment.yaml
@@ -22,7 +22,7 @@ spec:
       serviceAccountName: flagger
       containers:
       - name: flagger
-        image: weaveworks/flagger:0.20.0
+        image: weaveworks/flagger:0.20.1
         imagePullPolicy: IfNotPresent
         ports:
         - name: http

--- a/artifacts/loadtester/deployment.yaml
+++ b/artifacts/loadtester/deployment.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
         - name: loadtester
-          image: weaveworks/flagger-loadtester:0.10.0
+          image: weaveworks/flagger-loadtester:0.11.0
           imagePullPolicy: IfNotPresent
           ports:
             - name: http

--- a/charts/flagger/Chart.yaml
+++ b/charts/flagger/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: flagger
-version: 0.20.0
-appVersion: 0.20.0
+version: 0.20.1
+appVersion: 0.20.1
 kubeVersion: ">=1.11.0-0"
 engine: gotpl
 description: Flagger is a Kubernetes operator that automates the promotion of canary deployments using Istio, Linkerd, App Mesh, Gloo or NGINX routing for traffic shifting and Prometheus metrics for canary analysis.

--- a/charts/flagger/values.yaml
+++ b/charts/flagger/values.yaml
@@ -2,7 +2,7 @@
 
 image:
   repository: weaveworks/flagger
-  tag: 0.20.0
+  tag: 0.20.1
   pullPolicy: IfNotPresent
   pullSecret:
 

--- a/charts/loadtester/Chart.yaml
+++ b/charts/loadtester/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: loadtester
-version: 0.10.0
-appVersion: 0.10.0
+version: 0.11.0
+appVersion: 0.11.0
 kubeVersion: ">=1.11.0-0"
 engine: gotpl
 description: Flagger's load testing services based on rakyll/hey and bojand/ghz that generates traffic during canary analysis when configured as a webhook.

--- a/charts/loadtester/values.yaml
+++ b/charts/loadtester/values.yaml
@@ -2,7 +2,7 @@ replicaCount: 1
 
 image:
   repository: weaveworks/flagger-loadtester
-  tag: 0.10.0
+  tag: 0.11.0
   pullPolicy: IfNotPresent
 
 podAnnotations:

--- a/cmd/loadtester/main.go
+++ b/cmd/loadtester/main.go
@@ -10,7 +10,7 @@ import (
 	"time"
 )
 
-var VERSION = "0.10.0"
+var VERSION = "0.11.0"
 var (
 	logLevel          string
 	port              string

--- a/kustomize/base/flagger/kustomization.yaml
+++ b/kustomize/base/flagger/kustomization.yaml
@@ -8,4 +8,4 @@ resources:
   - deployment.yaml
 images:
   - name: weaveworks/flagger
-    newTag: 0.20.0
+    newTag: 0.20.1

--- a/kustomize/tester/deployment.yaml
+++ b/kustomize/tester/deployment.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
         - name: loadtester
-          image: weaveworks/flagger-loadtester:0.10.0
+          image: weaveworks/flagger-loadtester:0.11.0
           imagePullPolicy: IfNotPresent
           ports:
             - name: http

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,4 +1,4 @@
 package version
 
-var VERSION = "0.20.0"
+var VERSION = "0.20.1"
 var REVISION = "unknown"


### PR DESCRIPTION
Version 0.20.1 fixes promql execution and updates the load testing tools

#### Improvements 

- Update load tester Helm tools [#8349dd1](https://github.com/weaveworks/flagger/commit/8349dd1cda59a741c7bed9a0f67c0fc0fbff4635)
- e2e testing: update providers [#346](https://github.com/weaveworks/flagger/pull/346)

#### Fixes

- Fix Prometheus query escape [#353](https://github.com/weaveworks/flagger/pull/353)
- Updating hey release link [#350](https://github.com/weaveworks/flagger/pull/350)