### PR TITLE
Set destination port for Istio ingress gateways

### DIFF
--- a/pkg/router/istio.go
+++ b/pkg/router/istio.go
@@ -395,5 +395,20 @@ func makeDestination(canary *flaggerv1.Canary, host string, weight int) istiov1a
 		Weight: weight,
 	}
 
+	// set destination port when an ingress gateway is specified
+	if canary.Spec.Service.PortDiscovery &&
+		len(canary.Spec.Service.Gateways) > 0 &&
+		canary.Spec.Service.Gateways[0] != "mesh" {
+		dest = istiov1alpha3.DestinationWeight{
+			Destination: istiov1alpha3.Destination{
+				Host: host,
+				Port: &istiov1alpha3.PortSelector{
+					Number: uint32(canary.Spec.Service.Port),
+				},
+			},
+			Weight: weight,
+		}
+	}
+
 	return dest
 }

--- a/pkg/router/router_test.go
+++ b/pkg/router/router_test.go
@@ -113,7 +113,8 @@ func newMockCanary() *flaggerv1.Canary {
 				Kind:       "Deployment",
 			},
 			Service: flaggerv1.CanaryService{
-				Port: 9898,
+				Port:          9898,
+				PortDiscovery: true,
 				Headers: &istiov1alpha3.Headers{
 					Request: &istiov1alpha3.HeaderOperations{
 						Add: map[string]string{
@@ -135,6 +136,10 @@ func newMockCanary() *flaggerv1.Canary {
 				Retries: &istiov1alpha3.HTTPRetry{
 					Attempts:      10,
 					PerTryTimeout: "30s",
+				},
+				Gateways: []string{
+					"public-gateway.istio",
+					"mesh",
 				},
 			}, CanaryAnalysis: flaggerv1.CanaryAnalysis{
 				Threshold:  10,


### PR DESCRIPTION
This PR makes it possible to have multiple ports exposed inside the mesh when using an Istio ingress gateway. The `service.port` is mapped in the virtual service so that the Gateway traffic would reach the destination on that port. When using the `mesh` gateway, all ports are subject to traffic shifting, when using an ingress gateway only the `service.port` will be used.

Fix: #434 