### PR TITLE
ci: push container for master only

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -253,6 +253,10 @@ workflows:
             - e2e-gloo-testing
             - e2e-nginx-testing
             - e2e-linkerd-testing
+          filters:
+            branches:
+              only:
+                - master
 
   release:
     jobs:


### PR DESCRIPTION
Push Flagger container image to Docker Hub only for master builds.