### PR TITLE
pkg/{canary,controller}: remove unused skipLivenessChecks

### DIFF
--- a/pkg/canary/config_tracker_test.go
+++ b/pkg/canary/config_tracker_test.go
@@ -15,8 +15,7 @@ func TestConfigTracker_ConfigMaps(t *testing.T) {
 		configMap := newDeploymentControllerTestConfigMap()
 		configMapProjected := newDeploymentControllerTestConfigProjected()
 
-		err := mocks.controller.Initialize(mocks.canary, true)
-		require.NoError(t, err)
+		mocks.initializeCanary(t)
 
 		depPrimary, err := mocks.kubeClient.AppsV1().Deployments("default").Get("podinfo-primary", metav1.GetOptions{})
 		require.NoError(t, err)
@@ -53,7 +52,7 @@ func TestConfigTracker_ConfigMaps(t *testing.T) {
 		configMap := newDaemonSetControllerTestConfigMap()
 		configMapProjected := newDaemonSetControllerTestConfigProjected()
 
-		err := mocks.controller.Initialize(mocks.canary, true)
+		err := mocks.controller.Initialize(mocks.canary)
 		require.NoError(t, err)
 
 		depPrimary, err := mocks.kubeClient.AppsV1().DaemonSets("default").Get("podinfo-primary", metav1.GetOptions{})
@@ -93,8 +92,7 @@ func TestConfigTracker_Secrets(t *testing.T) {
 		secret := newDeploymentControllerTestSecret()
 		secretProjected := newDeploymentControllerTestSecretProjected()
 
-		err := mocks.controller.Initialize(mocks.canary, true)
-		require.NoError(t, err)
+		mocks.initializeCanary(t)
 
 		depPrimary, err := mocks.kubeClient.AppsV1().Deployments("default").Get("podinfo-primary", metav1.GetOptions{})
 		if assert.NoError(t, err) {
@@ -131,8 +129,7 @@ func TestConfigTracker_Secrets(t *testing.T) {
 		secret := newDaemonSetControllerTestSecret()
 		secretProjected := newDaemonSetControllerTestSecretProjected()
 
-		err := mocks.controller.Initialize(mocks.canary, true)
-		require.NoError(t, err)
+		mocks.controller.Initialize(mocks.canary)
 
 		daePrimary, err := mocks.kubeClient.AppsV1().DaemonSets("default").Get("podinfo-primary", metav1.GetOptions{})
 		if assert.NoError(t, err) {

--- a/pkg/canary/controller.go
+++ b/pkg/canary/controller.go
@@ -13,7 +13,7 @@ type Controller interface {
 	SetStatusWeight(canary *flaggerv1.Canary, val int) error
 	SetStatusIterations(canary *flaggerv1.Canary, val int) error
 	SetStatusPhase(canary *flaggerv1.Canary, phase flaggerv1.CanaryPhase) error
-	Initialize(canary *flaggerv1.Canary, skipLivenessChecks bool) error
+	Initialize(canary *flaggerv1.Canary) error
 	Promote(canary *flaggerv1.Canary) error
 	HasTargetChanged(canary *flaggerv1.Canary) (bool, error)
 	HaveDependenciesChanged(canary *flaggerv1.Canary) (bool, error)

--- a/pkg/canary/daemonset_controller.go
+++ b/pkg/canary/daemonset_controller.go
@@ -74,14 +74,14 @@ func (c *DaemonSetController) ScaleFromZero(cd *flaggerv1.Canary) error {
 
 // Initialize creates the primary DaemonSet, scales down the canary DaemonSet,
 // and returns the pod selector label and container ports
-func (c *DaemonSetController) Initialize(cd *flaggerv1.Canary, skipLivenessChecks bool) (err error) {
+func (c *DaemonSetController) Initialize(cd *flaggerv1.Canary) (err error) {
 	err = c.createPrimaryDaemonSet(cd)
 	if err != nil {
 		return fmt.Errorf("createPrimaryDaemonSet failed: %w", err)
 	}
 
 	if cd.Status.Phase == "" || cd.Status.Phase == flaggerv1.CanaryPhaseInitializing {
-		if !skipLivenessChecks && !cd.SkipAnalysis() {
+		if !cd.SkipAnalysis() {
 			if err := c.IsPrimaryReady(cd); err != nil {
 				return fmt.Errorf("IsPrimaryReady failed: %w", err)
 			}

--- a/pkg/canary/daemonset_controller_test.go
+++ b/pkg/canary/daemonset_controller_test.go
@@ -15,7 +15,7 @@ import (
 
 func TestDaemonSetController_Sync(t *testing.T) {
 	mocks := newDaemonSetFixture()
-	err := mocks.controller.Initialize(mocks.canary, true)
+	err := mocks.controller.Initialize(mocks.canary)
 	require.NoError(t, err)
 
 	daePrimary, err := mocks.kubeClient.AppsV1().DaemonSets("default").Get("podinfo-primary", metav1.GetOptions{})
@@ -29,7 +29,7 @@ func TestDaemonSetController_Sync(t *testing.T) {
 
 func TestDaemonSetController_Promote(t *testing.T) {
 	mocks := newDaemonSetFixture()
-	err := mocks.controller.Initialize(mocks.canary, true)
+	err := mocks.controller.Initialize(mocks.canary)
 	require.NoError(t, err)
 
 	dae2 := newDaemonSetControllerTestPodInfoV2()
@@ -60,7 +60,7 @@ func TestDaemonSetController_NoConfigTracking(t *testing.T) {
 	mocks := newDaemonSetFixture()
 	mocks.controller.configTracker = &NopTracker{}
 
-	err := mocks.controller.Initialize(mocks.canary, true)
+	err := mocks.controller.Initialize(mocks.canary)
 	require.NoError(t, err)
 
 	daePrimary, err := mocks.kubeClient.AppsV1().DaemonSets("default").Get("podinfo-primary", metav1.GetOptions{})
@@ -75,7 +75,7 @@ func TestDaemonSetController_NoConfigTracking(t *testing.T) {
 
 func TestDaemonSetController_HasTargetChanged(t *testing.T) {
 	mocks := newDaemonSetFixture()
-	err := mocks.controller.Initialize(mocks.canary, true)
+	err := mocks.controller.Initialize(mocks.canary)
 	require.NoError(t, err)
 
 	// save last applied hash
@@ -163,7 +163,7 @@ func TestDaemonSetController_HasTargetChanged(t *testing.T) {
 func TestDaemonSetController_Scale(t *testing.T) {
 	t.Run("ScaleToZero", func(t *testing.T) {
 		mocks := newDaemonSetFixture()
-		err := mocks.controller.Initialize(mocks.canary, true)
+		err := mocks.controller.Initialize(mocks.canary)
 		require.NoError(t, err)
 
 		err = mocks.controller.ScaleToZero(mocks.canary)
@@ -179,7 +179,7 @@ func TestDaemonSetController_Scale(t *testing.T) {
 	})
 	t.Run("ScaleFromZeo", func(t *testing.T) {
 		mocks := newDaemonSetFixture()
-		err := mocks.controller.Initialize(mocks.canary, true)
+		err := mocks.controller.Initialize(mocks.canary)
 		require.NoError(t, err)
 
 		err = mocks.controller.ScaleFromZero(mocks.canary)
@@ -197,7 +197,7 @@ func TestDaemonSetController_Scale(t *testing.T) {
 
 func TestDaemonSetController_Finalize(t *testing.T) {
 	mocks := newDaemonSetFixture()
-	err := mocks.controller.Initialize(mocks.canary, true)
+	err := mocks.controller.Initialize(mocks.canary)
 	require.NoError(t, err)
 
 	err = mocks.controller.Finalize(mocks.canary)

--- a/pkg/canary/daemonset_ready_test.go
+++ b/pkg/canary/daemonset_ready_test.go
@@ -4,7 +4,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -14,8 +13,8 @@ import (
 
 func TestDaemonSetController_IsReady(t *testing.T) {
 	mocks := newDaemonSetFixture()
-	err := mocks.controller.Initialize(mocks.canary, true)
-	assert.NoError(t, err, "Expected primary readiness check to fail")
+	err := mocks.controller.Initialize(mocks.canary)
+	require.NoError(t, err)
 
 	err = mocks.controller.IsPrimaryReady(mocks.canary)
 	require.NoError(t, err)

--- a/pkg/canary/daemonset_status_test.go
+++ b/pkg/canary/daemonset_status_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestDaemonSetController_SyncStatus(t *testing.T) {
 	mocks := newDaemonSetFixture()
-	err := mocks.controller.Initialize(mocks.canary, true)
+	err := mocks.controller.Initialize(mocks.canary)
 	require.NoError(t, err)
 
 	status := flaggerv1.CanaryStatus{
@@ -36,7 +36,7 @@ func TestDaemonSetController_SyncStatus(t *testing.T) {
 
 func TestDaemonSetController_SetFailedChecks(t *testing.T) {
 	mocks := newDaemonSetFixture()
-	err := mocks.controller.Initialize(mocks.canary, true)
+	err := mocks.controller.Initialize(mocks.canary)
 	require.NoError(t, err)
 
 	err = mocks.controller.SetStatusFailedChecks(mocks.canary, 1)
@@ -49,7 +49,7 @@ func TestDaemonSetController_SetFailedChecks(t *testing.T) {
 
 func TestDaemonSetController_SetState(t *testing.T) {
 	mocks := newDaemonSetFixture()
-	err := mocks.controller.Initialize(mocks.canary, true)
+	err := mocks.controller.Initialize(mocks.canary)
 	require.NoError(t, err)
 
 	err = mocks.controller.SetStatusPhase(mocks.canary, flaggerv1.CanaryPhaseProgressing)

--- a/pkg/canary/deployment_controller.go
+++ b/pkg/canary/deployment_controller.go
@@ -28,14 +28,14 @@ type DeploymentController struct {
 
 // Initialize creates the primary deployment, hpa,
 // scales to zero the canary deployment and returns the pod selector label and container ports
-func (c *DeploymentController) Initialize(cd *flaggerv1.Canary, skipLivenessChecks bool) (err error) {
+func (c *DeploymentController) Initialize(cd *flaggerv1.Canary) (err error) {
 	primaryName := fmt.Sprintf("%s-primary", cd.Spec.TargetRef.Name)
 	if err := c.createPrimaryDeployment(cd); err != nil {
 		return fmt.Errorf("createPrimaryDeployment failed: %w", err)
 	}
 
 	if cd.Status.Phase == "" || cd.Status.Phase == flaggerv1.CanaryPhaseInitializing {
-		if !skipLivenessChecks && !cd.SkipAnalysis() {
+		if !cd.SkipAnalysis() {
 			if err := c.IsPrimaryReady(cd); err != nil {
 				return fmt.Errorf("IsPrimaryReady failed: %w", err)
 			}

--- a/pkg/canary/deployment_ready_test.go
+++ b/pkg/canary/deployment_ready_test.go
@@ -8,12 +8,13 @@ import (
 
 func TestDeploymentController_IsReady(t *testing.T) {
 	mocks := newDeploymentFixture()
-	err := mocks.controller.Initialize(mocks.canary, true)
-	require.NoError(t, err, "Expected primary readiness check to fail")
+	mocks.controller.Initialize(mocks.canary)
 
-	err = mocks.controller.IsPrimaryReady(mocks.canary)
+	err := mocks.controller.IsPrimaryReady(mocks.canary)
 	require.Error(t, err)
 
 	_, err = mocks.controller.IsCanaryReady(mocks.canary)
 	require.NoError(t, err)
 }
+
+// TODO: more detailed tests as daemonset

--- a/pkg/canary/deployment_status_test.go
+++ b/pkg/canary/deployment_status_test.go
@@ -12,14 +12,13 @@ import (
 
 func TestDeploymentController_SyncStatus(t *testing.T) {
 	mocks := newDeploymentFixture()
-	err := mocks.controller.Initialize(mocks.canary, true)
-	require.NoError(t, err)
+	mocks.initializeCanary(t)
 
 	status := flaggerv1.CanaryStatus{
 		Phase:        flaggerv1.CanaryPhaseProgressing,
 		FailedChecks: 2,
 	}
-	err = mocks.controller.SyncStatus(mocks.canary, status)
+	err := mocks.controller.SyncStatus(mocks.canary, status)
 	require.NoError(t, err)
 
 	res, err := mocks.flaggerClient.FlaggerV1beta1().Canaries("default").Get("podinfo", metav1.GetOptions{})
@@ -36,10 +35,9 @@ func TestDeploymentController_SyncStatus(t *testing.T) {
 
 func TestDeploymentController_SetFailedChecks(t *testing.T) {
 	mocks := newDeploymentFixture()
-	err := mocks.controller.Initialize(mocks.canary, true)
-	require.NoError(t, err)
+	mocks.initializeCanary(t)
 
-	err = mocks.controller.SetStatusFailedChecks(mocks.canary, 1)
+	err := mocks.controller.SetStatusFailedChecks(mocks.canary, 1)
 	require.NoError(t, err)
 
 	res, err := mocks.flaggerClient.FlaggerV1beta1().Canaries("default").Get("podinfo", metav1.GetOptions{})
@@ -49,10 +47,9 @@ func TestDeploymentController_SetFailedChecks(t *testing.T) {
 
 func TestDeploymentController_SetState(t *testing.T) {
 	mocks := newDeploymentFixture()
-	err := mocks.controller.Initialize(mocks.canary, true)
-	require.NoError(t, err)
+	mocks.initializeCanary(t)
 
-	err = mocks.controller.SetStatusPhase(mocks.canary, flaggerv1.CanaryPhaseProgressing)
+	err := mocks.controller.SetStatusPhase(mocks.canary, flaggerv1.CanaryPhaseProgressing)
 	require.NoError(t, err)
 
 	res, err := mocks.flaggerClient.FlaggerV1beta1().Canaries("default").Get("podinfo", metav1.GetOptions{})

--- a/pkg/canary/service_controller.go
+++ b/pkg/canary/service_controller.go
@@ -47,7 +47,7 @@ func (c *ServiceController) GetMetadata(_ *flaggerv1.Canary) (string, map[string
 }
 
 // Initialize creates or updates the primary and canary services to prepare for the canary release process targeted on the K8s service
-func (c *ServiceController) Initialize(cd *flaggerv1.Canary, _ bool) (err error) {
+func (c *ServiceController) Initialize(cd *flaggerv1.Canary) (err error) {
 	targetName := cd.Spec.TargetRef.Name
 	primaryName := fmt.Sprintf("%s-primary", targetName)
 	canaryName := fmt.Sprintf("%s-canary", targetName)

--- a/pkg/controller/job.go
+++ b/pkg/controller/job.go
@@ -6,8 +6,7 @@ import "time"
 type CanaryJob struct {
 	Name             string
 	Namespace        string
-	SkipTests        bool
-	function         func(name string, namespace string, skipTests bool)
+	function         func(name string, namespace string)
 	done             chan bool
 	ticker           *time.Ticker
 	analysisInterval time.Duration
@@ -17,11 +16,11 @@ type CanaryJob struct {
 func (j CanaryJob) Start() {
 	go func() {
 		// run the infra bootstrap on job creation
-		j.function(j.Name, j.Namespace, j.SkipTests)
+		j.function(j.Name, j.Namespace)
 		for {
 			select {
 			case <-j.ticker.C:
-				j.function(j.Name, j.Namespace, j.SkipTests)
+				j.function(j.Name, j.Namespace)
 			case <-j.done:
 				return
 			}

--- a/pkg/controller/scheduler_daemonset_test.go
+++ b/pkg/controller/scheduler_daemonset_test.go
@@ -19,7 +19,7 @@ import (
 
 func TestScheduler_DaemonSetInit(t *testing.T) {
 	mocks := newDaemonSetFixture(nil)
-	mocks.ctrl.advanceCanary("podinfo", "default", true)
+	mocks.ctrl.advanceCanary("podinfo", "default")
 
 	_, err := mocks.kubeClient.AppsV1().DaemonSets("default").Get("podinfo-primary", metav1.GetOptions{})
 	require.NoError(t, err)
@@ -27,7 +27,7 @@ func TestScheduler_DaemonSetInit(t *testing.T) {
 
 func TestScheduler_DaemonSetNewRevision(t *testing.T) {
 	mocks := newDaemonSetFixture(nil)
-	mocks.ctrl.advanceCanary("podinfo", "default", true)
+	mocks.ctrl.advanceCanary("podinfo", "default")
 
 	// update
 	dae2 := newDaemonSetTestDaemonSetV2()
@@ -35,7 +35,7 @@ func TestScheduler_DaemonSetNewRevision(t *testing.T) {
 	require.NoError(t, err)
 
 	// detect changes
-	mocks.ctrl.advanceCanary("podinfo", "default", true)
+	mocks.ctrl.advanceCanary("podinfo", "default")
 
 	_, err = mocks.kubeClient.AppsV1().DaemonSets("default").Get("podinfo", metav1.GetOptions{})
 	require.NoError(t, err)
@@ -44,7 +44,7 @@ func TestScheduler_DaemonSetNewRevision(t *testing.T) {
 func TestScheduler_DaemonSetRollback(t *testing.T) {
 	mocks := newDaemonSetFixture(nil)
 	// init
-	mocks.ctrl.advanceCanary("podinfo", "default", true)
+	mocks.ctrl.advanceCanary("podinfo", "default")
 
 	// update failed checks to max
 	err := mocks.deployer.SyncStatus(mocks.canary, flaggerv1.CanaryStatus{Phase: flaggerv1.CanaryPhaseProgressing, FailedChecks: 10})
@@ -68,10 +68,10 @@ func TestScheduler_DaemonSetRollback(t *testing.T) {
 	require.NoError(t, err)
 
 	// run metric checks
-	mocks.ctrl.advanceCanary("podinfo", "default", true)
+	mocks.ctrl.advanceCanary("podinfo", "default")
 
 	// finalise analysis
-	mocks.ctrl.advanceCanary("podinfo", "default", true)
+	mocks.ctrl.advanceCanary("podinfo", "default")
 
 	// check status
 	c, err = mocks.flaggerClient.FlaggerV1beta1().Canaries("default").Get("podinfo", metav1.GetOptions{})
@@ -82,7 +82,7 @@ func TestScheduler_DaemonSetRollback(t *testing.T) {
 func TestScheduler_DaemonSetSkipAnalysis(t *testing.T) {
 	mocks := newDaemonSetFixture(nil)
 	// init
-	mocks.ctrl.advanceCanary("podinfo", "default", true)
+	mocks.ctrl.advanceCanary("podinfo", "default")
 
 	// enable skip
 	cd, err := mocks.flaggerClient.FlaggerV1beta1().Canaries("default").Get("podinfo", metav1.GetOptions{})
@@ -98,9 +98,9 @@ func TestScheduler_DaemonSetSkipAnalysis(t *testing.T) {
 	require.NoError(t, err)
 
 	// detect changes
-	mocks.ctrl.advanceCanary("podinfo", "default", true)
+	mocks.ctrl.advanceCanary("podinfo", "default")
 	// advance
-	mocks.ctrl.advanceCanary("podinfo", "default", true)
+	mocks.ctrl.advanceCanary("podinfo", "default")
 
 	c, err := mocks.flaggerClient.FlaggerV1beta1().Canaries("default").Get("podinfo", metav1.GetOptions{})
 	require.NoError(t, err)
@@ -111,7 +111,7 @@ func TestScheduler_DaemonSetSkipAnalysis(t *testing.T) {
 func TestScheduler_DaemonSetNewRevisionReset(t *testing.T) {
 	mocks := newDaemonSetFixture(nil)
 	// init
-	mocks.ctrl.advanceCanary("podinfo", "default", true)
+	mocks.ctrl.advanceCanary("podinfo", "default")
 
 	// first update
 	dae2 := newDaemonSetTestDaemonSetV2()
@@ -119,9 +119,9 @@ func TestScheduler_DaemonSetNewRevisionReset(t *testing.T) {
 	require.NoError(t, err)
 
 	// detect changes
-	mocks.ctrl.advanceCanary("podinfo", "default", true)
+	mocks.ctrl.advanceCanary("podinfo", "default")
 	// advance
-	mocks.ctrl.advanceCanary("podinfo", "default", true)
+	mocks.ctrl.advanceCanary("podinfo", "default")
 
 	primaryWeight, canaryWeight, mirrored, err := mocks.router.GetRoutes(mocks.canary)
 	require.NoError(t, err)
@@ -135,7 +135,7 @@ func TestScheduler_DaemonSetNewRevisionReset(t *testing.T) {
 	require.NoError(t, err)
 
 	// detect changes
-	mocks.ctrl.advanceCanary("podinfo", "default", true)
+	mocks.ctrl.advanceCanary("podinfo", "default")
 
 	primaryWeight, canaryWeight, mirrored, err = mocks.router.GetRoutes(mocks.canary)
 	require.NoError(t, err)
@@ -148,7 +148,7 @@ func TestScheduler_DaemonSetPromotion(t *testing.T) {
 	mocks := newDaemonSetFixture(nil)
 
 	// init
-	mocks.ctrl.advanceCanary("podinfo", "default", true)
+	mocks.ctrl.advanceCanary("podinfo", "default")
 
 	// check initialized status
 	c, err := mocks.flaggerClient.FlaggerV1beta1().Canaries("default").Get("podinfo", metav1.GetOptions{})
@@ -161,7 +161,7 @@ func TestScheduler_DaemonSetPromotion(t *testing.T) {
 	require.NoError(t, err)
 
 	// detect pod spec changes
-	mocks.ctrl.advanceCanary("podinfo", "default", true)
+	mocks.ctrl.advanceCanary("podinfo", "default")
 
 	config2 := newDaemonSetTestConfigMapV2()
 	_, err = mocks.kubeClient.CoreV1().ConfigMaps("default").Update(config2)
@@ -172,7 +172,7 @@ func TestScheduler_DaemonSetPromotion(t *testing.T) {
 	require.NoError(t, err)
 
 	// detect configs changes
-	mocks.ctrl.advanceCanary("podinfo", "default", true)
+	mocks.ctrl.advanceCanary("podinfo", "default")
 
 	primaryWeight, canaryWeight, mirrored, err := mocks.router.GetRoutes(mocks.canary)
 	require.NoError(t, err)
@@ -183,7 +183,7 @@ func TestScheduler_DaemonSetPromotion(t *testing.T) {
 	require.NoError(t, err)
 
 	// advance
-	mocks.ctrl.advanceCanary("podinfo", "default", true)
+	mocks.ctrl.advanceCanary("podinfo", "default")
 
 	// check progressing status
 	c, err = mocks.flaggerClient.FlaggerV1beta1().Canaries("default").Get("podinfo", metav1.GetOptions{})
@@ -191,7 +191,7 @@ func TestScheduler_DaemonSetPromotion(t *testing.T) {
 	assert.Equal(t, flaggerv1.CanaryPhaseProgressing, c.Status.Phase)
 
 	// promote
-	mocks.ctrl.advanceCanary("podinfo", "default", true)
+	mocks.ctrl.advanceCanary("podinfo", "default")
 
 	// check promoting status
 	c, err = mocks.flaggerClient.FlaggerV1beta1().Canaries("default").Get("podinfo", metav1.GetOptions{})
@@ -199,7 +199,7 @@ func TestScheduler_DaemonSetPromotion(t *testing.T) {
 	assert.Equal(t, flaggerv1.CanaryPhasePromoting, c.Status.Phase)
 
 	// finalise
-	mocks.ctrl.advanceCanary("podinfo", "default", true)
+	mocks.ctrl.advanceCanary("podinfo", "default")
 
 	primaryWeight, canaryWeight, mirrored, err = mocks.router.GetRoutes(mocks.canary)
 	require.NoError(t, err)
@@ -228,7 +228,7 @@ func TestScheduler_DaemonSetPromotion(t *testing.T) {
 	assert.Equal(t, flaggerv1.CanaryPhaseFinalising, c.Status.Phase)
 
 	// scale canary to zero
-	mocks.ctrl.advanceCanary("podinfo", "default", true)
+	mocks.ctrl.advanceCanary("podinfo", "default")
 
 	c, err = mocks.flaggerClient.FlaggerV1beta1().Canaries("default").Get("podinfo", metav1.GetOptions{})
 	require.NoError(t, err)
@@ -238,7 +238,7 @@ func TestScheduler_DaemonSetPromotion(t *testing.T) {
 func TestScheduler_DaemonSetMirroring(t *testing.T) {
 	mocks := newDaemonSetFixture(newDaemonSetTestCanaryMirror())
 	// init
-	mocks.ctrl.advanceCanary("podinfo", "default", true)
+	mocks.ctrl.advanceCanary("podinfo", "default")
 
 	// update
 	dae2 := newDaemonSetTestDaemonSetV2()
@@ -246,10 +246,10 @@ func TestScheduler_DaemonSetMirroring(t *testing.T) {
 	require.NoError(t, err)
 
 	// detect pod spec changes
-	mocks.ctrl.advanceCanary("podinfo", "default", true)
+	mocks.ctrl.advanceCanary("podinfo", "default")
 
 	// advance
-	mocks.ctrl.advanceCanary("podinfo", "default", true)
+	mocks.ctrl.advanceCanary("podinfo", "default")
 
 	// check if traffic is mirrored to canary
 	primaryWeight, canaryWeight, mirrored, err := mocks.router.GetRoutes(mocks.canary)
@@ -259,7 +259,7 @@ func TestScheduler_DaemonSetMirroring(t *testing.T) {
 	assert.True(t, mirrored)
 
 	// advance
-	mocks.ctrl.advanceCanary("podinfo", "default", true)
+	mocks.ctrl.advanceCanary("podinfo", "default")
 
 	// check if traffic is mirrored to canary
 	primaryWeight, canaryWeight, mirrored, err = mocks.router.GetRoutes(mocks.canary)
@@ -272,7 +272,7 @@ func TestScheduler_DaemonSetMirroring(t *testing.T) {
 func TestScheduler_DaemonSetABTesting(t *testing.T) {
 	mocks := newDaemonSetFixture(newDaemonSetTestCanaryAB())
 	// init
-	mocks.ctrl.advanceCanary("podinfo", "default", true)
+	mocks.ctrl.advanceCanary("podinfo", "default")
 
 	// update
 	dae2 := newDaemonSetTestDaemonSetV2()
@@ -280,10 +280,10 @@ func TestScheduler_DaemonSetABTesting(t *testing.T) {
 	require.NoError(t, err)
 
 	// detect pod spec changes
-	mocks.ctrl.advanceCanary("podinfo", "default", true)
+	mocks.ctrl.advanceCanary("podinfo", "default")
 
 	// advance
-	mocks.ctrl.advanceCanary("podinfo", "default", true)
+	mocks.ctrl.advanceCanary("podinfo", "default")
 
 	// check if traffic is routed to canary
 	primaryWeight, canaryWeight, mirrored, err := mocks.router.GetRoutes(mocks.canary)
@@ -300,10 +300,10 @@ func TestScheduler_DaemonSetABTesting(t *testing.T) {
 	require.NoError(t, err)
 
 	// advance
-	mocks.ctrl.advanceCanary("podinfo", "default", true)
+	mocks.ctrl.advanceCanary("podinfo", "default")
 
 	// finalising
-	mocks.ctrl.advanceCanary("podinfo", "default", true)
+	mocks.ctrl.advanceCanary("podinfo", "default")
 
 	// check finalising status
 	c, err := mocks.flaggerClient.FlaggerV1beta1().Canaries("default").Get("podinfo", metav1.GetOptions{})
@@ -319,7 +319,7 @@ func TestScheduler_DaemonSetABTesting(t *testing.T) {
 	assert.Equal(t, canaryImage, primaryImage)
 
 	// shutdown canary
-	mocks.ctrl.advanceCanary("podinfo", "default", true)
+	mocks.ctrl.advanceCanary("podinfo", "default")
 
 	// check rollout status
 	c, err = mocks.flaggerClient.FlaggerV1beta1().Canaries("default").Get("podinfo", metav1.GetOptions{})
@@ -337,7 +337,7 @@ func TestScheduler_DaemonSetPortDiscovery(t *testing.T) {
 	_, err = mocks.flaggerClient.FlaggerV1beta1().Canaries("default").Update(cd)
 	require.NoError(t, err)
 
-	mocks.ctrl.advanceCanary("podinfo", "default", true)
+	mocks.ctrl.advanceCanary("podinfo", "default")
 
 	canarySvc, err := mocks.kubeClient.CoreV1().Services("default").Get("podinfo-canary", metav1.GetOptions{})
 	require.NoError(t, err)
@@ -370,7 +370,7 @@ func TestScheduler_DaemonSetTargetPortNumber(t *testing.T) {
 	_, err = mocks.flaggerClient.FlaggerV1beta1().Canaries("default").Update(cd)
 	require.NoError(t, err)
 
-	mocks.ctrl.advanceCanary("podinfo", "default", true)
+	mocks.ctrl.advanceCanary("podinfo", "default")
 
 	canarySvc, err := mocks.kubeClient.CoreV1().Services("default").Get("podinfo-canary", metav1.GetOptions{})
 	require.NoError(t, err)
@@ -403,7 +403,7 @@ func TestScheduler_DaemonSetTargetPortName(t *testing.T) {
 	_, err = mocks.flaggerClient.FlaggerV1beta1().Canaries("default").Update(cd)
 	require.NoError(t, err)
 
-	mocks.ctrl.advanceCanary("podinfo", "default", true)
+	mocks.ctrl.advanceCanary("podinfo", "default")
 
 	canarySvc, err := mocks.kubeClient.CoreV1().Services("default").Get("podinfo-canary", metav1.GetOptions{})
 	require.NoError(t, err)
@@ -464,5 +464,5 @@ func TestScheduler_DaemonSetAlerts(t *testing.T) {
 	require.NoError(t, err)
 
 	// init canary and send alerts
-	mocks.ctrl.advanceCanary("podinfo", "default", true)
+	mocks.ctrl.advanceCanary("podinfo", "default")
 }

--- a/pkg/controller/scheduler_svc_test.go
+++ b/pkg/controller/scheduler_svc_test.go
@@ -14,7 +14,7 @@ func TestScheduler_ServicePromotion(t *testing.T) {
 	mocks := newDeploymentFixture(newTestServiceCanary())
 
 	// init
-	mocks.ctrl.advanceCanary("podinfo", "default", true)
+	mocks.ctrl.advanceCanary("podinfo", "default")
 
 	// check initialized status
 	c, err := mocks.flaggerClient.FlaggerV1beta1().Canaries("default").Get("podinfo", metav1.GetOptions{})
@@ -27,7 +27,7 @@ func TestScheduler_ServicePromotion(t *testing.T) {
 	require.NoError(t, err)
 
 	// detect service spec changes
-	mocks.ctrl.advanceCanary("podinfo", "default", true)
+	mocks.ctrl.advanceCanary("podinfo", "default")
 
 	primaryWeight, canaryWeight, mirrored, err := mocks.router.GetRoutes(mocks.canary)
 	require.NoError(t, err)
@@ -38,7 +38,7 @@ func TestScheduler_ServicePromotion(t *testing.T) {
 	require.NoError(t, err)
 
 	// advance
-	mocks.ctrl.advanceCanary("podinfo", "default", true)
+	mocks.ctrl.advanceCanary("podinfo", "default")
 
 	// check progressing status
 	c, err = mocks.flaggerClient.FlaggerV1beta1().Canaries("default").Get("podinfo", metav1.GetOptions{})
@@ -46,7 +46,7 @@ func TestScheduler_ServicePromotion(t *testing.T) {
 	assert.Equal(t, flaggerv1.CanaryPhaseProgressing, c.Status.Phase)
 
 	// promote
-	mocks.ctrl.advanceCanary("podinfo", "default", true)
+	mocks.ctrl.advanceCanary("podinfo", "default")
 
 	// check promoting status
 	c, err = mocks.flaggerClient.FlaggerV1beta1().Canaries("default").Get("podinfo", metav1.GetOptions{})
@@ -54,7 +54,7 @@ func TestScheduler_ServicePromotion(t *testing.T) {
 	assert.Equal(t, flaggerv1.CanaryPhasePromoting, c.Status.Phase)
 
 	// finalise
-	mocks.ctrl.advanceCanary("podinfo", "default", true)
+	mocks.ctrl.advanceCanary("podinfo", "default")
 
 	primaryWeight, canaryWeight, mirrored, err = mocks.router.GetRoutes(mocks.canary)
 	require.NoError(t, err)
@@ -75,7 +75,7 @@ func TestScheduler_ServicePromotion(t *testing.T) {
 	assert.Equal(t, flaggerv1.CanaryPhaseFinalising, c.Status.Phase)
 
 	// scale canary to zero
-	mocks.ctrl.advanceCanary("podinfo", "default", true)
+	mocks.ctrl.advanceCanary("podinfo", "default")
 
 	c, err = mocks.flaggerClient.FlaggerV1beta1().Canaries("default").Get("podinfo", metav1.GetOptions{})
 	require.NoError(t, err)


### PR DESCRIPTION
I realized that `skipLivenessChecks bool` (which equals to `job.SkipTests`) has been always set to be false and it's not necessary. 

So this PR deleted it and fixed tests accordingly 
___

P.S. I think we'd better use gomock of `canary.Controller` and `mesh.Router` interface in order to simplify tests in controller package. Currently they are like small e2e tests and deeply connected with internal implementations of these interfaces, which make it harder for developers who want to contribute to Flagger to understand the internal functionality.