### PR TITLE
Expose canaries on public domains with App Mesh Gateway

### DIFF
--- a/pkg/router/router_test.go
+++ b/pkg/router/router_test.go
@@ -70,7 +70,14 @@ func newMockCanaryAppMesh() *flaggerv1.Canary {
 			Service: flaggerv1.CanaryService{
 				Port:     9898,
 				MeshName: "global",
+				Hosts:    []string{"*"},
 				Backends: []string{"backend.default"},
+				Timeout:  "25",
+				Retries: &istiov1alpha3.HTTPRetry{
+					Attempts:      5,
+					PerTryTimeout: "gateway-error",
+					RetryOn:       "5s",
+				},
 			}, CanaryAnalysis: flaggerv1.CanaryAnalysis{
 				Threshold:  10,
 				StepWeight: 10,


### PR DESCRIPTION
This PR adds support for exposing caries outside the mesh with [App Mesh Gateway](https://github.com/stefanprodan/appmesh-gateway) by mapping `canary.spec.service.hosts`, `retries` and `timeout` to `gateway.appmesh.k8s.aws` annotations.

Fix: #357 