### PR TITLE
Add wrk to load tester tools

### DIFF
--- a/Dockerfile.loadtester
+++ b/Dockerfile.loadtester
@@ -1,36 +1,52 @@
-FROM bats/bats:v1.1.0
+FROM alpine:3.10.3 as build
 
-RUN addgroup -S app \
-    && adduser -S -g app app \
-    && apk --no-cache add ca-certificates curl jq
-
-WORKDIR /home/app
+RUN apk --no-cache add alpine-sdk perl curl
 
 RUN curl -sSLo hey "https://storage.googleapis.com/hey-release/hey_linux_amd64" && \
 chmod +x hey && mv hey /usr/local/bin/hey
 
-# verify hey works
-RUN hey -n 1 -c 1 https://flagger.app > /dev/null && echo $? | grep 0
-
-RUN curl -sSL "https://get.helm.sh/helm-v2.15.1-linux-amd64.tar.gz" | tar xvz && \
+RUN HELM2_VERSION=2.16.1 && \
+curl -sSL "https://get.helm.sh/helm-v${HELM2_VERSION}-linux-amd64.tar.gz" | tar xvz && \
 chmod +x linux-amd64/helm && mv linux-amd64/helm /usr/local/bin/helm && \
-chmod +x linux-amd64/tiller && mv linux-amd64/tiller /usr/local/bin/tiller && \
-rm -rf linux-amd64
+chmod +x linux-amd64/tiller && mv linux-amd64/tiller /usr/local/bin/tiller
 
-RUN curl -sSL "https://get.helm.sh/helm-v3.0.0-rc.2-linux-amd64.tar.gz" | tar xvz && \
-chmod +x linux-amd64/helm && mv linux-amd64/helm /usr/local/bin/helmv3 && \
-rm -rf linux-amd64
+RUN HELM3_VERSION=3.0.0-rc.3 && \
+curl -sSL "https://get.helm.sh/helm-v${HELM3_VERSION}-linux-amd64.tar.gz" | tar xvz && \
+chmod +x linux-amd64/helm && mv linux-amd64/helm /usr/local/bin/helmv3
 
 RUN GRPC_HEALTH_PROBE_VERSION=v0.3.1 && \
 wget -qO /usr/local/bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-amd64 && \
 chmod +x /usr/local/bin/grpc_health_probe
 
-RUN curl -sSL "https://github.com/bojand/ghz/releases/download/v0.39.0/ghz_0.39.0_Linux_x86_64.tar.gz" | tar xz -C /tmp && \
-mv /tmp/ghz /usr/local/bin && chmod +x /usr/local/bin/ghz && rm -rf /tmp/ghz-web
+RUN GHZ_VERSION=0.39.0 && \
+curl -sSL "https://github.com/bojand/ghz/releases/download/v${GHZ_VERSION}/ghz_${GHZ_VERSION}_Linux_x86_64.tar.gz" | tar xz -C /tmp && \
+mv /tmp/ghz /usr/local/bin && chmod +x /usr/local/bin/ghz
 
+RUN HELM_TILLER_VERSION=0.9.3 && \
+curl -sSL "https://github.com/rimusz/helm-tiller/archive/v${HELM_TILLER_VERSION}.tar.gz" | tar xz -C /tmp && \
+mv /tmp/helm-tiller-${HELM_TILLER_VERSION} /tmp/helm-tiller
+
+RUN WRK_VERSION=4.0.2 && \
+cd /tmp && git clone -b ${WRK_VERSION} https://github.com/wg/wrk
+RUN cd /tmp/wrk && make
+
+FROM bats/bats:v1.1.0
+
+RUN addgroup -S app && \
+adduser -S -g app app && \
+apk --no-cache add ca-certificates curl jq libgcc
+
+WORKDIR /home/app
+
+COPY --from=build /usr/local/bin/hey /usr/local/bin/
+COPY --from=build /tmp/wrk/wrk /usr/local/bin/
+COPY --from=build /usr/local/bin/helm /usr/local/bin/
+COPY --from=build /usr/local/bin/tiller /usr/local/bin/
+COPY --from=build /usr/local/bin/ghz /usr/local/bin/
+COPY --from=build /usr/local/bin/helmv3 /usr/local/bin/
+COPY --from=build /usr/local/bin/grpc_health_probe /usr/local/bin/
+COPY --from=build /tmp/helm-tiller /tmp/helm-tiller
 ADD https://raw.githubusercontent.com/grpc/grpc-proto/master/grpc/health/v1/health.proto /tmp/ghz/health.proto
