### PR TITLE
pkg/router: renamed KubernetesDeploymentRouter to KubernetesDefaultRouter

### DIFF
--- a/pkg/router/factory.go
+++ b/pkg/router/factory.go
@@ -34,25 +34,20 @@ func NewFactory(kubeConfig *restclient.Config, kubeClient kubernetes.Interface,
 	}
 }
 
-// KubernetesDeploymentRouter returns a ClusterIP service router
+// KubernetesRouter returns a KubernetesRouter interface implementation
 func (factory *Factory) KubernetesRouter(kind string, labelSelector string, annotations map[string]string, ports map[string]int32) KubernetesRouter {
-	deploymentRouter := &KubernetesDeploymentRouter{
-		logger:        factory.logger,
-		flaggerClient: factory.flaggerClient,
-		kubeClient:    factory.kubeClient,
-		labelSelector: labelSelector,
-		annotations:   annotations,
-		ports:         ports,
-	}
-	noopRouter := &KubernetesNoopRouter{}
-
-	switch {
-	case kind == "Deployment":
-		return deploymentRouter
-	case kind == "Service":
-		return noopRouter
-	default:
-		return deploymentRouter
+	switch kind {
+	case "Service":
+		return &KubernetesNoopRouter{}
+	default: // Daemonset or Deployment
+		return &KubernetesDefaultRouter{
+			logger:        factory.logger,
+			flaggerClient: factory.flaggerClient,
+			kubeClient:    factory.kubeClient,
+			labelSelector: labelSelector,
+			annotations:   annotations,
+			ports:         ports,
+		}
 	}
 }
 

--- a/pkg/router/kubernetes_default.go
+++ b/pkg/router/kubernetes_default.go
@@ -17,8 +17,8 @@ import (
 	clientset "github.com/weaveworks/flagger/pkg/client/clientset/versioned"
 )
 
-// KubernetesDeploymentRouter is managing ClusterIP services
-type KubernetesDeploymentRouter struct {
+// KubernetesDefaultRouter is managing ClusterIP services
+type KubernetesDefaultRouter struct {
 	kubeClient    kubernetes.Interface
 	flaggerClient clientset.Interface
 	logger        *zap.SugaredLogger
@@ -28,7 +28,7 @@ type KubernetesDeploymentRouter struct {
 }
 
 // Initialize creates the primary and canary services
-func (c *KubernetesDeploymentRouter) Initialize(canary *flaggerv1.Canary) error {
+func (c *KubernetesDefaultRouter) Initialize(canary *flaggerv1.Canary) error {
 	_, primaryName, canaryName := canary.GetServiceNames()
 
 	// canary svc
@@ -47,7 +47,7 @@ func (c *KubernetesDeploymentRouter) Initialize(canary *flaggerv1.Canary) error 
 }
 
 // Reconcile creates or updates the main service
-func (c *KubernetesDeploymentRouter) Reconcile(canary *flaggerv1.Canary) error {
+func (c *KubernetesDefaultRouter) Reconcile(canary *flaggerv1.Canary) error {
 	apexName, _, _ := canary.GetServiceNames()
 
 	// main svc
@@ -59,15 +59,15 @@ func (c *KubernetesDeploymentRouter) Reconcile(canary *flaggerv1.Canary) error {
 	return nil
 }
 
-func (c *KubernetesDeploymentRouter) SetRoutes(_ *flaggerv1.Canary, _ int, _ int) error {
+func (c *KubernetesDefaultRouter) SetRoutes(_ *flaggerv1.Canary, _ int, _ int) error {
 	return nil
 }
 
-func (c *KubernetesDeploymentRouter) GetRoutes(_ *flaggerv1.Canary) (primaryRoute int, canaryRoute int, err error) {
+func (c *KubernetesDefaultRouter) GetRoutes(_ *flaggerv1.Canary) (primaryRoute int, canaryRoute int, err error) {
 	return 0, 0, nil
 }
 
-func (c *KubernetesDeploymentRouter) reconcileService(canary *flaggerv1.Canary, name string, podSelector string) error {
+func (c *KubernetesDefaultRouter) reconcileService(canary *flaggerv1.Canary, name string, podSelector string) error {
 	portName := canary.Spec.Service.PortName
 	if portName == "" {
 		portName = "http"

--- a/pkg/router/kubernetes_default_test.go
+++ b/pkg/router/kubernetes_default_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestServiceRouter_Create(t *testing.T) {
 	mocks := newFixture(nil)
-	router := &KubernetesDeploymentRouter{
+	router := &KubernetesDefaultRouter{
 		kubeClient:    mocks.kubeClient,
 		flaggerClient: mocks.flaggerClient,
 		logger:        mocks.logger,
@@ -37,7 +37,7 @@ func TestServiceRouter_Create(t *testing.T) {
 
 func TestServiceRouter_Update(t *testing.T) {
 	mocks := newFixture(nil)
-	router := &KubernetesDeploymentRouter{
+	router := &KubernetesDefaultRouter{
 		kubeClient:    mocks.kubeClient,
 		flaggerClient: mocks.flaggerClient,
 		logger:        mocks.logger,
@@ -71,7 +71,7 @@ func TestServiceRouter_Update(t *testing.T) {
 
 func TestServiceRouter_Undo(t *testing.T) {
 	mocks := newFixture(nil)
-	router := &KubernetesDeploymentRouter{
+	router := &KubernetesDefaultRouter{
 		kubeClient:    mocks.kubeClient,
 		flaggerClient: mocks.flaggerClient,
 		logger:        mocks.logger,


### PR DESCRIPTION
rename `KubernetesDeploymentRouter ` -> `KubernetesDefaultRouter` for clarity

related issues: #455 