### PR TITLE
Refactor canary package

### DIFF
--- a/pkg/canary/controller.go
+++ b/pkg/canary/controller.go
@@ -1,0 +1,19 @@
+package canary
+
+import "github.com/weaveworks/flagger/pkg/apis/flagger/v1alpha3"
+
+type Controller interface {
+	IsPrimaryReady(canary *v1alpha3.Canary) (bool, error)
+	IsCanaryReady(canary *v1alpha3.Canary) (bool, error)
+	SyncStatus(canary *v1alpha3.Canary, status v1alpha3.CanaryStatus) error
+	SetStatusFailedChecks(canary *v1alpha3.Canary, val int) error
+	SetStatusWeight(canary *v1alpha3.Canary, val int) error
+	SetStatusIterations(canary *v1alpha3.Canary, val int) error
+	SetStatusPhase(canary *v1alpha3.Canary, phase v1alpha3.CanaryPhase) error
+	Initialize(canary *v1alpha3.Canary, skipLivenessChecks bool) (label string, ports map[string]int32, err error)
+	Promote(canary *v1alpha3.Canary) error
+	HasTargetChanged(canary *v1alpha3.Canary) (bool, error)
+	HaveDependenciesChanged(canary *v1alpha3.Canary) (bool, error)
+	Scale(canary *v1alpha3.Canary, replicas int32) error
+	ScaleFromZero(canary *v1alpha3.Canary) error
+}

--- a/pkg/canary/deployment_test.go
+++ b/pkg/canary/deployment_test.go
@@ -107,7 +107,7 @@ func TestCanaryDeployer_IsNewSpec(t *testing.T) {
 		t.Fatal(err.Error())
 	}
 
-	isNew, err := mocks.deployer.HasDeploymentChanged(mocks.canary)
+	isNew, err := mocks.deployer.HasTargetChanged(mocks.canary)
 	if err != nil {
 		t.Fatal(err.Error())
 	}

--- a/pkg/canary/factory.go
+++ b/pkg/canary/factory.go
@@ -1,0 +1,52 @@
+package canary
+
+import (
+	"go.uber.org/zap"
+	"k8s.io/client-go/kubernetes"
+
+	clientset "github.com/weaveworks/flagger/pkg/client/clientset/versioned"
+)
+
+type Factory struct {
+	kubeClient    kubernetes.Interface
+	flaggerClient clientset.Interface
+	logger        *zap.SugaredLogger
+	configTracker ConfigTracker
+	labels        []string
+}
+
+func NewFactory(kubeClient kubernetes.Interface,
+	flaggerClient clientset.Interface,
+	configTracker ConfigTracker,
+	labels []string,
+	logger *zap.SugaredLogger) *Factory {
+	return &Factory{
+		kubeClient:    kubeClient,
+		flaggerClient: flaggerClient,
+		logger:        logger,
+		configTracker: configTracker,
+		labels:        labels,
+	}
+}
+
+func (factory *Factory) Controller(kind string) Controller {
+	deploymentCtrl := &DeploymentController{
+		logger:        factory.logger,
+		kubeClient:    factory.kubeClient,
+		flaggerClient: factory.flaggerClient,
+		labels:        factory.labels,
+		configTracker: ConfigTracker{
+			Logger:        factory.logger,
+			KubeClient:    factory.kubeClient,
+			FlaggerClient: factory.flaggerClient,
+		},
+	}
+
+	switch {
+	case kind == "Deployment":
+		return deploymentCtrl
+	default:
+		return deploymentCtrl
+	}
+
+}

--- a/pkg/canary/mock.go
+++ b/pkg/canary/mock.go
@@ -20,7 +20,7 @@ type Mocks struct {
 	canary        *flaggerv1.Canary
 	kubeClient    kubernetes.Interface
 	flaggerClient clientset.Interface
-	deployer      Deployer
+	deployer      DeploymentController
 	logger        *zap.SugaredLogger
 }
 
