### PR TITLE
Update nginx-ingress to 1.26.0

### DIFF
--- a/test/e2e-nginx.sh
+++ b/test/e2e-nginx.sh
@@ -4,7 +4,7 @@ set -o errexit
 
 REPO_ROOT=$(git rev-parse --show-toplevel)
 export KUBECONFIG="$(kind get kubeconfig-path --name="kind")"
-NGINX_VERSION=1.24.4
+NGINX_VERSION=1.26.0
 
 echo '>>> Installing NGINX Ingress'
 helm upgrade -i nginx-ingress stable/nginx-ingress --version=${NGINX_VERSION} \


### PR DESCRIPTION
Update nginx-ingress helm chart to v1.26.0 for end-to-end testing.