### PR TITLE
Rename spec.canaryAnalysis to spec.analysis

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,8 +14,8 @@ jobs:
           name: Run go mod download
           command: go mod download
       - run:
-          name: Run go fmt
-          command: make test-fmt
+          name: Check code formatting
+          command: go install golang.org/x/tools/cmd/goimports && make test-fmt
       - run:
           name: Build Flagger
           command: |

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,6 @@ TAG?=latest
 VERSION?=$(shell grep 'VERSION' pkg/version/version.go | awk '{ print $$4 }' | tr -d '"')
 VERSION_MINOR:=$(shell grep 'VERSION' pkg/version/version.go | awk '{ print $$4 }' | tr -d '"' | rev | cut -d'.' -f2- | rev)
 PATCH:=$(shell grep 'VERSION' pkg/version/version.go | awk '{ print $$4 }' | tr -d '"' | awk -F. '{print $$NF}')
-SOURCE_DIRS = cmd pkg/apis pkg/controller pkg/server pkg/canary pkg/metrics pkg/router pkg/notifier
 LT_VERSION?=$(shell grep 'VERSION' cmd/loadtester/main.go | awk '{ print $$4 }' | tr -d '"' | head -n1)
 TS=$(shell date +%Y-%m-%d_%H-%M-%S)
 
@@ -43,10 +42,12 @@ push:
 	docker push weaveworks/flagger:$(VERSION)
 
 fmt:
-	gofmt -l -s -w $(SOURCE_DIRS)
+	gofmt -l -s -w ./
+	goimports -l -w ./
 
 test-fmt:
-	gofmt -l -s $(SOURCE_DIRS) | grep ".*\.go"; if [ "$$?" = "0" ]; then exit 1; fi
+	gofmt -l -s ./ | grep ".*\.go"; if [ "$$?" = "0" ]; then exit 1; fi
+	goimports -l ./ | grep ".*\.go"; if [ "$$?" = "0" ]; then exit 1; fi
 
 test-codegen:
 	./hack/verify-codegen.sh

--- a/artifacts/flagger/crd.yaml
+++ b/artifacts/flagger/crd.yaml
@@ -42,19 +42,19 @@ spec:
       priority: 1
     - name: Interval
       type: string
-      JSONPath: .spec.canaryAnalysis.interval
+      JSONPath: .spec.analysis.interval
       priority: 1
     - name: Mirror
       type: boolean
-      JSONPath: .spec.canaryAnalysis.mirror
+      JSONPath: .spec.analysis.mirror
       priority: 1
     - name: StepWeight
       type: string
-      JSONPath: .spec.canaryAnalysis.stepWeight
+      JSONPath: .spec.analysis.stepWeight
       priority: 1
     - name: MaxWeight
       type: string
-      JSONPath: .spec.canaryAnalysis.maxWeight
+      JSONPath: .spec.analysis.maxWeight
       priority: 1
     - name: LastTransitionTime
       type: string
@@ -66,7 +66,7 @@ spec:
           required:
             - targetRef
             - service
-            - canaryAnalysis
+            - analysis
           properties:
             provider:
               description: Traffic managent provider
@@ -502,9 +502,12 @@ spec:
             skipAnalysis:
               description: Skip analysis and promote canary
               type: boolean
-            canaryAnalysis:
+            analysis:
               description: Canary analysis for this canary
               type: object
+              oneOf:
+                - required: ["interval", "threshold", "iterations"]
+                - required: ["interval", "threshold", "stepWeight"]
               properties:
                 interval:
                   description: Schedule interval for this canary
@@ -523,7 +526,7 @@ spec:
                   description: Incremental traffic percentage step
                   type: number
                 mirror:
-                  description: Mirror traffic to canary before shifting
+                  description: Mirror traffic to canary
                   type: boolean
                 match:
                   description: A/B testing match conditions

--- a/charts/flagger/crds/crd.yaml
+++ b/charts/flagger/crds/crd.yaml
@@ -42,19 +42,19 @@ spec:
       priority: 1
     - name: Interval
       type: string
-      JSONPath: .spec.canaryAnalysis.interval
+      JSONPath: .spec.analysis.interval
       priority: 1
     - name: Mirror
       type: boolean
-      JSONPath: .spec.canaryAnalysis.mirror
+      JSONPath: .spec.analysis.mirror
       priority: 1
     - name: StepWeight
       type: string
-      JSONPath: .spec.canaryAnalysis.stepWeight
+      JSONPath: .spec.analysis.stepWeight
       priority: 1
     - name: MaxWeight
       type: string
-      JSONPath: .spec.canaryAnalysis.maxWeight
+      JSONPath: .spec.analysis.maxWeight
       priority: 1
     - name: LastTransitionTime
       type: string
@@ -66,7 +66,7 @@ spec:
           required:
             - targetRef
             - service
-            - canaryAnalysis
+            - analysis
           properties:
             provider:
               description: Traffic managent provider
@@ -502,9 +502,12 @@ spec:
             skipAnalysis:
               description: Skip analysis and promote canary
               type: boolean
