### PR TITLE
Add docs for Istio multi-cluster setup

### DIFF
--- a/charts/flagger/README.md
+++ b/charts/flagger/README.md
@@ -103,6 +103,8 @@ Parameter | Description | Default
 `affinity` | Node/pod affinities | None
 `nodeSelector` | Node labels for pod assignment | `{}`
 `tolerations` | List of node taints to tolerate | `[]`
+`istio.kubeconfig.secretName` | The name of the Kubernetes secret containing the Istio shared control plane kubeconfig | None
+`istio.kubeconfig.key` | The name of Kubernetes secret data key that contains the Istio control plane kubeconfig | `kubeconfig`
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade`. For example,
 

--- a/charts/flagger/templates/deployment.yaml
+++ b/charts/flagger/templates/deployment.yaml
@@ -43,10 +43,10 @@ spec:
         - name: {{ .Values.image.pullSecret }}
       {{- end }}
       volumes:
-        {{- if .Values.kubeconfigHost }}
+        {{- if .Values.istio.kubeconfig.secretName }}
         - name: kubeconfig
           secret:
-            secretName: "{{ .Values.kubeconfigHost }}"
+            secretName: "{{ .Values.istio.kubeconfig.secretName }}"
         {{- end }}
       containers:
         - name: flagger
@@ -54,7 +54,7 @@ spec:
             readOnlyRootFilesystem: true
             runAsUser: 10001
           volumeMounts:
-            {{- if .Values.kubeconfigHost }}
+            {{- if .Values.istio.kubeconfig.secretName }}
             - name: kubeconfig
               mountPath: "/tmp/istio-host"
             {{- end }}
@@ -101,8 +101,8 @@ spec:
           {{- if .Values.eventWebhook }}
           - -event-webhook={{ .Values.eventWebhook }}
           {{- end }}
-          {{- if .Values.kubeconfigHost }}
-          - -kubeconfig-host=/tmp/istio-host/kubeconfig
+          {{- if .Values.istio.kubeconfig.secretName }}
+          - -kubeconfig-service-mesh=/tmp/istio-host/{{ .Values.istio.kubeconfig.key }}
           {{- end }}
           livenessProbe:
             exec:

--- a/charts/flagger/values.yaml
+++ b/charts/flagger/values.yaml
@@ -103,4 +103,11 @@ prometheus:
   # to be used with ingress controllers
   install: false
 
-kubeconfigHost: ""
+#  Istio multi-cluster service mesh (shared control plane single-network)
+# https://istio.io/docs/setup/install/multicluster/shared-vpn/
+istio:
+  kubeconfig:
+    # istio.kubeconfig.secretName: The name of the secret containing the Istio control plane kubeconfig
+    secretName: ""
+    # istio.kubeconfig.key: The name of secret data key that contains the Istio control plane kubeconfig
+    key: "kubeconfig"

--- a/cmd/flagger/main.go
+++ b/cmd/flagger/main.go
@@ -58,7 +58,7 @@ var (
 	leaderElectionNamespace  string
 	enableConfigTracking     bool
 	ver                      bool
-	kubeconfigHost           string
+	kubeconfigServiceMesh    string
 )
 
 func init() {
@@ -84,7 +84,7 @@ func init() {
 	flag.StringVar(&leaderElectionNamespace, "leader-election-namespace", "kube-system", "Namespace used to create the leader election config map.")
 	flag.BoolVar(&enableConfigTracking, "enable-config-tracking", true, "Enable secrets and configmaps tracking.")
 	flag.BoolVar(&ver, "version", false, "Print version")
-	flag.StringVar(&kubeconfigHost, "kubeconfig-host", "", "Path to a kubeconfig for host cluster. Only required if cluster has a host cluster.")
+	flag.StringVar(&kubeconfigServiceMesh, "kubeconfig-service-mesh", "", "Path to a kubeconfig for the service mesh control plane cluster.")
 }
 
 func main() {
@@ -124,8 +124,8 @@ func main() {
 		logger.Fatalf("Error building flagger clientset: %s", err.Error())
 	}
 
-	//if host kube config is there than this should be spawned with host kubeconfig
-	cfgHost, err := clientcmd.BuildConfigFromFlags(masterURL, kubeconfigHost)
+	// use a remote cluster for routing if a service mesh kubeconfig is specified
+	cfgHost, err := clientcmd.BuildConfigFromFlags(masterURL, kubeconfigServiceMesh)
 	if err != nil {
 		logger.Fatalf("Error building host kubeconfig: %v", err)
 	}

--- a/docs/gitbook/install/flagger-install-on-kubernetes.md
+++ b/docs/gitbook/install/flagger-install-on-kubernetes.md
@@ -43,8 +43,9 @@ helm upgrade -i flagger flagger/flagger \
 --set istio.kubeconfig.key=kubeconfig
 ```
 
