### PR TITLE
pkg/canary/daemonset: fix ready condition according to kubectl

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/aws/aws-sdk-go v1.29.29
 	github.com/davecgh/go-spew v1.1.1
 	github.com/google/go-cmp v0.4.0
+	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.5.1
 	github.com/stretchr/testify v1.5.1
 	go.uber.org/zap v1.14.1

--- a/pkg/canary/daemonset_ready_test.go
+++ b/pkg/canary/daemonset_ready_test.go
@@ -1,6 +1,7 @@
 package canary
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -24,39 +25,57 @@ func TestDaemonSetController_IsReady(t *testing.T) {
 }
 
 func TestDaemonSetController_isDaemonSetReady(t *testing.T) {
-	ds := &appsv1.DaemonSet{
-		Status: appsv1.DaemonSetStatus{
-			DesiredNumberScheduled: 1,
-			UpdatedNumberScheduled: 1,
-		},
-	}
-
-	cd := &flaggerv1.Canary{}
-	cd.Spec.ProgressDeadlineSeconds = int32p(1e5)
-	cd.Status.LastTransitionTime = metav1.Now()
-
-	// ready
 	mocks := newDaemonSetFixture()
-	_, err := mocks.controller.isDaemonSetReady(cd, ds)
+	cd := &flaggerv1.Canary{}
+
+	// observed generation is less than desired generation
+	ds := &appsv1.DaemonSet{Status: appsv1.DaemonSetStatus{}}
+	ds.Status.ObservedGeneration--
+	retyable, err := mocks.controller.isDaemonSetReady(cd, ds)
+	require.Error(t, err)
+	require.True(t, retyable)
+
+	// succeeded
+	ds = &appsv1.DaemonSet{Status: appsv1.DaemonSetStatus{
+		UpdatedNumberScheduled: 1,
+		DesiredNumberScheduled: 1,
+		NumberAvailable:        1,
+	}}
+	retyable, err = mocks.controller.isDaemonSetReady(cd, ds)
 	require.NoError(t, err)
+	require.True(t, retyable)
 
-	// not ready but retriable
-	ds.Status.NumberUnavailable++
-	retrieable, err := mocks.controller.isDaemonSetReady(cd, ds)
-	require.Error(t, err)
-	require.True(t, retrieable)
-	ds.Status.NumberUnavailable--
-
-	ds.Status.DesiredNumberScheduled++
-	retrieable, err = mocks.controller.isDaemonSetReady(cd, ds)
-	require.Error(t, err)
-	require.True(t, retrieable)
-
-	// not ready and not retriable
+	// deadline exceeded
+	ds = &appsv1.DaemonSet{Status: appsv1.DaemonSetStatus{
+		UpdatedNumberScheduled: 0,
+		DesiredNumberScheduled: 1,
+	}}
 	cd.Status.LastTransitionTime = metav1.Now()
-	cd.Spec.ProgressDeadlineSeconds = int32p(-1e5)
-	retrieable, err = mocks.controller.isDaemonSetReady(cd, ds)
+	cd.Spec.ProgressDeadlineSeconds = int32p(-1e6)
+	retyable, err = mocks.controller.isDaemonSetReady(cd, ds)
 	require.Error(t, err)
-	require.False(t, retrieable)
+	require.False(t, retyable)
 
+	// only newCond not satisfied
+	ds = &appsv1.DaemonSet{Status: appsv1.DaemonSetStatus{
+		UpdatedNumberScheduled: 0,
+		DesiredNumberScheduled: 1,
+		NumberAvailable:        1,
+	}}
+	cd.Spec.ProgressDeadlineSeconds = int32p(1e6)
+	retyable, err = mocks.controller.isDaemonSetReady(cd, ds)
+	require.Error(t, err)
+	require.True(t, retyable)
+	require.True(t, strings.Contains(err.Error(), "new pods"))
+
+	// only availableCond not satisfied
+	ds = &appsv1.DaemonSet{Status: appsv1.DaemonSetStatus{
+		UpdatedNumberScheduled: 1,
+		DesiredNumberScheduled: 1,
+		NumberAvailable:        0,
+	}}
+	retyable, err = mocks.controller.isDaemonSetReady(cd, ds)
+	require.Error(t, err)
+	require.True(t, retyable)
+	require.True(t, strings.Contains(err.Error(), "available"))
 }


### PR DESCRIPTION
not sure but hope this will solve #525 
___

fixed `isDaemonSetReady` function according to kubectl's [official implementation](https://github.com/kubernetes/kubernetes/blob/5232ad4a00ec93942d0b2c6359ee6cd1201b46bc/pkg/kubectl/rollout_status.go#L110)