### PR TITLE
Add initialization phase to Kubernetes router

### DIFF
--- a/pkg/canary/controller.go
+++ b/pkg/canary/controller.go
@@ -1,21 +1,22 @@
 package canary
 
 import (
-	"github.com/weaveworks/flagger/pkg/apis/flagger/v1alpha3"
+	flaggerv1 "github.com/weaveworks/flagger/pkg/apis/flagger/v1alpha3"
 )
 
 type Controller interface {
-	IsPrimaryReady(canary *v1alpha3.Canary) (bool, error)
-	IsCanaryReady(canary *v1alpha3.Canary) (bool, error)
-	SyncStatus(canary *v1alpha3.Canary, status v1alpha3.CanaryStatus) error
-	SetStatusFailedChecks(canary *v1alpha3.Canary, val int) error
-	SetStatusWeight(canary *v1alpha3.Canary, val int) error
-	SetStatusIterations(canary *v1alpha3.Canary, val int) error
-	SetStatusPhase(canary *v1alpha3.Canary, phase v1alpha3.CanaryPhase) error
-	Initialize(canary *v1alpha3.Canary, skipLivenessChecks bool) (label string, ports map[string]int32, err error)
-	Promote(canary *v1alpha3.Canary) error
-	HasTargetChanged(canary *v1alpha3.Canary) (bool, error)
-	HaveDependenciesChanged(canary *v1alpha3.Canary) (bool, error)
-	Scale(canary *v1alpha3.Canary, replicas int32) error
-	ScaleFromZero(canary *v1alpha3.Canary) error
+	IsPrimaryReady(canary *flaggerv1.Canary) (bool, error)
+	IsCanaryReady(canary *flaggerv1.Canary) (bool, error)
+	GetMetadata(canary *flaggerv1.Canary) (string, map[string]int32, error)
+	SyncStatus(canary *flaggerv1.Canary, status flaggerv1.CanaryStatus) error
+	SetStatusFailedChecks(canary *flaggerv1.Canary, val int) error
+	SetStatusWeight(canary *flaggerv1.Canary, val int) error
+	SetStatusIterations(canary *flaggerv1.Canary, val int) error
+	SetStatusPhase(canary *flaggerv1.Canary, phase flaggerv1.CanaryPhase) error
+	Initialize(canary *flaggerv1.Canary, skipLivenessChecks bool) error
+	Promote(canary *flaggerv1.Canary) error
+	HasTargetChanged(canary *flaggerv1.Canary) (bool, error)
+	HaveDependenciesChanged(canary *flaggerv1.Canary) (bool, error)
+	Scale(canary *flaggerv1.Canary, replicas int32) error
+	ScaleFromZero(canary *flaggerv1.Canary) error
 }