-Note that the Istio control plane kubeconfig must be stored in a Kubernetes secret with a data key named `kubeconfig`.
-For more details on how to configure the kubeconfig read the [Istio docs](https://istio.io/docs/setup/install/multicluster/shared-vpn/#credentials).
+Note that the Istio kubeconfig must be stored in a Kubernetes secret with a data key named `kubeconfig`.
+For more details on how to configure Istio multi-cluster credentials read the
+[Istio docs](https://istio.io/docs/setup/install/multicluster/shared-vpn/#credentials).
 
 Deploy Flagger for Linkerd:
 
@@ -67,6 +68,11 @@ helm upgrade -i flagger flagger/flagger \
 ```
 
 You can install Flagger in any namespace as long as it can talk to the Prometheus service on port 9090.
+
+For ingress controllers, the install instructions are:
+* [Contour](https://docs.flagger.app/tutorials/contour-progressive-delivery)
+* [Gloo](https://docs.flagger.app/tutorials/gloo-progressive-delivery)
+* [NGINX](https://docs.flagger.app/tutorials/nginx-progressive-delivery)
 
 Enable **Slack** notifications:
 
@@ -266,4 +272,5 @@ Install Flagger with Slack:
 kubectl apply -k .
 ```
 
-If you want to use MS Teams instead of Slack, replace `-slack-url` with `-msteams-url` and set the webhook address to `https://outlook.office.com/webhook/YOUR/TEAMS/WEBHOOK`.
+If you want to use MS Teams instead of Slack, replace `-slack-url` with `-msteams-url` and
+set the webhook address to `https://outlook.office.com/webhook/YOUR/TEAMS/WEBHOOK`.

--- a/docs/gitbook/install/flagger-install-on-kubernetes.md
+++ b/docs/gitbook/install/flagger-install-on-kubernetes.md
@@ -30,6 +30,22 @@ helm upgrade -i flagger flagger/flagger \
 --set metricsServer=http://prometheus:9090
 ```
 
+For Istio multi-cluster shared control plane you can install Flagger on each remote cluster and set the
+Istio control plane host cluster kubeconfig:
+
+```bash
+helm upgrade -i flagger flagger/flagger \
+--namespace=istio-system \
+--set crd.create=false \
+--set meshProvider=istio \
+--set metricsServer=http://istio-cluster-prometheus:9090 \
+--set istio.kubeconfig.secretName=istio-kubeconfig \
+--set istio.kubeconfig.key=kubeconfig
+```
+
+Note that the Istio control plane kubeconfig must be stored in a Kubernetes secret with a data key named `kubeconfig`.
+For more details on how to configure the kubeconfig read the [Istio docs](https://istio.io/docs/setup/install/multicluster/shared-vpn/#credentials).
+
 Deploy Flagger for Linkerd:
 
 ```bash


### PR DESCRIPTION
Followup of #447 ref #437 

Changes:
- rename command flag to `kubeconfig-service-mesh`
- add `istio.kubeconfig` options to Helm chart and readme
- add Istio multi-cluster setup to install docs