@@ -43,12 +43,12 @@ func SetupMocks() Mocks {
 
 	logger, _ := logger.NewLogger("debug")
 
-	deployer := Deployer{
-		FlaggerClient: flaggerClient,
-		KubeClient:    kubeClient,
-		Logger:        logger,
-		Labels:        []string{"app", "name"},
-		ConfigTracker: ConfigTracker{
+	deployer := DeploymentController{
+		flaggerClient: flaggerClient,
+		kubeClient:    kubeClient,
+		logger:        logger,
+		labels:        []string{"app", "name"},
+		configTracker: ConfigTracker{
 			Logger:        logger,
 			KubeClient:    kubeClient,
 			FlaggerClient: flaggerClient,

--- a/pkg/canary/ready.go
+++ b/pkg/canary/ready.go
@@ -14,9 +14,9 @@ import (
 // IsPrimaryReady checks the primary deployment status and returns an error if
 // the deployment is in the middle of a rolling update or if the pods are unhealthy
 // it will return a non retriable error if the rolling update is stuck
-func (c *Deployer) IsPrimaryReady(cd *flaggerv1.Canary) (bool, error) {
+func (c *DeploymentController) IsPrimaryReady(cd *flaggerv1.Canary) (bool, error) {
 	primaryName := fmt.Sprintf("%s-primary", cd.Spec.TargetRef.Name)
-	primary, err := c.KubeClient.AppsV1().Deployments(cd.Namespace).Get(primaryName, metav1.GetOptions{})
+	primary, err := c.kubeClient.AppsV1().Deployments(cd.Namespace).Get(primaryName, metav1.GetOptions{})
 	if err != nil {
 		if errors.IsNotFound(err) {
 			return true, fmt.Errorf("deployment %s.%s not found", primaryName, cd.Namespace)
@@ -39,9 +39,9 @@ func (c *Deployer) IsPrimaryReady(cd *flaggerv1.Canary) (bool, error) {
 // IsCanaryReady checks the primary deployment status and returns an error if
 // the deployment is in the middle of a rolling update or if the pods are unhealthy
 // it will return a non retriable error if the rolling update is stuck
-func (c *Deployer) IsCanaryReady(cd *flaggerv1.Canary) (bool, error) {
+func (c *DeploymentController) IsCanaryReady(cd *flaggerv1.Canary) (bool, error) {
 	targetName := cd.Spec.TargetRef.Name
-	canary, err := c.KubeClient.AppsV1().Deployments(cd.Namespace).Get(targetName, metav1.GetOptions{})
+	canary, err := c.kubeClient.AppsV1().Deployments(cd.Namespace).Get(targetName, metav1.GetOptions{})
 	if err != nil {
 		if errors.IsNotFound(err) {
 			return true, fmt.Errorf("deployment %s.%s not found", targetName, cd.Namespace)
@@ -64,7 +64,7 @@ func (c *Deployer) IsCanaryReady(cd *flaggerv1.Canary) (bool, error) {
 
 // isDeploymentReady determines if a deployment is ready by checking the status conditions
 // if a deployment has exceeded the progress deadline it returns a non retriable error
-func (c *Deployer) isDeploymentReady(deployment *appsv1.Deployment, deadline int) (bool, error) {
+func (c *DeploymentController) isDeploymentReady(deployment *appsv1.Deployment, deadline int) (bool, error) {
 	retriable := true
 	if deployment.Generation <= deployment.Status.ObservedGeneration {
 		progress := c.getDeploymentCondition(deployment.Status, appsv1.DeploymentProgressing)
@@ -99,7 +99,7 @@ func (c *Deployer) isDeploymentReady(deployment *appsv1.Deployment, deadline int
 	return true, nil
 }
 
-func (c *Deployer) getDeploymentCondition(
+func (c *DeploymentController) getDeploymentCondition(
 	status appsv1.DeploymentStatus,
 	conditionType appsv1.DeploymentConditionType,
 ) *appsv1.DeploymentCondition {

--- a/pkg/canary/tracker.go
+++ b/pkg/canary/tracker.go
@@ -16,7 +16,7 @@ import (
 	clientset "github.com/weaveworks/flagger/pkg/client/clientset/versioned"
 )
 
-// ConfigTracker is managing the operations for Kubernetes ConfigMaps and Secrets
+// configTracker is managing the operations for Kubernetes ConfigMaps and Secrets
 type ConfigTracker struct {
 	KubeClient    kubernetes.Interface
 	FlaggerClient clientset.Interface


### PR DESCRIPTION
This PR introduces a canary controller interface that can be used to implement other target kinds than Kubernetes Deployment:
- add canary factory for Kubernetes targets
- extract Kubernetes operations to controller interface
- implement controller interface for kind Deployment

Fix: #377 