### PR TITLE
e2e: Istio 1.5

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,7 +81,7 @@ jobs:
       - run: test/container-build.sh
       - run: test/e2e-kind.sh
       - run: test/e2e-istio.sh
-      - run: test/e2e-tests.sh
+      - run: test/e2e-istio-tests.sh
 
   e2e-kubernetes-daemonset-testing:
     machine: true
@@ -104,28 +104,6 @@ jobs:
       - run: test/e2e-kind.sh v1.17.0
       - run: test/e2e-kubernetes.sh
       - run: test/e2e-kubernetes-tests-deployment.sh
-
-  e2e-kubernetes-svc-testing:
-    machine: true
-    steps:
-      - checkout
-      - attach_workspace:
-          at: /tmp/bin
-      - run: test/container-build.sh
-      - run: test/e2e-kind.sh
-      - run: test/e2e-kubernetes.sh
-      - run: test/e2e-kubernetes-svc-tests.sh
-
-  e2e-smi-istio-testing:
-    machine: true
-    steps:
-      - checkout
-      - attach_workspace:
-          at: /tmp/bin
-      - run: test/container-build.sh
-      - run: test/e2e-kind.sh
-      - run: test/e2e-smi-istio.sh
-      - run: test/e2e-tests.sh canary
 
   e2e-gloo-testing:
     machine: true

--- a/cmd/flagger/main.go
+++ b/cmd/flagger/main.go
@@ -125,6 +125,9 @@ func main() {
 	}
 
 	// use a remote cluster for routing if a service mesh kubeconfig is specified
+	if kubeconfigServiceMesh == "" {
+		kubeconfigServiceMesh = kubeconfig
+	}
 	cfgHost, err := clientcmd.BuildConfigFromFlags(masterURL, kubeconfigServiceMesh)
 	if err != nil {
 		logger.Fatalf("Error building host kubeconfig: %v", err)

--- a/test/e2e-istio.sh
+++ b/test/e2e-istio.sh
@@ -2,23 +2,15 @@
 
 set -o errexit
 
-ISTIO_VER="1.4.5"
+ISTIO_VER="1.5.0"
 REPO_ROOT=$(git rev-parse --show-toplevel)
 
+echo ">>> Downloading Istio ${ISTIO_VER}"
+cd ${REPO_ROOT}/bin && \
+curl -L https://istio.io/downloadIstio | ISTIO_VERSION=${ISTIO_VER} sh -
+
 echo ">>> Installing Istio ${ISTIO_VER}"
-kubectl create ns istio-system
-helm repo add istio.io https://storage.googleapis.com/istio-release/releases/${ISTIO_VER}/charts
-
-echo '>>> Installing Istio CRDs'
-helm upgrade -i istio-init istio.io/istio-init --wait --namespace istio-system
-
-echo '>>> Waiting for Istio CRDs to be ready'
-kubectl -n istio-system wait --for=condition=complete job/istio-init-crd-10-${ISTIO_VER}
-kubectl -n istio-system wait --for=condition=complete job/istio-init-crd-11-${ISTIO_VER}
-kubectl -n istio-system wait --for=condition=complete job/istio-init-crd-14-${ISTIO_VER}
-
-echo '>>> Installing Istio control plane'
-helm upgrade -i istio istio.io/istio --wait --namespace istio-system -f ${REPO_ROOT}/test/e2e-istio-values.yaml
+${REPO_ROOT}/bin/istio-${ISTIO_VER}/bin/istioctl manifest apply --set profile=default
 
 kubectl -n istio-system get all
 

--- a/test/e2e-istio.sh
+++ b/test/e2e-istio.sh
@@ -12,6 +12,8 @@ curl -L https://istio.io/downloadIstio | ISTIO_VERSION=${ISTIO_VER} sh -
 echo ">>> Installing Istio ${ISTIO_VER}"
 ${REPO_ROOT}/bin/istio-${ISTIO_VER}/bin/istioctl manifest apply --set profile=default
 
+kubectl -n istio-system rollout status deployment/prometheus
+
 kubectl -n istio-system get all
 
 echo '>>> Load Flagger image in Kind'


### PR DESCRIPTION
End-to-end tests changes:
- replace Istio Helm install with istioctl
- update Istio to 1.5.0
- replace the `request-duration` builtin check with a metric template that uses `istio_request_duration_milliseconds_bucket` (breaking change in Istio telemetry v2 ref: #478)