### PR TITLE
Release 0.20.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to this project are documented in this file.
 
+## 0.20.4 (2019-12-03) 
+
+Adds support for taking over a running deployment without disruption
+
+#### Improvements 
+
+- Add initialization phase to Kubernetes router [#384](https://github.com/weaveworks/flagger/pull/384)
+- Add canary controller interface and Kubernetes deployment kind implementation [#378](https://github.com/weaveworks/flagger/pull/378)
+
+#### Fixes
+
+- Skip primary check on skip analysis [#380](https://github.com/weaveworks/flagger/pull/380)
+
 ## 0.20.3 (2019-11-13) 
 
 Adds wrk to load tester tools and the App Mesh gateway chart to Flagger Helm repository

--- a/artifacts/flagger/deployment.yaml
+++ b/artifacts/flagger/deployment.yaml
@@ -22,7 +22,7 @@ spec:
       serviceAccountName: flagger
       containers:
       - name: flagger
-        image: weaveworks/flagger:0.20.3
+        image: weaveworks/flagger:0.20.4
         imagePullPolicy: IfNotPresent
         ports:
         - name: http

--- a/charts/flagger/Chart.yaml
+++ b/charts/flagger/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: flagger
-version: 0.20.3
-appVersion: 0.20.3
+version: 0.20.4
+appVersion: 0.20.4
 kubeVersion: ">=1.11.0-0"
 engine: gotpl
 description: Flagger is a progressive delivery operator for Kubernetes

--- a/charts/flagger/values.yaml
+++ b/charts/flagger/values.yaml
@@ -2,7 +2,7 @@
 
 image:
   repository: weaveworks/flagger
-  tag: 0.20.3
+  tag: 0.20.4
   pullPolicy: IfNotPresent
   pullSecret:
 

--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: grafana
-version: 1.3.0
-appVersion: 6.2.5
+version: 1.4.0
+appVersion: 6.5.1
 description: Grafana dashboards for monitoring Flagger canary deployments
 icon: https://raw.githubusercontent.com/weaveworks/flagger/master/docs/logo/weaveworks.png
 home: https://flagger.app

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: grafana/grafana
-  tag: 6.2.5
+  tag: 6.5.1
   pullPolicy: IfNotPresent
 
 podAnnotations: {}

--- a/kustomize/base/flagger/kustomization.yaml
+++ b/kustomize/base/flagger/kustomization.yaml
@@ -8,4 +8,4 @@ resources:
   - deployment.yaml
 images:
   - name: weaveworks/flagger
-    newTag: 0.20.3
+    newTag: 0.20.4

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,4 +1,4 @@
 package version
 
-var VERSION = "0.20.3"
+var VERSION = "0.20.4"
 var REVISION = "unknown"


### PR DESCRIPTION
Version 0.20.4 adds support for taking over a running deployment without disruption.

#### Improvements 

- Add initialization phase to Kubernetes router [#384](https://github.com/weaveworks/flagger/pull/384)
- Add canary controller interface and Kubernetes deployment kind implementation [#378](https://github.com/weaveworks/flagger/pull/378)

#### Fixes

- Skip primary check on skip analysis [#380](https://github.com/weaveworks/flagger/pull/380)
