### PR TITLE
Implement event dispatching webhook

### DIFF
--- a/artifacts/flagger/crd.yaml
+++ b/artifacts/flagger/crd.yaml
@@ -245,6 +245,7 @@ spec:
                             - rollout
                             - confirm-promotion
                             - post-rollout
+                            - event
                         url:
                           description: URL address of this webhook
                           type: string

--- a/charts/flagger/templates/crd.yaml
+++ b/charts/flagger/templates/crd.yaml
@@ -246,6 +246,7 @@ spec:
                             - rollout
                             - confirm-promotion
                             - post-rollout
+                            - event
                         url:
                           description: URL address of this webhook
                           type: string

--- a/docs/gitbook/usage/alerting.md
+++ b/docs/gitbook/usage/alerting.md
@@ -92,3 +92,13 @@ Example:
   }
 }
 ```
+
+The event webhook can be overwritten at canary level with:
+
+```yaml
+  canaryAnalysis:
+    webhooks:
+      - name: "send to Slack"
+        type: event
+        url: http://event-recevier.notifications/slack
+```

--- a/kustomize/base/flagger/crd.yaml
+++ b/kustomize/base/flagger/crd.yaml
@@ -245,6 +245,7 @@ spec:
                             - rollout
                             - confirm-promotion
                             - post-rollout
+                            - event
                         url:
                           description: URL address of this webhook
                           type: string

--- a/pkg/apis/flagger/v1alpha3/types.go
+++ b/pkg/apis/flagger/v1alpha3/types.go
@@ -149,6 +149,8 @@ const (
 	ConfirmRolloutHook HookType = "confirm-rollout"
 	// ConfirmPromotionHook halt canary promotion until webhook returns HTTP 200
 	ConfirmPromotionHook HookType = "confirm-promotion"
+	// EventHook dispatches Flagger events to the specified endpoint
+	EventHook HookType = "event"
 )
 
 // CanaryWebhook holds the reference to external checks used for canary analysis


### PR DESCRIPTION
This PR adds a a new webhook type named `event`. When an event webhook is present in the canary spec, Flagger will dispatch all events to that URL or URLs. This allows Flagger users to implement a webhook receiver that posts events to Slack, MS Teams or any other platform.

The event receiver should expose a URL that accepts HTTP POST with the following JSON body:

```json
{
  "name": "string (canary name)",
  "namespace": "string (canary namespace)",
  "phase": "string (canary phase)",
  "metadata": {
    "eventMessage": "string (canary event message)",
    "eventType": "string (canary event type)",
    "timestamp": "string (unix timestamp ms)"
  }
}
```

The receiver can create alerts based on the received phase (possible values: ` Initialized`, `Waiting`, `Progressing`, `Promoting`, `Finalising`, `Succeeded` or `Failed`).

Fix: #393
Fix: #242
Fix: #128
