### PR TITLE
chart: Add annotations for service account

### DIFF
--- a/charts/flagger/README.md
+++ b/charts/flagger/README.md
@@ -120,6 +120,9 @@ Parameter | Description | Default
 `podMonitor.podMonitor` | Additional labels to add to the PodMonitor | `{}`
 `leaderElection.enabled` | If `true`, Flagger will run in HA mode | `false`
 `leaderElection.replicaCount` | Number of replicas | `1`
+`serviceAccount.create` | If `true`, Flagger will create service account | `true`
+`serviceAccount.name` | The name of the service account to create or use | `""`
+`serviceAccount.annotations` | Annotations for service account | `{}`
 `ingressAnnotationsPrefix` | Annotations prefix for ingresses | `custom.ingress.kubernetes.io`
 `rbac.create` | If `true`, create and use RBAC resources | `true`
 `rbac.pspEnabled` | If `true`, create and use a restricted pod security policy | `false`

--- a/charts/flagger/README.md
+++ b/charts/flagger/README.md
@@ -121,7 +121,7 @@ Parameter | Description | Default
 `leaderElection.enabled` | If `true`, Flagger will run in HA mode | `false`
 `leaderElection.replicaCount` | Number of replicas | `1`
 `serviceAccount.create` | If `true`, Flagger will create service account | `true`
-`serviceAccount.name` | The name of the service account to create or use | `""`
+`serviceAccount.name` | The name of the service account to create or use. If not set and `serviceAccount.create` is `true`, a name is generated using the Flagger fullname | `""`
 `serviceAccount.annotations` | Annotations for service account | `{}`
 `ingressAnnotationsPrefix` | Annotations prefix for ingresses | `custom.ingress.kubernetes.io`
 `rbac.create` | If `true`, create and use RBAC resources | `true`

--- a/charts/flagger/templates/account.yaml
+++ b/charts/flagger/templates/account.yaml
@@ -3,6 +3,10 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ template "flagger.serviceAccountName" . }}
+  annotations:
+  {{- if .Values.serviceAccount.annotations }}
+{{ toYaml .Values.serviceAccount.annotations | indent 4 }}
+  {{- end }}
   labels:
     helm.sh/chart: {{ template "flagger.chart" . }}
     app.kubernetes.io/name: {{ template "flagger.name" . }}

--- a/charts/flagger/values.yaml
+++ b/charts/flagger/values.yaml
@@ -76,6 +76,8 @@ serviceAccount:
   create: true
   # serviceAccount.name: The name of the service account to create or use
   name: ""
+  # serviceAccount.annotations: Annotations for service account
+  annotations: {}
 
 rbac:
   # rbac.create: `true` if rbac resources should be created


### PR DESCRIPTION
In order to use AWS EKS IAM Roles for Service Accounts feature, one must annotate the service account to specify what IAM role admin wants to grant to that service account.

```yaml
apiVersion: v1
kind: ServiceAccount
metadata:
  annotations:
    eks.amazonaws.com/role-arn: arn:aws:iam::AWS_ACCOUNT_ID:role/IAM_ROLE_NAME
```