-            canaryAnalysis:
+            analysis:
               description: Canary analysis for this canary
               type: object
+              oneOf:
+                - required: ["interval", "threshold", "iterations"]
+                - required: ["interval", "threshold", "stepWeight"]
               properties:
                 interval:
                   description: Schedule interval for this canary
@@ -523,7 +526,7 @@ spec:
                   description: Incremental traffic percentage step
                   type: number
                 mirror:
-                  description: Mirror traffic to canary before shifting
+                  description: Mirror traffic to canary
                   type: boolean
                 match:
                   description: A/B testing match conditions

--- a/cmd/loadtester/main.go
+++ b/cmd/loadtester/main.go
@@ -2,12 +2,13 @@ package main
 
 import (
 	"flag"
+	"log"
+	"time"
+
 	"github.com/weaveworks/flagger/pkg/loadtester"
 	"github.com/weaveworks/flagger/pkg/logger"
 	"github.com/weaveworks/flagger/pkg/signals"
 	"go.uber.org/zap"
-	"log"
-	"time"
 )
 
 var VERSION = "0.12.1"

--- a/kustomize/base/flagger/crd.yaml
+++ b/kustomize/base/flagger/crd.yaml
@@ -42,19 +42,19 @@ spec:
       priority: 1
     - name: Interval
       type: string
-      JSONPath: .spec.canaryAnalysis.interval
+      JSONPath: .spec.analysis.interval
       priority: 1
     - name: Mirror
       type: boolean
-      JSONPath: .spec.canaryAnalysis.mirror
+      JSONPath: .spec.analysis.mirror
       priority: 1
     - name: StepWeight
       type: string
-      JSONPath: .spec.canaryAnalysis.stepWeight
+      JSONPath: .spec.analysis.stepWeight
       priority: 1
     - name: MaxWeight
       type: string
-      JSONPath: .spec.canaryAnalysis.maxWeight
+      JSONPath: .spec.analysis.maxWeight
       priority: 1
     - name: LastTransitionTime
       type: string
@@ -66,7 +66,7 @@ spec:
           required:
             - targetRef
             - service
-            - canaryAnalysis
+            - analysis
           properties:
             provider:
               description: Traffic managent provider
@@ -502,9 +502,12 @@ spec:
             skipAnalysis:
               description: Skip analysis and promote canary
               type: boolean
-            canaryAnalysis:
+            analysis:
               description: Canary analysis for this canary
               type: object
+              oneOf:
+                - required: ["interval", "threshold", "iterations"]
+                - required: ["interval", "threshold", "stepWeight"]
               properties:
                 interval:
                   description: Schedule interval for this canary
@@ -523,7 +526,7 @@ spec:
                   description: Incremental traffic percentage step
                   type: number
                 mirror:
-                  description: Mirror traffic to canary before shifting
+                  description: Mirror traffic to canary
                   type: boolean
                 match:
                   description: A/B testing match conditions

--- a/pkg/apis/flagger/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/flagger/v1beta1/zz_generated.deepcopy.go
@@ -392,7 +392,16 @@ func (in *CanarySpec) DeepCopyInto(out *CanarySpec) {
 		**out = **in
 	}
 	in.Service.DeepCopyInto(&out.Service)
