### PR TITLE
Add PodMonitor template to flagger chart

### DIFF
--- a/charts/flagger/README.md
+++ b/charts/flagger/README.md
@@ -84,6 +84,10 @@ Parameter | Description | Default
 `slack.channel` | Slack channel | None
 `slack.user` | Slack username | `flagger`
 `msteams.url` | Microsoft Teams incoming webhook | None
+`podMonitor.enabled` | if `true`, create a PodMonitor for [monitoring the metrics](https://docs.flagger.app/usage/monitoring#metrics) | `false`
+`podMonitor.namespace` | the namespace where the PodMonitor is created | the same namespace 
+`podMonitor.interval` | interval at which metrics should be scraped | `15s` 
+`podMonitor.podMonitor` | additional labels to add to the PodMonitor | `{}`
 `leaderElection.enabled` | leader election must be enabled when running more than one replica | `false`
 `leaderElection.replicaCount` | number of replicas | `1`
 `ingressAnnotationsPrefix` | annotations prefix for ingresses | `custom.ingress.kubernetes.io`

--- a/charts/flagger/templates/podmonitor.yaml
+++ b/charts/flagger/templates/podmonitor.yaml
@@ -1,0 +1,27 @@
+{{- if .Values.podMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  labels:
+    helm.sh/chart: {{ template "flagger.chart" . }}
+    app.kubernetes.io/name: {{ template "flagger.name" . }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    {{- range $k, $v := .Values.podMonitor.additionalLabels }}
+    {{ $k }}: {{ $v | quote }}
+    {{- end }}
+  name: {{ include "flagger.fullname" . }}
+  namespace: {{ .Values.podMonitor.namespace | default .Release.Namespace }}
+spec:
+  podMetricsEndpoints:
+  - interval: {{ .Values.podMonitor.interval }}
+    path: /metrics
+    port: http
+  namespaceSelector:
+    matchNames:
+    - {{ .Release.Namespace }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ template "flagger.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/charts/flagger/values.yaml
+++ b/charts/flagger/values.yaml
@@ -33,6 +33,12 @@ msteams:
   # MS Teams incoming webhook URL
   url:
 
+podMonitor:
+  enabled: false
+  namespace:
+  interval: 15s
+  additionalLabels: {}
+
 #env:
 #- name: SLACK_URL
 #  valueFrom:


### PR DESCRIPTION
This will add a PodMonitor template to the flagger chart. 