-
-RUN ls /tmp
 
 COPY ./bin/loadtester .
 
@@ -38,7 +54,11 @@ RUN chown -R app:app ./
 
 USER app
 
-RUN curl -sSL "https://github.com/rimusz/helm-tiller/archive/v0.9.3.tar.gz" | tar xvz && \
-helm init --client-only && helm plugin install helm-tiller-0.9.3 && helm plugin list
+# test load generator tools
+RUN hey -n 1 -c 1 https://flagger.app > /dev/null && echo $? | grep 0
+RUN wrk -d 1s -c 1 -t 1 https://flagger.app > /dev/null && echo $? | grep 0
+
+# install Helm v2 plugins
+RUN helm init --client-only && helm plugin install /tmp/helm-tiller
 
 ENTRYPOINT ["./loadtester"]

--- a/artifacts/loadtester/deployment.yaml
+++ b/artifacts/loadtester/deployment.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
         - name: loadtester
-          image: weaveworks/flagger-loadtester:0.11.0
+          image: weaveworks/flagger-loadtester:0.12.0
           imagePullPolicy: IfNotPresent
           ports:
             - name: http

--- a/charts/appmesh-gateway/Chart.yaml
+++ b/charts/appmesh-gateway/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 name: appmesh-gateway
 description: Flagger Gateway for AWS App Mesh is an edge L7 load balancer that exposes applications outside the mesh.
-version: 1.1.0
-appVersion: 1.0.0
+version: 1.1.1
+appVersion: 1.1.0
 home: https://flagger.app
 icon: https://raw.githubusercontent.com/weaveworks/flagger/master/docs/logo/weaveworks.png
 sources:

--- a/charts/appmesh-gateway/values.yaml
+++ b/charts/appmesh-gateway/values.yaml
@@ -17,7 +17,7 @@ proxy:
 controller:
   image:
     repository: weaveworks/flagger-appmesh-gateway
-    tag: v1.0.0
+    tag: v1.1.0
     pullPolicy: IfNotPresent
 
 nameOverride: ""

--- a/charts/loadtester/Chart.yaml
+++ b/charts/loadtester/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: loadtester
-version: 0.11.0
-appVersion: 0.11.0
+version: 0.12.0
+appVersion: 0.12.0
 kubeVersion: ">=1.11.0-0"
 engine: gotpl
 description: Flagger's load testing services based on rakyll/hey and bojand/ghz that generates traffic during canary analysis when configured as a webhook.

--- a/charts/loadtester/values.yaml
+++ b/charts/loadtester/values.yaml
@@ -2,7 +2,7 @@ replicaCount: 1
 
 image:
   repository: weaveworks/flagger-loadtester
-  tag: 0.11.0
+  tag: 0.12.0
   pullPolicy: IfNotPresent
 
 podAnnotations:

--- a/cmd/loadtester/main.go
+++ b/cmd/loadtester/main.go
@@ -10,7 +10,7 @@ import (
 	"time"
 )
 
-var VERSION = "0.11.0"
+var VERSION = "0.12.0"
 var (
 	logLevel          string
 	port              string

--- a/kustomize/tester/deployment.yaml
+++ b/kustomize/tester/deployment.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
         - name: loadtester
-          image: weaveworks/flagger-loadtester:0.11.0
+          image: weaveworks/flagger-loadtester:0.12.0
           imagePullPolicy: IfNotPresent
           ports:
             - name: http


### PR DESCRIPTION
Release flagger-loadtester v0.12.0 with:
- wrk v4.0.2
- Helm v2.16.1
- Helm v3.0.0-rc.3

Ref: #366 