--- a/pkg/canary/deployment_controller_test.go
+++ b/pkg/canary/deployment_controller_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestCanaryDeployer_Sync(t *testing.T) {
 	mocks := SetupMocks()
-	_, _, err := mocks.deployer.Initialize(mocks.canary, true)
+	err := mocks.deployer.Initialize(mocks.canary, true)
 	if err != nil {
 		t.Fatal(err.Error())
 	}
@@ -96,7 +96,7 @@ func TestCanaryDeployer_Sync(t *testing.T) {
 
 func TestCanaryDeployer_IsNewSpec(t *testing.T) {
 	mocks := SetupMocks()
-	_, _, err := mocks.deployer.Initialize(mocks.canary, true)
+	err := mocks.deployer.Initialize(mocks.canary, true)
 	if err != nil {
 		t.Fatal(err.Error())
 	}
@@ -119,7 +119,7 @@ func TestCanaryDeployer_IsNewSpec(t *testing.T) {
 
 func TestCanaryDeployer_Promote(t *testing.T) {
 	mocks := SetupMocks()
-	_, _, err := mocks.deployer.Initialize(mocks.canary, true)
+	err := mocks.deployer.Initialize(mocks.canary, true)
 	if err != nil {
 		t.Fatal(err.Error())
 	}
@@ -185,7 +185,7 @@ func TestCanaryDeployer_Promote(t *testing.T) {
 
 func TestCanaryDeployer_IsReady(t *testing.T) {
 	mocks := SetupMocks()
-	_, _, err := mocks.deployer.Initialize(mocks.canary, true)
+	err := mocks.deployer.Initialize(mocks.canary, true)
 	if err != nil {
 		t.Error("Expected primary readiness check to fail")
 	}
@@ -203,7 +203,7 @@ func TestCanaryDeployer_IsReady(t *testing.T) {
 
 func TestCanaryDeployer_SetFailedChecks(t *testing.T) {
 	mocks := SetupMocks()
-	_, _, err := mocks.deployer.Initialize(mocks.canary, true)
+	err := mocks.deployer.Initialize(mocks.canary, true)
 	if err != nil {
 		t.Fatal(err.Error())
 	}
@@ -225,7 +225,7 @@ func TestCanaryDeployer_SetFailedChecks(t *testing.T) {
 
 func TestCanaryDeployer_SetState(t *testing.T) {
 	mocks := SetupMocks()
-	_, _, err := mocks.deployer.Initialize(mocks.canary, true)
+	err := mocks.deployer.Initialize(mocks.canary, true)
 	if err != nil {
 		t.Fatal(err.Error())
 	}
@@ -247,7 +247,7 @@ func TestCanaryDeployer_SetState(t *testing.T) {
 
 func TestCanaryDeployer_SyncStatus(t *testing.T) {
 	mocks := SetupMocks()
-	_, _, err := mocks.deployer.Initialize(mocks.canary, true)
+	err := mocks.deployer.Initialize(mocks.canary, true)
 	if err != nil {
 		t.Fatal(err.Error())
 	}
@@ -286,7 +286,7 @@ func TestCanaryDeployer_SyncStatus(t *testing.T) {
 
 func TestCanaryDeployer_Scale(t *testing.T) {
 	mocks := SetupMocks()
-	_, _, err := mocks.deployer.Initialize(mocks.canary, true)
+	err := mocks.deployer.Initialize(mocks.canary, true)
 	if err != nil {
 		t.Fatal(err.Error())
 	}

--- a/pkg/canary/service_controller.go
+++ b/pkg/canary/service_controller.go
@@ -42,32 +42,35 @@ func (c *ServiceController) SetStatusPhase(cd *flaggerv1.Canary, phase flaggerv1
 	return setStatusPhase(c.flaggerClient, cd, phase)
 }
 
-var _ Controller = &ServiceController{}
+// GetMetadata returns the pod label selector and svc ports
+func (c *ServiceController) GetMetadata(cd *flaggerv1.Canary) (string, map[string]int32, error) {
+	return "", nil, nil
+}
 
 // Initialize creates or updates the primary and canary services to prepare for the canary release process targeted on the K8s service
-func (c *ServiceController) Initialize(cd *flaggerv1.Canary, skipLivenessChecks bool) (label string, ports map[string]int32, err error) {
+func (c *ServiceController) Initialize(cd *flaggerv1.Canary, skipLivenessChecks bool) (err error) {
 	targetName := cd.Spec.TargetRef.Name
 	primaryName := fmt.Sprintf("%s-primary", targetName)
 	canaryName := fmt.Sprintf("%s-canary", targetName)
 
 	svc, err := c.kubeClient.CoreV1().Services(cd.Namespace).Get(targetName, metav1.GetOptions{})
 	if err != nil {
-		return "", nil, err
+		return err
 	}
 
 	// canary svc
 	err = c.reconcileCanaryService(cd, canaryName, svc)
 	if err != nil {
-		return "", nil, err
+		return err
 	}
 
 	// primary svc
 	err = c.reconcilePrimaryService(cd, primaryName, svc)
 	if err != nil {
-		return "", nil, err
+		return err
 	}
 
-	return "", nil, nil
+	return nil
 }
 
 func (c *ServiceController) reconcileCanaryService(canary *flaggerv1.Canary, name string, src *corev1.Service) error {

--- a/pkg/router/kubernetes.go
+++ b/pkg/router/kubernetes.go
@@ -2,34 +2,12 @@ package router
 
 import (
 	flaggerv1 "github.com/weaveworks/flagger/pkg/apis/flagger/v1alpha3"
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
-// KubernetesDeploymentRouter is managing ClusterIP services
+// KubernetesRouter manages Kubernetes services
 type KubernetesRouter interface {
-	// Reconcile creates or updates K8s services to prepare for the canary release
+	// Initialize creates or updates the primary and canary services
+	Initialize(canary *flaggerv1.Canary) error
+	// Reconcile creates or updates the main service
 	Reconcile(canary *flaggerv1.Canary) error
-}
-
-func buildService(canary *flaggerv1.Canary, name string, src *corev1.Service) *corev1.Service {
-	svc := src.DeepCopy()
-	svc.ObjectMeta.Name = name
-	svc.ObjectMeta.Namespace = canary.Namespace
-	svc.ObjectMeta.OwnerReferences = []metav1.OwnerReference{
-		*metav1.NewControllerRef(canary, schema.GroupVersionKind{
-			Group:   flaggerv1.SchemeGroupVersion.Group,
-			Version: flaggerv1.SchemeGroupVersion.Version,
-			Kind:    flaggerv1.CanaryKind,
-		}),
-	}
-	_, exists := svc.ObjectMeta.Annotations["kubectl.kubernetes.io/last-applied-configuration"]
-	if exists {
-		// Leaving this results in updates from flagger to this svc never succeed due to resourceVersion mismatch:
-		//   Operation cannot be fulfilled on services "mysvc-canary": the object has been modified; please apply your changes to the latest version and try again
-		delete(svc.ObjectMeta.Annotations, "kubectl.kubernetes.io/last-applied-configuration")
-	}
-
-	return svc
 }

--- a/pkg/router/kubernetes_deployment_test.go
+++ b/pkg/router/kubernetes_deployment_test.go
@@ -14,7 +14,12 @@ func TestServiceRouter_Create(t *testing.T) {
 		logger:        mocks.logger,
 	}
 
-	err := router.Reconcile(mocks.canary)
+	err := router.Initialize(mocks.canary)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+
+	err = router.Reconcile(mocks.canary)
 	if err != nil {
 		t.Fatal(err.Error())
 	}
@@ -54,7 +59,12 @@ func TestServiceRouter_Update(t *testing.T) {
 		logger:        mocks.logger,
 	}
 
-	err := router.Reconcile(mocks.canary)
+	err := router.Initialize(mocks.canary)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+
+	err = router.Reconcile(mocks.canary)
 	if err != nil {
 		t.Fatal(err.Error())
 	}
@@ -73,6 +83,10 @@ func TestServiceRouter_Update(t *testing.T) {
 	}
 
 	// apply changes
+	err = router.Initialize(c)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
 	err = router.Reconcile(c)
 	if err != nil {
 		t.Fatal(err.Error())
@@ -96,7 +110,12 @@ func TestServiceRouter_Undo(t *testing.T) {
 		logger:        mocks.logger,
 	}
 
-	err := router.Reconcile(mocks.canary)
+	err := router.Initialize(mocks.canary)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+
+	err = router.Reconcile(mocks.canary)
 	if err != nil {
 		t.Fatal(err.Error())
 	}
@@ -116,6 +135,10 @@ func TestServiceRouter_Undo(t *testing.T) {
 	}
 
 	// undo changes
+	err = router.Initialize(mocks.canary)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
 	err = router.Reconcile(mocks.canary)
 	if err != nil {
 		t.Fatal(err.Error())

--- a/pkg/router/kubernetes_noop.go
+++ b/pkg/router/kubernetes_noop.go
@@ -9,6 +9,10 @@ import (
 type KubernetesNoopRouter struct {
 }
 
+func (c *KubernetesNoopRouter) Initialize(canary *flaggerv1.Canary) error {
+	return nil
+}
+
 func (c *KubernetesNoopRouter) Reconcile(canary *flaggerv1.Canary) error {
 	return nil
 }


### PR DESCRIPTION
This PR makes Flagger take over a running deployment without disruption:
- create Kubernetes services before deployments
- ensure Envoy's readiness by creating the canary and primary ClusterIP services
- take over main service after primary becomes availability
- create mesh routes after primary becomes availability

Fix: #374
Fix: #308