### PR TITLE
Release Flagger v1.0.0-rc.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,43 @@
 
 All notable changes to this project are documented in this file.
 
+## 1.0.0-rc.2 (2020-03-19) 
+
+This is a release candidate for Flagger v1.0.0.
+
+The upgrade procedure from 0.x to 1.0 can be found [here](https://docs.flagger.app/dev/upgrade-guide).
+
+#### Features
+
+- Make mirror percentage configurable when using Istio traffic shadowing
+    [#492](https://github.com/weaveworks/flagger/pull/455)
+- Add support for running Concord tests with loadtester webhooks
+    [#507](https://github.com/weaveworks/flagger/pull/507)
+
+#### Improvements
+
+- docs: add Istio telemetry v2 upgrade guide
+    [#486](https://github.com/weaveworks/flagger/pull/486),
+    update A/B testing tutorial for Istio 1.5
+    [#502](https://github.com/weaveworks/flagger/pull/502),
+    add how to retry a failed release to FAQ
+    [#494](https://github.com/weaveworks/flagger/pull/494)
+- e2e: update end-to-end tests to
+    Istio 1.5 [#447](https://github.com/weaveworks/flagger/pull/447) and
+    NGINX Ingress 0.30
+    [#489](https://github.com/weaveworks/flagger/pull/489)
+    [#511](https://github.com/weaveworks/flagger/pull/511)
+- refactoring:
+    error handling [#480](https://github.com/weaveworks/flagger/pull/480),
+    scheduler [#484](https://github.com/weaveworks/flagger/pull/484) and 
+    unit tests [#475](https://github.com/weaveworks/flagger/pull/475)
+- chart: add the log level configuration to Flagger helm chart
+    [#506](https://github.com/weaveworks/flagger/pull/506)
+
+#### Fixes
+
+- Fix nil pointer for the global notifiers [#504](https://github.com/weaveworks/flagger/pull/504)
+
 ## 1.0.0-rc.1 (2020-03-03) 
 
 This is a release candidate for Flagger v1.0.0.

--- a/artifacts/flagger/deployment.yaml
+++ b/artifacts/flagger/deployment.yaml
@@ -22,7 +22,7 @@ spec:
       serviceAccountName: flagger
       containers:
       - name: flagger
-        image: weaveworks/flagger:1.0.0-rc.1
+        image: weaveworks/flagger:1.0.0-rc.2
         imagePullPolicy: IfNotPresent
         ports:
         - name: http

--- a/charts/flagger/Chart.yaml
+++ b/charts/flagger/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: flagger
-version: 0.24.0
-appVersion: 1.0.0-rc.1
+version: 0.25.0
+appVersion: 1.0.0-rc.2
 kubeVersion: ">=1.11.0-0"
 engine: gotpl
 description: Flagger is a progressive delivery operator for Kubernetes

--- a/charts/flagger/README.md
+++ b/charts/flagger/README.md
@@ -1,11 +1,14 @@
 # Flagger
 
-[Flagger](https://github.com/weaveworks/flagger) is a Kubernetes operator that automates the promotion of canary
-deployments using Istio, Linkerd, App Mesh, NGINX or Gloo routing for traffic shifting and Prometheus metrics for canary analysis. 
+[Flagger](https://github.com/weaveworks/flagger) is an operator that automates the release process of applications on Kubernetes. 
 
-Flagger implements a control loop that gradually shifts traffic to the canary while measuring key performance indicators
-like HTTP requests success rate, requests average duration and pods health.
-Based on the KPIs analysis a canary is promoted or aborted and the analysis result is published to Slack or MS Teams.
+Flagger can run automated application analysis, testing, promotion and rollback for the following deployment strategies:
+* Canary Release (progressive traffic shifting)
+* A/B Testing (HTTP headers and cookies traffic routing)
+* Blue/Green (traffic switching and mirroring)
+
+Flagger works with service mesh solutions (Istio, Linkerd, AWS App Mesh) and with Kubernetes ingress controllers (NGINX, Gloo, Contour).
+Flagger can be configured to send alerts to various chat platforms such as Slack, Microsoft Teams, Discord and Rocket.
 
 ## Prerequisites
 
@@ -26,34 +29,58 @@ Install Flagger's custom resource definitions:
 $ kubectl apply -f https://raw.githubusercontent.com/weaveworks/flagger/master/artifacts/flagger/crd.yaml
 ```
 
-To install the chart with the release name `flagger` for Istio:
+To install Flagger for **Istio**:
 
 ```console
 $ helm upgrade -i flagger flagger/flagger \
     --namespace=istio-system \
-    --set crd.create=false \
     --set meshProvider=istio \
     --set metricsServer=http://prometheus:9090
 ```
 
-To install the chart with the release name `flagger` for Linkerd:
+To install Flagger for **Linkerd**:
 
 ```console
 $ helm upgrade -i flagger flagger/flagger \
     --namespace=linkerd \
-    --set crd.create=false \
     --set meshProvider=linkerd \
     --set metricsServer=http://linkerd-prometheus:9090
 ```
 
-To install the chart with the release name `flagger` for AWS App Mesh:
+To install Flagger for **AWS App Mesh**:
 
 ```console
 $ helm upgrade -i flagger flagger/flagger \
     --namespace=appmesh-system \
-    --set crd.create=false \
     --set meshProvider=appmesh \
     --set metricsServer=http://appmesh-prometheus:9090
+```
+
+To install Flagger and Prometheus for **NGINX** Ingress (requires controller metrics enabled):
+
+```console
+$ helm upgrade -i flagger flagger/flagger \
+    --namespace=ingress-nginx \
+    --set meshProvider=nginx \
+    --set prometheus.install=true
+```
+
+To install Flagger and Prometheus for **Gloo** (requires Gloo discovery enabled):
+
+```console
+$ helm upgrade -i flagger flagger/flagger \
+    --namespace=gloo-system \
+    --set meshProvider=gloo \
+    --set prometheus.install=true
+```
+
+To install Flagger and Prometheus for **Contour**:
+
+```console
+$ helm upgrade -i flagger flagger/flagger \
+    --namespace=projectcontour \
+    --set meshProvider=contour \
+    --set prometheus.install=true
 ```
 
 The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -112,7 +139,6 @@ Specify each parameter using the `--set key=value[,key=value]` argument to `helm
 ```console
 $ helm upgrade -i flagger flagger/flagger \
   --namespace flagger-system \
-  --set crd.create=false \
   --set slack.url=https://hooks.slack.com/services/YOUR/SLACK/WEBHOOK \
   --set slack.channel=general
 ```

--- a/charts/flagger/values.yaml
+++ b/charts/flagger/values.yaml
@@ -2,7 +2,7 @@
 
 image:
   repository: weaveworks/flagger
-  tag: 1.0.0-rc.1
+  tag: 1.0.0-rc.2
   pullPolicy: IfNotPresent
   pullSecret:
 

--- a/charts/loadtester/Chart.yaml
+++ b/charts/loadtester/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: loadtester
-version: 0.13.0
-appVersion: 0.13.0
+version: 0.14.0
+appVersion: 0.14.0
 kubeVersion: ">=1.11.0-0"
 engine: gotpl
 description: Flagger's load testing services based on rakyll/hey and bojand/ghz that generates traffic during canary analysis when configured as a webhook.

--- a/charts/loadtester/values.yaml
+++ b/charts/loadtester/values.yaml
@@ -2,7 +2,7 @@ replicaCount: 1
 
 image:
   repository: weaveworks/flagger-loadtester
-  tag: 0.13.0
+  tag: 0.14.0
   pullPolicy: IfNotPresent
 
 podAnnotations:

--- a/cmd/loadtester/main.go
+++ b/cmd/loadtester/main.go
@@ -11,7 +11,7 @@ import (
 	"go.uber.org/zap"
 )
 
-var VERSION = "0.13.0"
+var VERSION = "0.14.0"
 var (
 	logLevel          string
 	port              string

--- a/kustomize/base/flagger/kustomization.yaml
+++ b/kustomize/base/flagger/kustomization.yaml
@@ -8,4 +8,4 @@ resources:
   - deployment.yaml
 images:
   - name: weaveworks/flagger
-    newTag: 1.0.0-rc.1
+    newTag: 1.0.0-rc.2

--- a/kustomize/tester/deployment.yaml
+++ b/kustomize/tester/deployment.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
         - name: loadtester
-          image: weaveworks/flagger-loadtester:0.13.0
+          image: weaveworks/flagger-loadtester:0.14.0
           imagePullPolicy: IfNotPresent
           ports:
             - name: http

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,4 +1,4 @@
 package version
 
-var VERSION = "1.0.0-rc.1"
+var VERSION = "1.0.0-rc.2"
 var REVISION = "unknown"


### PR DESCRIPTION
Changelog:

- Make mirror percentage configurable when using Istio traffic shadowing 
- Add support for running Concord tests with loadtester webhooks
- Add Istio telemetry v2 upgrade guide, update A/B testing tutorial for Istio 1.5, add how to retry a failed release to FAQ
- Update end-to-end tests to Istio 1.5  and NGINX Ingress 0.30
- Refactor error handling, scheduler and unit tests
- Add the log level configuration to Flagger helm chart
- Fix nil pointer for the global notifiers