### PR TITLE
e2e: Upgrade nginx helm chart to 1.34.2

### DIFF
--- a/docs/gitbook/tutorials/nginx-progressive-delivery.md
+++ b/docs/gitbook/tutorials/nginx-progressive-delivery.md
@@ -14,7 +14,6 @@ Install NGINX with Helm v3:
 kubectl create ns ingress-nginx
 helm upgrade -i nginx-ingress stable/nginx-ingress \
 --namespace ingress-nginx \
---set controller.stats.enabled=true \
 --set controller.metrics.enabled=true \
 --set controller.podAnnotations."prometheus\.io/scrape"=true \
 --set controller.podAnnotations."prometheus\.io/port"=10254

--- a/test/e2e-nginx-custom-annotations.sh
+++ b/test/e2e-nginx-custom-annotations.sh
@@ -9,7 +9,6 @@ echo '>>> Installing NGINX Ingress'
 helm upgrade -i nginx-ingress stable/nginx-ingress --version=${NGINX_HELM_VERSION} \
 --wait \
 --namespace ingress-nginx \
---set controller.stats.enabled=true \
 --set controller.metrics.enabled=true \
 --set controller.podAnnotations."prometheus\.io/scrape"=true \
 --set controller.podAnnotations."prometheus\.io/port"=10254 \

--- a/test/e2e-nginx-custom-annotations.sh
+++ b/test/e2e-nginx-custom-annotations.sh
@@ -3,7 +3,7 @@
 set -o errexit
 
 REPO_ROOT=$(git rev-parse --show-toplevel)
-NGINX_HELM_VERSION=1.33.4 # ingress v0.30.0
+NGINX_HELM_VERSION=1.34.2 # ingress v0.30.0
 
 echo '>>> Installing NGINX Ingress'
 helm upgrade -i nginx-ingress stable/nginx-ingress --version=${NGINX_HELM_VERSION} \

--- a/test/e2e-nginx.sh
+++ b/test/e2e-nginx.sh
@@ -10,7 +10,6 @@ kubectl create ns ingress-nginx
 helm upgrade -i nginx-ingress stable/nginx-ingress --version=${NGINX_HELM_VERSION} \
 --wait \
 --namespace ingress-nginx \
---set controller.stats.enabled=true \
 --set controller.metrics.enabled=true \
 --set controller.podAnnotations."prometheus\.io/scrape"=true \
 --set controller.podAnnotations."prometheus\.io/port"=10254 \

--- a/test/e2e-nginx.sh
+++ b/test/e2e-nginx.sh
@@ -3,7 +3,7 @@
 set -o errexit
 
 REPO_ROOT=$(git rev-parse --show-toplevel)
-NGINX_HELM_VERSION=1.33.4 # ingress v0.30.0
+NGINX_HELM_VERSION=1.34.2 # ingress v0.30.0
 
 echo '>>> Installing NGINX Ingress'
 kubectl create ns ingress-nginx


### PR DESCRIPTION
Upgrade nginx chart to 1.34.2
Remove obsolete stats configuration as per https://github.com/helm/charts/pull/16139/files