-	in.CanaryAnalysis.DeepCopyInto(&out.CanaryAnalysis)
+	if in.Analysis != nil {
+		in, out := &in.Analysis, &out.Analysis
+		*out = new(CanaryAnalysis)
+		(*in).DeepCopyInto(*out)
+	}
+	if in.CanaryAnalysis != nil {
+		in, out := &in.CanaryAnalysis, &out.CanaryAnalysis
+		*out = new(CanaryAnalysis)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.ProgressDeadlineSeconds != nil {
 		in, out := &in.ProgressDeadlineSeconds, &out.ProgressDeadlineSeconds
 		*out = new(int32)

--- a/pkg/canary/daemonset_controller.go
+++ b/pkg/canary/daemonset_controller.go
@@ -91,7 +91,7 @@ func (c *DaemonSetController) Initialize(cd *flaggerv1.Canary, skipLivenessCheck
 	}
 
 	if cd.Status.Phase == "" || cd.Status.Phase == flaggerv1.CanaryPhaseInitializing {
-		if !skipLivenessChecks && !cd.Spec.SkipAnalysis {
+		if !skipLivenessChecks && !cd.SkipAnalysis() {
 			_, readyErr := c.IsPrimaryReady(cd)
 			if readyErr != nil {
 				return readyErr

--- a/pkg/canary/deployment_controller.go
+++ b/pkg/canary/deployment_controller.go
@@ -37,7 +37,7 @@ func (c *DeploymentController) Initialize(cd *flaggerv1.Canary, skipLivenessChec
 	}
 
 	if cd.Status.Phase == "" || cd.Status.Phase == flaggerv1.CanaryPhaseInitializing {
-		if !skipLivenessChecks && !cd.Spec.SkipAnalysis {
+		if !skipLivenessChecks && !cd.SkipAnalysis() {
 			_, readyErr := c.IsPrimaryReady(cd)
 			if readyErr != nil {
 				return readyErr

--- a/pkg/canary/deployment_fixture_test.go
+++ b/pkg/canary/deployment_fixture_test.go
@@ -207,7 +207,7 @@ func newDeploymentControllerTestCanary() *flaggerv1.Canary {
 				Kind:       "HorizontalPodAutoscaler",
 			}, Service: flaggerv1.CanaryService{
 				Port: 9898,
-			}, CanaryAnalysis: flaggerv1.CanaryAnalysis{
+			}, CanaryAnalysis: &flaggerv1.CanaryAnalysis{
 				Threshold:  10,
 				StepWeight: 10,
 				MaxWeight:  50,

--- a/pkg/controller/events.go
+++ b/pkg/controller/events.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"fmt"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	corev1 "k8s.io/api/core/v1"

--- a/pkg/controller/events.go
+++ b/pkg/controller/events.go
@@ -30,8 +30,8 @@ func (c *Controller) recordEventWarningf(r *flaggerv1.Canary, template string, a
 
 func (c *Controller) sendEventToWebhook(r *flaggerv1.Canary, eventType, template string, args []interface{}) {
 	webhookOverride := false
-	if len(r.Spec.CanaryAnalysis.Webhooks) > 0 {
-		for _, canaryWebhook := range r.Spec.CanaryAnalysis.Webhooks {
+	if len(r.GetAnalysis().Webhooks) > 0 {
+		for _, canaryWebhook := range r.GetAnalysis().Webhooks {
 			if canaryWebhook.Type == flaggerv1.EventHook {
 				webhookOverride = true
 				err := CallEventWebhook(r, canaryWebhook.URL, fmt.Sprintf(template, args...), eventType)
@@ -51,7 +51,7 @@ func (c *Controller) sendEventToWebhook(r *flaggerv1.Canary, eventType, template
 }
 
 func (c *Controller) alert(canary *flaggerv1.Canary, message string, metadata bool, severity flaggerv1.AlertSeverity) {
-	if c.notifier == nil && len(canary.Spec.CanaryAnalysis.Alerts) == 0 {
+	if c.notifier == nil && len(canary.GetAnalysis().Alerts) == 0 {
 		return
 	}
 
@@ -61,7 +61,7 @@ func (c *Controller) alert(canary *flaggerv1.Canary, message string, metadata bo
 	}
 
 	// send alert with the global notifier
-	if len(canary.Spec.CanaryAnalysis.Alerts) == 0 {
+	if len(canary.GetAnalysis().Alerts) == 0 {
 		err := c.notifier.Post(canary.Name, canary.Namespace, message, fields, string(severity))
 		if err != nil {
 			c.logger.With("canary", fmt.Sprintf("%s.%s", canary.Name, canary.Namespace)).
@@ -72,7 +72,7 @@ func (c *Controller) alert(canary *flaggerv1.Canary, message string, metadata bo
 	}
 
 	// send canary alerts
-	for _, alert := range canary.Spec.CanaryAnalysis.Alerts {
+	for _, alert := range canary.GetAnalysis().Alerts {
 		// determine if alert should be sent based on severity level
 		shouldAlert := false
 		if alert.Severity == flaggerv1.SeverityInfo {
@@ -161,7 +161,7 @@ func alertMetadata(canary *flaggerv1.Canary) []notifier.Field {
 		},
 		notifier.Field{
 			Name:  "Failed checks threshold",
-			Value: fmt.Sprintf("%v", canary.Spec.CanaryAnalysis.Threshold),
+			Value: fmt.Sprintf("%v", canary.GetAnalysisThreshold()),
 		},
 		notifier.Field{
 			Name:  "Progress deadline",
@@ -169,19 +169,19 @@ func alertMetadata(canary *flaggerv1.Canary) []notifier.Field {
 		},
 	)
 
-	if canary.Spec.CanaryAnalysis.StepWeight > 0 {
+	if canary.GetAnalysis().StepWeight > 0 {
 		fields = append(fields, notifier.Field{
 			Name: "Traffic routing",
 			Value: fmt.Sprintf("Weight step: %v max: %v",
-				canary.Spec.CanaryAnalysis.StepWeight,
-				canary.Spec.CanaryAnalysis.MaxWeight),
+				canary.GetAnalysis().StepWeight,
+				canary.GetAnalysis().MaxWeight),
 		})
-	} else if len(canary.Spec.CanaryAnalysis.Match) > 0 {
+	} else if len(canary.GetAnalysis().Match) > 0 {
 		fields = append(fields, notifier.Field{
 			Name:  "Traffic routing",
 			Value: "A/B Testing",
 		})
-	} else if canary.Spec.CanaryAnalysis.Iterations > 0 {
+	} else if canary.GetAnalysis().Iterations > 0 {
 		fields = append(fields, notifier.Field{
 			Name:  "Traffic routing",
 			Value: "Blue/Green",

--- a/pkg/controller/scheduler_common_test.go
+++ b/pkg/controller/scheduler_common_test.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"fmt"
+
 	flaggerv1 "github.com/weaveworks/flagger/pkg/apis/flagger/v1beta1"
 	clientset "github.com/weaveworks/flagger/pkg/client/clientset/versioned"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/pkg/controller/scheduler_common_test.go
+++ b/pkg/controller/scheduler_common_test.go
@@ -1,5 +1,25 @@
 package controller
 
+import (
+	"fmt"
+	flaggerv1 "github.com/weaveworks/flagger/pkg/apis/flagger/v1beta1"
+	clientset "github.com/weaveworks/flagger/pkg/client/clientset/versioned"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func assertPhase(flaggerClient clientset.Interface, canary string, phase flaggerv1.CanaryPhase) error {
+	c, err := flaggerClient.FlaggerV1beta1().Canaries("default").Get(canary, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+
+	if c.Status.Phase != phase {
+		return fmt.Errorf("Got canary state %v wanted %v", c.Status.Phase, phase)
+	}
+
+	return nil
+}
+
 func alwaysReady() bool {
 	return true
 }

--- a/pkg/controller/scheduler_daemonset_fixture_test.go
+++ b/pkg/controller/scheduler_daemonset_fixture_test.go
@@ -250,7 +250,7 @@ func newDaemonSetTestCanary() *flaggerv1.Canary {
 				Kind:       "DaemonSet",
 			}, Service: flaggerv1.CanaryService{
 				Port: 9898,
-			}, CanaryAnalysis: flaggerv1.CanaryAnalysis{
+			}, CanaryAnalysis: &flaggerv1.CanaryAnalysis{
 				Threshold:  10,
 				StepWeight: 10,
 				MaxWeight:  50,
@@ -307,7 +307,7 @@ func newDaemonSetTestCanaryAB() *flaggerv1.Canary {
 				Kind:       "DaemonSet",
 			}, Service: flaggerv1.CanaryService{
 				Port: 9898,
-			}, CanaryAnalysis: flaggerv1.CanaryAnalysis{
+			}, CanaryAnalysis: &flaggerv1.CanaryAnalysis{
 				Threshold:  10,
 				Iterations: 10,
 				Match: []istiov1alpha3.HTTPMatchRequest{

--- a/pkg/controller/scheduler_deployment_fixture_test.go
+++ b/pkg/controller/scheduler_deployment_fixture_test.go
@@ -257,7 +257,7 @@ func newDeploymentTestCanary() *flaggerv1.Canary {
 				Kind:       "HorizontalPodAutoscaler",
 			}, Service: flaggerv1.CanaryService{
 				Port: 9898,
-			}, CanaryAnalysis: flaggerv1.CanaryAnalysis{
+			}, CanaryAnalysis: &flaggerv1.CanaryAnalysis{
 				Threshold:  10,
 				StepWeight: 10,
 				MaxWeight:  50,
@@ -319,7 +319,7 @@ func newDeploymentTestCanaryAB() *flaggerv1.Canary {
 				Kind:       "HorizontalPodAutoscaler",
 			}, Service: flaggerv1.CanaryService{
 				Port: 9898,
-			}, CanaryAnalysis: flaggerv1.CanaryAnalysis{
+			}, CanaryAnalysis: &flaggerv1.CanaryAnalysis{
 				Threshold:  10,
 				Iterations: 10,
 				Match: []istiov1alpha3.HTTPMatchRequest{

--- a/pkg/controller/scheduler_svc_test.go
+++ b/pkg/controller/scheduler_svc_test.go
@@ -142,7 +142,7 @@ func newTestServiceCanary() *flaggerv1.Canary {
 			Service: flaggerv1.CanaryService{
 				Port: 9898,
 			},
-			CanaryAnalysis: flaggerv1.CanaryAnalysis{
+			CanaryAnalysis: &flaggerv1.CanaryAnalysis{
 				Threshold:  10,
 				StepWeight: 10,
 				MaxWeight:  50,

--- a/pkg/controller/webhook.go
+++ b/pkg/controller/webhook.go
@@ -7,11 +7,12 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
-	"k8s.io/utils/clock"
 	"net/http"
 	"net/url"
 	"strconv"
 	"time"
+
+	"k8s.io/utils/clock"
 
 	flaggerv1 "github.com/weaveworks/flagger/pkg/apis/flagger/v1beta1"
 )

--- a/pkg/loadtester/runner.go
+++ b/pkg/loadtester/runner.go
@@ -2,10 +2,11 @@ package loadtester
 
 import (
 	"context"
-	"go.uber.org/zap"
 	"sync"
 	"sync/atomic"
 	"time"
+
+	"go.uber.org/zap"
 )
 
 type TaskRunner struct {

--- a/pkg/loadtester/runner_test.go
+++ b/pkg/loadtester/runner_test.go
@@ -1,9 +1,10 @@
 package loadtester
 
 import (
-	"github.com/weaveworks/flagger/pkg/logger"
 	"testing"
 	"time"
+
+	"github.com/weaveworks/flagger/pkg/logger"
 )
 
 func TestTaskRunner_Start(t *testing.T) {

--- a/pkg/loadtester/server.go
+++ b/pkg/loadtester/server.go
@@ -179,7 +179,6 @@ func ListenAndServe(port string, timeout time.Duration, logger *zap.SugaredLogge
 			return
 		}
 
-
 		canaryName := fmt.Sprintf("rollback.%s.%s", canary.Name, canary.Namespace)
 		gate.close(canaryName)
 

--- a/pkg/loadtester/task.go
+++ b/pkg/loadtester/task.go
@@ -3,9 +3,10 @@ package loadtester
 import (
 	"context"
 	"encoding/hex"
-	"go.uber.org/zap"
 	"hash/fnv"
 	"sync"
+
+	"go.uber.org/zap"
 )
 
 // Modeling a loadtester task

--- a/pkg/loadtester/task_ngrinder.go
+++ b/pkg/loadtester/task_ngrinder.go
@@ -6,12 +6,13 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"go.uber.org/zap"
 	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strconv"
 	"time"
+
+	"go.uber.org/zap"
 )
 
 const TaskTypeNGrinder = "ngrinder"

--- a/pkg/loadtester/task_ngrinder_test.go
+++ b/pkg/loadtester/task_ngrinder_test.go
@@ -3,10 +3,11 @@ package loadtester
 import (
 	"context"
 	"fmt"
-	"github.com/weaveworks/flagger/pkg/logger"
-	"gopkg.in/h2non/gock.v1"
 	"testing"
 	"time"
+
+	"github.com/weaveworks/flagger/pkg/logger"
+	"gopkg.in/h2non/gock.v1"
 )
 
 func TestTaskNGrinder(t *testing.T) {

--- a/pkg/loadtester/task_shell.go
+++ b/pkg/loadtester/task_shell.go
@@ -4,9 +4,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"go.uber.org/zap"
 	"os/exec"
 	"strconv"
+
+	"go.uber.org/zap"
 )
 
 const TaskTypeShell = "cmd"

--- a/pkg/metrics/observers/observer.go
+++ b/pkg/metrics/observers/observer.go
@@ -1,8 +1,9 @@
 package observers
 
 import (
-	flaggerv1 "github.com/weaveworks/flagger/pkg/apis/flagger/v1beta1"
 	"time"
+
+	flaggerv1 "github.com/weaveworks/flagger/pkg/apis/flagger/v1beta1"
 )
 
 type Interface interface {

--- a/pkg/router/appmesh.go
+++ b/pkg/router/appmesh.go
@@ -203,7 +203,7 @@ func (ar *AppMeshRouter) reconcileVirtualService(canary *flaggerv1.Canary, name 
 	}
 
 	// A/B testing - header based routing
-	if len(canary.Spec.CanaryAnalysis.Match) > 0 && canaryWeight == 0 {
+	if len(canary.GetAnalysis().Match) > 0 && canaryWeight == 0 {
 		routes = []appmeshv1.Route{
 			{
 				Name:     fmt.Sprintf("%s-a", apexName),
@@ -451,7 +451,7 @@ func makeRetryPolicy(canary *flaggerv1.Canary) *appmeshv1.HttpRetryPolicy {
 func (ar *AppMeshRouter) makeHeaders(canary *flaggerv1.Canary) []appmeshv1.HttpRouteHeader {
 	headers := []appmeshv1.HttpRouteHeader{}
 
-	for _, m := range canary.Spec.CanaryAnalysis.Match {
+	for _, m := range canary.GetAnalysis().Match {
 		for key, value := range m.Headers {
 			header := appmeshv1.HttpRouteHeader{
 				Name: key,

--- a/pkg/router/contour.go
+++ b/pkg/router/contour.go
@@ -64,7 +64,7 @@ func (cr *ContourRouter) Reconcile(canary *flaggerv1.Canary) error {
 		},
 	}
 
-	if len(canary.Spec.CanaryAnalysis.Match) > 0 {
+	if len(canary.GetAnalysis().Match) > 0 {
 		newSpec = contourv1.HTTPProxySpec{
 			Routes: []contourv1.Route{
 				{
@@ -277,7 +277,7 @@ func (cr *ContourRouter) SetRoutes(
 		},
 	}
 
-	if len(canary.Spec.CanaryAnalysis.Match) > 0 {
+	if len(canary.GetAnalysis().Match) > 0 {
 		proxy.Spec = contourv1.HTTPProxySpec{
 			Routes: []contourv1.Route{
 				{
@@ -364,8 +364,8 @@ func (cr *ContourRouter) makePrefix(canary *flaggerv1.Canary) string {
 func (cr *ContourRouter) makeConditions(canary *flaggerv1.Canary) []contourv1.Condition {
 	list := []contourv1.Condition{}
 
-	if len(canary.Spec.CanaryAnalysis.Match) > 0 {
-		for _, match := range canary.Spec.CanaryAnalysis.Match {
+	if len(canary.GetAnalysis().Match) > 0 {
+		for _, match := range canary.GetAnalysis().Match {
 			for s, stringMatch := range match.Headers {
 				h := &contourv1.HeaderCondition{
 					Name:  s,

--- a/pkg/router/ingress.go
+++ b/pkg/router/ingress.go
@@ -117,7 +117,7 @@ func (i *IngressRouter) GetRoutes(canary *flaggerv1.Canary) (
 	}
 
 	// A/B testing
-	if len(canary.Spec.CanaryAnalysis.Match) > 0 {
+	if len(canary.GetAnalysis().Match) > 0 {
 		for k := range canaryIngress.Annotations {
 			if k == i.GetAnnotationWithPrefix("canary-by-cookie") || k == i.GetAnnotationWithPrefix("canary-by-header") {
 				return 0, 100, false, nil
@@ -158,11 +158,11 @@ func (i *IngressRouter) SetRoutes(
 	iClone := canaryIngress.DeepCopy()
 
 	// A/B testing
-	if len(canary.Spec.CanaryAnalysis.Match) > 0 {
+	if len(canary.GetAnalysis().Match) > 0 {
 		cookie := ""
 		header := ""
 		headerValue := ""
-		for _, m := range canary.Spec.CanaryAnalysis.Match {
+		for _, m := range canary.GetAnalysis().Match {
 			for k, v := range m.Headers {
 				if k == "cookie" {
 					cookie = v.Exact

--- a/pkg/router/istio.go
+++ b/pkg/router/istio.go
@@ -152,8 +152,8 @@ func (ir *IstioRouter) reconcileVirtualService(canary *flaggerv1.Canary) error {
 		},
 	}
 
-	if len(canary.Spec.CanaryAnalysis.Match) > 0 {
-		canaryMatch := mergeMatchConditions(canary.Spec.CanaryAnalysis.Match, canary.Spec.Service.Match)
+	if len(canary.GetAnalysis().Match) > 0 {
+		canaryMatch := mergeMatchConditions(canary.GetAnalysis().Match, canary.Spec.Service.Match)
 		newSpec.Http = []istiov1alpha3.HTTPRoute{
 			{
 				Match:      canaryMatch,
@@ -323,9 +323,9 @@ func (ir *IstioRouter) SetRoutes(
 	}
 
 	// fix routing (A/B testing)
-	if len(canary.Spec.CanaryAnalysis.Match) > 0 {
+	if len(canary.GetAnalysis().Match) > 0 {
 		// merge the common routes with the canary ones
-		canaryMatch := mergeMatchConditions(canary.Spec.CanaryAnalysis.Match, canary.Spec.Service.Match)
+		canaryMatch := mergeMatchConditions(canary.GetAnalysis().Match, canary.Spec.Service.Match)
 		vsCopy.Spec.Http = []istiov1alpha3.HTTPRoute{
 			{
 				Match:      canaryMatch,

--- a/pkg/router/router_test.go
+++ b/pkg/router/router_test.go
@@ -112,7 +112,7 @@ func newTestCanary() *flaggerv1.Canary {
 					"public-gateway.istio",
 					"mesh",
 				},
-			}, CanaryAnalysis: flaggerv1.CanaryAnalysis{
+			}, CanaryAnalysis: &flaggerv1.CanaryAnalysis{
 				Threshold:  10,
 				StepWeight: 10,
 				MaxWeight:  50,
@@ -158,7 +158,7 @@ func newTestCanaryAppMesh() *flaggerv1.Canary {
 					PerTryTimeout: "gateway-error",
 					RetryOn:       "5s",
 				},
-			}, CanaryAnalysis: flaggerv1.CanaryAnalysis{
+			}, CanaryAnalysis: &flaggerv1.CanaryAnalysis{
 				Threshold:  10,
 				StepWeight: 10,
 				MaxWeight:  50,
@@ -203,7 +203,7 @@ func newTestSMICanary() *flaggerv1.Canary {
 				},
 				PortDiscovery: true,
 			},
-			CanaryAnalysis: flaggerv1.CanaryAnalysis{
+			CanaryAnalysis: &flaggerv1.CanaryAnalysis{
 				Threshold:  10,
 				StepWeight: 10,
 				MaxWeight:  50,
@@ -227,7 +227,7 @@ func newTestSMICanary() *flaggerv1.Canary {
 
 func newTestMirror() *flaggerv1.Canary {
 	cd := newTestCanary()
-	cd.Spec.CanaryAnalysis.Mirror = true
+	cd.GetAnalysis().Mirror = true
 	return cd
 }
 
@@ -247,7 +247,7 @@ func newTestABTest() *flaggerv1.Canary {
 			Service: flaggerv1.CanaryService{
 				Port:     9898,
 				MeshName: "global",
-			}, CanaryAnalysis: flaggerv1.CanaryAnalysis{
+			}, CanaryAnalysis: &flaggerv1.CanaryAnalysis{
 				Threshold:  10,
 				Iterations: 2,
 				Match: []istiov1alpha3.HTTPMatchRequest{
@@ -397,7 +397,7 @@ func newTestCanaryIngress() *flaggerv1.Canary {
 			},
 			Service: flaggerv1.CanaryService{
 				Port: 9898,
-			}, CanaryAnalysis: flaggerv1.CanaryAnalysis{
+			}, CanaryAnalysis: &flaggerv1.CanaryAnalysis{
 				Threshold:  10,
 				StepWeight: 10,
 				MaxWeight:  50,

--- a/test/e2e-contour-tests.sh
+++ b/test/e2e-contour-tests.sh
@@ -34,7 +34,7 @@ spec:
 EOF
 
 cat <<EOF | kubectl apply -f -
-apiVersion: flagger.app/v1alpha3
+apiVersion: flagger.app/v1beta1
 kind: Canary
 metadata:
   name: podinfo
@@ -49,7 +49,7 @@ spec:
   service:
     port: 80
     targetPort: 9898
-  canaryAnalysis:
+  analysis:
     interval: 15s
     threshold: 15
     maxWeight: 50
@@ -145,7 +145,7 @@ echo '✔ Canary promotion test passed'
 
 
 cat <<EOF | kubectl apply -f -
-apiVersion: flagger.app/v1alpha3
+apiVersion: flagger.app/v1beta1
 kind: Canary
 metadata:
   name: podinfo
@@ -160,7 +160,7 @@ spec:
   service:
     port: 80
     targetPort: 9898
-  canaryAnalysis:
+  analysis:
     interval: 15s
     threshold: 15
     maxWeight: 50
@@ -218,7 +218,7 @@ done
 echo '✔ Canary rollback test passed'
 
 cat <<EOF | kubectl apply -f -
-apiVersion: flagger.app/v1alpha3
+apiVersion: flagger.app/v1beta1
 kind: Canary
 metadata:
   name: podinfo
@@ -233,7 +233,7 @@ spec:
   service:
     port: 80
     targetPort: 9898
-  canaryAnalysis:
+  analysis:
     interval: 10s
     threshold: 5
     iterations: 5

--- a/test/e2e-gloo-tests.sh
+++ b/test/e2e-gloo-tests.sh
@@ -37,7 +37,7 @@ spec:
 EOF
 
 cat <<EOF | kubectl apply -f -
-apiVersion: flagger.app/v1alpha3
+apiVersion: flagger.app/v1beta1
 kind: Canary
 metadata:
   name: podinfo
@@ -52,7 +52,7 @@ spec:
   service:
     port: 80
     targetPort: 9898
-  canaryAnalysis:
+  analysis:
     interval: 15s
     threshold: 15
     maxWeight: 50

--- a/test/e2e-istio.sh
+++ b/test/e2e-istio.sh
@@ -2,7 +2,7 @@
 
 set -o errexit
 
-ISTIO_VER="1.4.4"
+ISTIO_VER="1.4.5"
 REPO_ROOT=$(git rev-parse --show-toplevel)
 
 echo ">>> Installing Istio ${ISTIO_VER}"

--- a/test/e2e-kubernetes-tests-daemonset.sh
+++ b/test/e2e-kubernetes-tests-daemonset.sh
@@ -18,7 +18,7 @@ echo '>>> Initialising canary'
 kubectl apply -f ${REPO_ROOT}/test/e2e-daemonset.yaml
 
 cat <<EOF | kubectl apply -f -
-apiVersion: flagger.app/v1alpha3
+apiVersion: flagger.app/v1beta1
 kind: Canary
 metadata:
   name: podinfo
@@ -35,7 +35,7 @@ spec:
     targetPort: 9898
     name: podinfo-svc
     portDiscovery: true
-  canaryAnalysis:
+  analysis:
     interval: 15s
     threshold: 10
     iterations: 5

--- a/test/e2e-kubernetes-tests-deployment.sh
+++ b/test/e2e-kubernetes-tests-deployment.sh
@@ -18,7 +18,7 @@ echo '>>> Initialising canary'
 kubectl apply -f ${REPO_ROOT}/test/e2e-workload.yaml
 
 cat <<EOF | kubectl apply -f -
-apiVersion: flagger.app/v1alpha3
+apiVersion: flagger.app/v1beta1
 kind: Canary
 metadata:
   name: podinfo
@@ -35,7 +35,7 @@ spec:
     targetPort: 9898
     name: podinfo-svc
     portDiscovery: true
-  canaryAnalysis:
+  analysis:
     interval: 15s
     threshold: 10
     iterations: 5

--- a/test/e2e-kubernetes-tests-svc.sh
+++ b/test/e2e-kubernetes-tests-svc.sh
@@ -34,7 +34,7 @@ spec:
 EOS
 
 cat <<EOF | kubectl apply -f -
-apiVersion: flagger.app/v1alpha3
+apiVersion: flagger.app/v1beta1
 kind: Canary
 metadata:
   name: podinfo
@@ -48,7 +48,7 @@ spec:
   progressDeadlineSeconds: 60
   service:
     port: 9898
-  canaryAnalysis:
+  analysis:
     interval: 15s
     threshold: 10
     iterations: 5

--- a/test/e2e-linkerd-tests.sh
+++ b/test/e2e-linkerd-tests.sh
@@ -43,7 +43,7 @@ spec:
 EOF
 
 cat <<EOF | kubectl apply -f -
-apiVersion: flagger.app/v1alpha3
+apiVersion: flagger.app/v1beta1
 kind: Canary
 metadata:
   name: podinfo
@@ -58,7 +58,7 @@ spec:
     port: 80
     targetPort: http
     portDiscovery: true
-  canaryAnalysis:
+  analysis:
     interval: 15s
     threshold: 15
     maxWeight: 50
@@ -154,7 +154,7 @@ done
 echo '✔ Canary promotion test passed'
 
 cat <<EOF | kubectl apply -f -
-apiVersion: flagger.app/v1alpha3
+apiVersion: flagger.app/v1beta1
 kind: Canary
 metadata:
   name: podinfo
@@ -168,7 +168,7 @@ spec:
   service:
     port: 80
     targetPort: 9898
-  canaryAnalysis:
+  analysis:
     interval: 15s
     threshold: 3
     maxWeight: 50

--- a/test/e2e-nginx-tests.sh
+++ b/test/e2e-nginx-tests.sh
@@ -19,7 +19,7 @@ kubectl apply -f ${REPO_ROOT}/test/e2e-workload.yaml
 kubectl apply -f ${REPO_ROOT}/test/e2e-ingress.yaml
 
 cat <<EOF | kubectl apply -f -
-apiVersion: flagger.app/v1alpha3
+apiVersion: flagger.app/v1beta1
 kind: Canary
 metadata:
   name: podinfo
@@ -37,7 +37,7 @@ spec:
   service:
     port: 80
     targetPort: http
-  canaryAnalysis:
+  analysis:
     interval: 15s
     threshold: 15
     maxWeight: 30
@@ -156,7 +156,7 @@ done
 echo '✔ Canary promotion test passed'
 
 cat <<EOF | kubectl apply -f -
-apiVersion: flagger.app/v1alpha3
+apiVersion: flagger.app/v1beta1
 kind: Canary
 metadata:
   name: podinfo
@@ -174,7 +174,7 @@ spec:
   service:
     port: 80
     targetPort: 9898
-  canaryAnalysis:
+  analysis:
     interval: 10s
     threshold: 5
     iterations: 5

--- a/test/e2e-nginx.sh
+++ b/test/e2e-nginx.sh
@@ -3,7 +3,7 @@
 set -o errexit
 
 REPO_ROOT=$(git rev-parse --show-toplevel)
-NGINX_VERSION=1.26.0
+NGINX_VERSION=1.33.0
 
 echo '>>> Installing NGINX Ingress'
 kubectl create ns ingress-nginx

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -19,7 +19,7 @@ echo '>>> Initialising canary'
 kubectl apply -f ${REPO_ROOT}/test/e2e-workload.yaml
 
 cat <<EOF | kubectl apply -f -
-apiVersion: flagger.app/v1alpha3
+apiVersion: flagger.app/v1beta1
 kind: Canary
 metadata:
   name: podinfo
@@ -39,7 +39,7 @@ spec:
           x-envoy-upstream-rq-timeout-ms: "15000"
           x-envoy-max-retries: "10"
           x-envoy-retry-on: "gateway-error,connect-failure,refused-stream"
-  canaryAnalysis:
+  analysis:
     interval: 15s
     threshold: 15
     maxWeight: 30
@@ -145,7 +145,7 @@ if [[ "$1" = "canary" ]]; then
 fi
 
 cat <<EOF | kubectl apply -f -
-apiVersion: flagger.app/v1alpha3
+apiVersion: flagger.app/v1beta1
 kind: Canary
 metadata:
   name: podinfo
@@ -161,7 +161,7 @@ spec:
     port: 80
     targetPort: 9898
     portName: http-podinfo
-  canaryAnalysis:
+  analysis:
     interval: 10s
     threshold: 5
     iterations: 5
@@ -234,7 +234,7 @@ done
 echo '✔ B/G promotion test passed'
 
 cat <<EOF | kubectl apply -f -
-apiVersion: flagger.app/v1alpha3
+apiVersion: flagger.app/v1beta1
 kind: Canary
 metadata:
   name: podinfo
@@ -250,7 +250,7 @@ spec:
     port: 80
     portName: http-podinfo
     targetPort: http
-  canaryAnalysis:
+  analysis:
     interval: 10s
     threshold: 5
     iterations: 5


### PR DESCRIPTION
Changes:
- add `analysis` field to Canary API
- deprecate `canaryAnalysis` filed (to be removed in the next API version)
- maintain backwards compatibility with v1alpha3 by using `spec.canaryAnalysis` if `spec.analysis` is nil
- set analysis threshold default value to 1
- crd: rename `spec.canaryAnalysis` to `spec.analysis`
- crd: required fields `spec.analysis.interval` and `spec.analysis.threshold`
- e2e: update tests to v1beta1 and rename `spec.canaryAnalysis` to `spec.analysis`

Upgrade from v1alpha3 to v1beta1:
- apply v1beta1 CRDs
- upgrade Flagger 
- replace `apiVersion: flagger.app/v1alpha3` with `apiVersion: flagger.app/v1beta1`
- replace `spec.canaryAnalysis` with `spec.analysis`
- apply all canary definitions on the cluster

Followup #457
- update docs and tutorials to v1beta1
- add upgrade guide to docs