### PR TITLE
Contour 1.2

### DIFF
--- a/docs/gitbook/tutorials/contour-progressive-delivery.md
+++ b/docs/gitbook/tutorials/contour-progressive-delivery.md
@@ -385,7 +385,7 @@ podinfod=stefanprodan/podinfo:3.1.3
 Flagger detects that the deployment revision changed and starts the A/B test:
 
 ```text
-kubectl -n appmesh-system logs deploy/flagger -f | jq .msg
+kubectl -n projectcontour logs deploy/flagger -f | jq .msg
 
 New revision detected! Starting canary analysis for podinfo.test
 Advance podinfo.test canary iteration 1/10

--- a/pkg/router/contour.go
+++ b/pkg/router/contour.go
@@ -423,7 +423,7 @@ func (cr *ContourRouter) makeRetryPolicy(canary *flaggerv1.Canary) *contourv1.Re
 func (cr *ContourRouter) makeLinkerdHeaderValue(canary *flaggerv1.Canary, serviceName string) contourv1.HeaderValue {
 	return contourv1.HeaderValue{
 		Name:  "l5d-dst-override",
-		Value: fmt.Sprintf("%s.%.s.svc.cluster.local:%v", serviceName, canary.Namespace, canary.Spec.Service.Port),
+		Value: fmt.Sprintf("%s.%s.svc.cluster.local:%v", serviceName, canary.Namespace, canary.Spec.Service.Port),
 	}
 
 }

--- a/test/e2e-contour.sh
+++ b/test/e2e-contour.sh
@@ -4,7 +4,7 @@ set -o errexit
 
 REPO_ROOT=$(git rev-parse --show-toplevel)
 
-CONTOUR_VER="release-1.1"
+CONTOUR_VER="release-1.2"
 
 echo '>>> Installing Contour'
 kubectl apply -f https://raw.githubusercontent.com/projectcontour/contour/${CONTOUR_VER}/examples/render/contour.yaml


### PR DESCRIPTION
- use Contour release 1.2 in end-to-end testing
- fix Contour header override for Linkerd
- fix logs command in Contour docs