### PR TITLE
pkg/router: update ingress API to networking.k8s.io/v1beta1

### DIFF
--- a/artifacts/flagger/account.yaml
+++ b/artifacts/flagger/account.yaml
@@ -33,7 +33,8 @@ rules:
       - horizontalpodautoscalers
     verbs: ["*"]
   - apiGroups:
-      - "extensions"
+      - extensions
+      - networking.k8s.io
     resources:
       - ingresses
       - ingresses/status

--- a/charts/flagger/templates/rbac.yaml
+++ b/charts/flagger/templates/rbac.yaml
@@ -29,7 +29,8 @@ rules:
       - horizontalpodautoscalers
     verbs: ["*"]
   - apiGroups:
-      - "extensions"
+      - extensions
+      - networking.k8s.io
     resources:
       - ingresses
       - ingresses/status

--- a/docs/gitbook/tutorials/nginx-progressive-delivery.md
+++ b/docs/gitbook/tutorials/nginx-progressive-delivery.md
@@ -6,7 +6,7 @@ This guide shows you how to use the NGINX ingress controller and Flagger to auto
 
 ## Prerequisites
 
-Flagger requires a Kubernetes cluster **v1.11** or newer and NGINX ingress **0.24** or newer.
+Flagger requires a Kubernetes cluster **v1.14** or newer and NGINX ingress **0.24** or newer.
 
 Install NGINX with Helm v3:
 
