### PR TITLE
Release v0.20.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to this project are documented in this file.
 
+## 0.20.2 (2019-11-07) 
+
+Adds support for exposing canaries outside the cluster using App Mesh Gateway annotations 
+
+#### Improvements 
+
+- Expose canaries on public domains with App Mesh Gateway [#358](https://github.com/weaveworks/flagger/pull/358)
+
+#### Fixes
+
+- Use the specified replicas when scaling up the canary [#363](https://github.com/weaveworks/flagger/pull/363)
+
 ## 0.20.1 (2019-11-03) 
 
 Fixes promql execution and updates the load testing tools

--- a/artifacts/flagger/deployment.yaml
+++ b/artifacts/flagger/deployment.yaml
@@ -22,7 +22,7 @@ spec:
       serviceAccountName: flagger
       containers:
       - name: flagger
-        image: weaveworks/flagger:0.20.1
+        image: weaveworks/flagger:0.20.2
         imagePullPolicy: IfNotPresent
         ports:
         - name: http

--- a/charts/flagger/Chart.yaml
+++ b/charts/flagger/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: flagger
-version: 0.20.1
-appVersion: 0.20.1
+version: 0.20.2
+appVersion: 0.20.2
 kubeVersion: ">=1.11.0-0"
 engine: gotpl
 description: Flagger is a Kubernetes operator that automates the promotion of canary deployments using Istio, Linkerd, App Mesh, Gloo or NGINX routing for traffic shifting and Prometheus metrics for canary analysis.

--- a/charts/flagger/values.yaml
+++ b/charts/flagger/values.yaml
@@ -2,7 +2,7 @@
 
 image:
   repository: weaveworks/flagger
-  tag: 0.20.1
+  tag: 0.20.2
   pullPolicy: IfNotPresent
   pullSecret:
 

--- a/docs/gitbook/usage/linkerd-progressive-delivery.md
+++ b/docs/gitbook/usage/linkerd-progressive-delivery.md
@@ -102,12 +102,12 @@ spec:
         timeout: 30s
         metadata:
           type: bash
-          cmd: "curl -sd 'test' http://podinfo-canary:9898/token | grep token"
+          cmd: "curl -sd 'test' http://podinfo-canary.test:9898/token | grep token"
       - name: load-test
         type: rollout
         url: http://flagger-loadtester.test/
         metadata:
-          cmd: "hey -z 2m -q 10 -c 2 http://podinfo:9898/"
+          cmd: "hey -z 2m -q 10 -c 2 http://podinfo-canary.test:9898/"
 ```
 
 Save the above resource as podinfo-canary.yaml and then apply it:

--- a/kustomize/base/flagger/kustomization.yaml
+++ b/kustomize/base/flagger/kustomization.yaml
@@ -8,4 +8,4 @@ resources:
   - deployment.yaml
 images:
   - name: weaveworks/flagger
-    newTag: 0.20.1
+    newTag: 0.20.2

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,4 +1,4 @@
 package version
 
-var VERSION = "0.20.1"
+var VERSION = "0.20.2"
 var REVISION = "unknown"


### PR DESCRIPTION
Version 0.20.2 adds support for exposing canaries outside the cluster using App Mesh Gateway annotations.

#### Improvements 

- Expose canaries on public domains with App Mesh Gateway [#358](https://github.com/weaveworks/flagger/pull/358)

#### Fixes

- Use the specified replicas when scaling up the canary [#363](https://github.com/weaveworks/flagger/pull/363)