### PR TITLE
loadtester: set write timeout

### DIFF
--- a/charts/loadtester/Chart.yaml
+++ b/charts/loadtester/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: loadtester
-version: 0.14.0
-appVersion: 0.14.0
+version: 0.15.0
+appVersion: 0.15.0
 kubeVersion: ">=1.11.0-0"
 engine: gotpl
 description: Flagger's load testing services based on rakyll/hey and bojand/ghz that generates traffic during canary analysis when configured as a webhook.

--- a/charts/loadtester/values.yaml
+++ b/charts/loadtester/values.yaml
@@ -2,7 +2,7 @@ replicaCount: 1
 
 image:
   repository: weaveworks/flagger-loadtester
-  tag: 0.14.0
+  tag: 0.15.0
   pullPolicy: IfNotPresent
 
 podAnnotations:

--- a/cmd/loadtester/main.go
+++ b/cmd/loadtester/main.go
@@ -11,7 +11,7 @@ import (
 	"go.uber.org/zap"
 )
 
-var VERSION = "0.14.0"
+var VERSION = "0.15.0"
 var (
 	logLevel          string
 	port              string

--- a/kustomize/tester/deployment.yaml
+++ b/kustomize/tester/deployment.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
         - name: loadtester
-          image: weaveworks/flagger-loadtester:0.14.0
+          image: weaveworks/flagger-loadtester:0.15.0
           imagePullPolicy: IfNotPresent
           ports:
             - name: http

--- a/pkg/loadtester/server.go
+++ b/pkg/loadtester/server.go
@@ -342,7 +342,7 @@ func ListenAndServe(port string, timeout time.Duration, logger *zap.SugaredLogge
 		Addr:         ":" + port,
 		Handler:      mux,
 		ReadTimeout:  5 * time.Second,
-		WriteTimeout: 1 * time.Minute,
+		WriteTimeout: timeout,
 		IdleTimeout:  15 * time.Second,
 	}
 


### PR DESCRIPTION
Set the HTTP server write timeout to allow `pre-rollout` hooks that take longer than 1m, fix: #527