@@ -69,7 +69,7 @@ helm upgrade -i flagger-loadtester flagger/loadtester \
 Create an ingress definition \(replace `app.example.com` with your own domain\):
 
 ```yaml
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: podinfo
@@ -111,7 +111,7 @@ spec:
     name: podinfo
   # ingress reference
   ingressRef:
-    apiVersion: extensions/v1beta1
+    apiVersion: networking.k8s.io/v1beta1
     kind: Ingress
     name: podinfo
   # HPA reference (optional)

--- a/kustomize/base/flagger/rbac.yaml
+++ b/kustomize/base/flagger/rbac.yaml
@@ -23,7 +23,8 @@ rules:
       - horizontalpodautoscalers
     verbs: ["*"]
   - apiGroups:
-      - "extensions"
+      - extensions
+      - networking.k8s.io
     resources:
       - ingresses
       - ingresses/status

--- a/pkg/router/ingress.go
+++ b/pkg/router/ingress.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"go.uber.org/zap"
-	"k8s.io/api/extensions/v1beta1"
+	"k8s.io/api/networking/v1beta1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -31,7 +31,7 @@ func (i *IngressRouter) Reconcile(canary *flaggerv1.Canary) error {
 	canaryName := fmt.Sprintf("%s-canary", apexName)
 	canaryIngressName := fmt.Sprintf("%s-canary", canary.Spec.IngressRef.Name)
 
-	ingress, err := i.kubeClient.ExtensionsV1beta1().Ingresses(canary.Namespace).Get(canary.Spec.IngressRef.Name, metav1.GetOptions{})
+	ingress, err := i.kubeClient.NetworkingV1beta1().Ingresses(canary.Namespace).Get(canary.Spec.IngressRef.Name, metav1.GetOptions{})
 	if err != nil {
 		return fmt.Errorf("ingress %s.%s get query error: %w", canary.Spec.IngressRef.Name, canary.Namespace, err)
 	}
@@ -54,7 +54,7 @@ func (i *IngressRouter) Reconcile(canary *flaggerv1.Canary) error {
 		return fmt.Errorf("backend %s not found in ingress %s", apexName, canary.Spec.IngressRef.Name)
 	}
 
-	canaryIngress, err := i.kubeClient.ExtensionsV1beta1().Ingresses(canary.Namespace).Get(canaryIngressName, metav1.GetOptions{})
+	canaryIngress, err := i.kubeClient.NetworkingV1beta1().Ingresses(canary.Namespace).Get(canaryIngressName, metav1.GetOptions{})
 
 	if errors.IsNotFound(err) {
 		ing := &v1beta1.Ingress{
@@ -74,7 +74,7 @@ func (i *IngressRouter) Reconcile(canary *flaggerv1.Canary) error {
 			Spec: ingressClone.Spec,
 		}
 
-		_, err := i.kubeClient.ExtensionsV1beta1().Ingresses(canary.Namespace).Create(ing)
+		_, err := i.kubeClient.NetworkingV1beta1().Ingresses(canary.Namespace).Create(ing)
 		if err != nil {
 			return fmt.Errorf("ingress %s.%s create error: %w", ing.Name, ing.Namespace, err)
 		}
@@ -90,7 +90,7 @@ func (i *IngressRouter) Reconcile(canary *flaggerv1.Canary) error {
 		iClone := canaryIngress.DeepCopy()
 		iClone.Spec = ingressClone.Spec
 
-		_, err := i.kubeClient.ExtensionsV1beta1().Ingresses(canary.Namespace).Update(iClone)
+		_, err := i.kubeClient.NetworkingV1beta1().Ingresses(canary.Namespace).Update(iClone)
 		if err != nil {
 			return fmt.Errorf("ingress %s.%s update error: %w", canaryIngressName, iClone.Namespace, err)
 		}
@@ -109,7 +109,7 @@ func (i *IngressRouter) GetRoutes(canary *flaggerv1.Canary) (
 	err error,
 ) {
 	canaryIngressName := fmt.Sprintf("%s-canary", canary.Spec.IngressRef.Name)
-	canaryIngress, err := i.kubeClient.ExtensionsV1beta1().Ingresses(canary.Namespace).Get(canaryIngressName, metav1.GetOptions{})
+	canaryIngress, err := i.kubeClient.NetworkingV1beta1().Ingresses(canary.Namespace).Get(canaryIngressName, metav1.GetOptions{})
 	if err != nil {
 		err = fmt.Errorf("ingress %s.%s get query error: %w", canaryIngressName, canary.Namespace, err)
 		return
@@ -150,7 +150,7 @@ func (i *IngressRouter) SetRoutes(
 	_ bool,
 ) error {
 	canaryIngressName := fmt.Sprintf("%s-canary", canary.Spec.IngressRef.Name)
-	canaryIngress, err := i.kubeClient.ExtensionsV1beta1().Ingresses(canary.Namespace).Get(canaryIngressName, metav1.GetOptions{})
+	canaryIngress, err := i.kubeClient.NetworkingV1beta1().Ingresses(canary.Namespace).Get(canaryIngressName, metav1.GetOptions{})
 	if err != nil {
 		return fmt.Errorf("ingress %s.%s get query error: %w", canaryIngressName, canary.Namespace, err)
 	}
@@ -184,7 +184,7 @@ func (i *IngressRouter) SetRoutes(
 		iClone.Annotations = i.makeAnnotations(iClone.Annotations)
 	}
 
-	_, err = i.kubeClient.ExtensionsV1beta1().Ingresses(canary.Namespace).Update(iClone)
+	_, err = i.kubeClient.NetworkingV1beta1().Ingresses(canary.Namespace).Update(iClone)
 	if err != nil {
 		return fmt.Errorf("ingress %s.%s update error %v", iClone.Name, iClone.Namespace, err)
 	}

--- a/pkg/router/ingress_test.go
+++ b/pkg/router/ingress_test.go
@@ -25,7 +25,7 @@ func TestIngressRouter_Reconcile(t *testing.T) {
 	canaryWeightAn := "custom.ingress.kubernetes.io/canary-weight"
 
 	canaryName := fmt.Sprintf("%s-canary", mocks.ingressCanary.Spec.IngressRef.Name)
-	inCanary, err := router.kubeClient.ExtensionsV1beta1().Ingresses("default").Get(canaryName, metav1.GetOptions{})
+	inCanary, err := router.kubeClient.NetworkingV1beta1().Ingresses("default").Get(canaryName, metav1.GetOptions{})
 	require.NoError(t, err)
 
 	// test initialisation
@@ -58,7 +58,7 @@ func TestIngressRouter_GetSetRoutes(t *testing.T) {
 	canaryWeightAn := "prefix1.nginx.ingress.kubernetes.io/canary-weight"
 
 	canaryName := fmt.Sprintf("%s-canary", mocks.ingressCanary.Spec.IngressRef.Name)
-	inCanary, err := router.kubeClient.ExtensionsV1beta1().Ingresses("default").Get(canaryName, metav1.GetOptions{})
+	inCanary, err := router.kubeClient.NetworkingV1beta1().Ingresses("default").Get(canaryName, metav1.GetOptions{})
 	require.NoError(t, err)
 
 	// test rollout
@@ -72,7 +72,7 @@ func TestIngressRouter_GetSetRoutes(t *testing.T) {
 	err = router.SetRoutes(mocks.ingressCanary, p, c, m)
 	require.NoError(t, err)
 
-	inCanary, err = router.kubeClient.ExtensionsV1beta1().Ingresses("default").Get(canaryName, metav1.GetOptions{})
+	inCanary, err = router.kubeClient.NetworkingV1beta1().Ingresses("default").Get(canaryName, metav1.GetOptions{})
 	require.NoError(t, err)
 
 	// test promotion

--- a/pkg/router/router_test.go
+++ b/pkg/router/router_test.go
@@ -4,7 +4,7 @@ import (
 	"go.uber.org/zap"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/api/extensions/v1beta1"
+	"k8s.io/api/networking/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/kubernetes"

--- a/test/e2e-ingress.yaml
+++ b/test/e2e-ingress.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: podinfo

--- a/test/e2e-nginx-tests.sh
+++ b/test/e2e-nginx-tests.sh
@@ -30,7 +30,7 @@ spec:
     kind: Deployment
     name: podinfo
   ingressRef:
-    apiVersion: extensions/v1beta1
+    apiVersion: networking.k8s.io/v1beta1
     kind: Ingress
     name: podinfo
   progressDeadlineSeconds: 60
@@ -167,7 +167,7 @@ spec:
     kind: Deployment
     name: podinfo
   ingressRef:
-    apiVersion: extensions/v1beta1
+    apiVersion: networking.k8s.io/v1beta1
     kind: Ingress
     name: podinfo
   progressDeadlineSeconds: 60


### PR DESCRIPTION
Changes:
- use `networking.k8s.io/v1beta1` in ingress router
- update unit tests, end-to-end tests and docs to `networking.k8s.io/v1beta1`

**Breaking change**: drop compatibility with Kubernetes 1.13.

Fix: #533 