### PR TITLE
fix: nil pointer on notifier

### DIFF
--- a/charts/flagger/templates/deployment.yaml
+++ b/charts/flagger/templates/deployment.yaml
@@ -85,7 +85,11 @@ spec:
           {{- end }}
           {{- if .Values.slack.url }}
           - -slack-url={{ .Values.slack.url }}
+          {{- end }}
+          {{- if .Values.slack.user }}
           - -slack-user={{ .Values.slack.user }}
+          {{- end }}
+          {{- if .Values.slack.channel }}
           - -slack-channel={{ .Values.slack.channel }}
           {{- end }}
           {{- if .Values.msteams.url }}

--- a/cmd/flagger/main.go
+++ b/cmd/flagger/main.go
@@ -318,21 +318,19 @@ func initNotifier(logger *zap.SugaredLogger) (client notifier.Interface) {
 	}
 	notifierFactory := notifier.NewFactory(notifierURL, slackUser, slackChannel)
 
-	if notifierURL != "" {
-		var err error
-		client, err = notifierFactory.Notifier(provider)
-		if err != nil {
-			logger.Errorf("Notifier %v", err)
-		} else {
-			logger.Infof("Notifications enabled for %s", notifierURL[0:30])
-		}
+	var err error
+	client, err = notifierFactory.Notifier(provider)
+	if err != nil {
+		logger.Errorf("Notifier %v", err)
+	} else if len(notifierURL) > 30 {
+		logger.Infof("Notifications enabled for %s", notifierURL[0:30])
 	}
 	return
 }
 
 func fromEnv(envVar string, defaultVal string) string {
-	if os.Getenv(envVar) != "" {
-		return os.Getenv(envVar)
+	if v := os.Getenv(envVar); v != "" {
+		return v
 	}
 	return defaultVal
 }

--- a/pkg/canary/daemonset_controller.go
+++ b/pkg/canary/daemonset_controller.go
@@ -289,7 +289,7 @@ func (c *DaemonSetController) getSelectorLabel(daemonSet *appsv1.DaemonSet) (str
 
 	return "", fmt.Errorf(
 		"daemonset %s.%s spec.selector.matchLabels must contain one of %v'",
-		c.labels, daemonSet.Name, daemonSet.Namespace,
+		daemonSet.Name, daemonSet.Namespace, c.labels,
 	)
 }
 

--- a/pkg/canary/deployment_controller.go
+++ b/pkg/canary/deployment_controller.go
@@ -369,7 +369,7 @@ func (c *DeploymentController) getSelectorLabel(deployment *appsv1.Deployment) (
 
 	return "", fmt.Errorf(
 		"deployment %s.%s spec.selector.matchLabels must contain one of %v",
-		c.labels, deployment.Name, deployment.Namespace,
+		deployment.Name, deployment.Namespace, c.labels,
 	)
 }
 

--- a/pkg/controller/events.go
+++ b/pkg/controller/events.go
@@ -50,10 +50,6 @@ func (c *Controller) sendEventToWebhook(r *flaggerv1.Canary, eventType, template
 }
 
 func (c *Controller) alert(canary *flaggerv1.Canary, message string, metadata bool, severity flaggerv1.AlertSeverity) {
-	if c.notifier == nil && len(canary.GetAnalysis().Alerts) == 0 {
-		return
-	}
-
 	var fields []notifier.Field
 	if metadata {
 		fields = alertMetadata(canary)

--- a/pkg/controller/scheduler_daemonset_fixture_test.go
+++ b/pkg/controller/scheduler_daemonset_fixture_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/weaveworks/flagger/pkg/logger"
 	"github.com/weaveworks/flagger/pkg/metrics"
 	"github.com/weaveworks/flagger/pkg/metrics/observers"
+	"github.com/weaveworks/flagger/pkg/notifier"
 	"github.com/weaveworks/flagger/pkg/router"
 )
 
@@ -102,6 +103,7 @@ func newDaemonSetFixture(c *flaggerv1.Canary) daemonSetFixture {
 		observerFactory:  observerFactory,
 		recorder:         metrics.NewRecorder(controllerAgentName, false),
 		routerFactory:    rf,
+		notifier:         &notifier.NopNotifier{},
 	}
 	ctrl.flaggerSynced = alwaysReady
 	ctrl.flaggerInformers.CanaryInformer.Informer().GetIndexer().Add(c)

--- a/pkg/controller/scheduler_deployment_fixture_test.go
+++ b/pkg/controller/scheduler_deployment_fixture_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/weaveworks/flagger/pkg/logger"
 	"github.com/weaveworks/flagger/pkg/metrics"
 	"github.com/weaveworks/flagger/pkg/metrics/observers"
+	"github.com/weaveworks/flagger/pkg/notifier"
 	"github.com/weaveworks/flagger/pkg/router"
 )
 
@@ -104,6 +105,7 @@ func newDeploymentFixture(c *flaggerv1.Canary) fixture {
 		observerFactory:  observerFactory,
 		recorder:         metrics.NewRecorder(controllerAgentName, false),
 		routerFactory:    rf,
+		notifier:         &notifier.NopNotifier{},
 	}
 	ctrl.flaggerSynced = alwaysReady
 	ctrl.flaggerInformers.CanaryInformer.Informer().GetIndexer().Add(c)

--- a/pkg/notifier/nop.go
+++ b/pkg/notifier/nop.go
@@ -1,0 +1,7 @@
+package notifier
+
+type NopNotifier struct{}
+
+func (n *NopNotifier) Post(string, string, string, []Field, string) error {
+	return nil
+}


### PR DESCRIPTION
resolves https://github.com/weaveworks/flagger/issues/496
___

if slack's url is configured through `SLACK_URL` environment variable without providing `slack.url`, current helm chart ignores `slack.channel` and  `slack.user`, which results in notifier in the controller struct becoming nil.

just in case, i added `nopNotifer` ~for warning users about misconfigurations in notifiers.~
