### PR TITLE
rbac: add finalizers to RBAC rules

### DIFF
--- a/artifacts/flagger/account.yaml
+++ b/artifacts/flagger/account.yaml
@@ -18,27 +18,61 @@ rules:
     resources:
       - events
       - configmaps
+      - configmaps/finalizers
       - secrets
+      - secrets/finalizers
       - services
-    verbs: ["*"]
+      - services/finalizers
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
   - apiGroups:
       - apps
     resources:
       - daemonsets
+      - daemonsets/finalizers
       - deployments
-    verbs: ["*"]
+      - deployments/finalizers
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
   - apiGroups:
       - autoscaling
     resources:
       - horizontalpodautoscalers
-    verbs: ["*"]
+      - horizontalpodautoscalers/finalizers
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
   - apiGroups:
       - extensions
       - networking.k8s.io
     resources:
       - ingresses
-      - ingresses/status
-    verbs: ["*"]
+      - ingresses/finalizers
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
   - apiGroups:
       - flagger.app
     resources:
@@ -48,50 +82,98 @@ rules:
       - metrictemplates/status
       - alertproviders
       - alertproviders/status
-    verbs: ["*"]
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
   - apiGroups:
       - networking.istio.io
     resources:
       - virtualservices
-      - virtualservices/status
+      - virtualservices/finalizers
       - destinationrules
-      - destinationrules/status
-    verbs: ["*"]
+      - destinationrules/finalizers
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
   - apiGroups:
       - appmesh.k8s.aws
     resources:
-      - meshes
-      - meshes/status
       - virtualnodes
-      - virtualnodes/status
+      - virtualnodes/finalizers
       - virtualservices
-      - virtualservices/status
-    verbs: ["*"]
+      - virtualservices/finalizers
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
   - apiGroups:
       - split.smi-spec.io
     resources:
       - trafficsplits
-    verbs: ["*"]
+      - trafficsplits/finalizers
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - specs.smi-spec.io
+    resources:
+      - httproutegroups
+      - httproutegroups/finalizers
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
   - apiGroups:
       - gloo.solo.io
     resources:
-      - settings
       - upstreams
+      - upstreams/finalizers
       - upstreamgroups
-      - proxies
-      - virtualservices
-    verbs: ["*"]
-  - apiGroups:
-      - gateway.solo.io
-    resources:
-      - virtualservices
-      - gateways
-    verbs: ["*"]
+      - upstreamgroups/finalizers
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
   - apiGroups:
       - projectcontour.io
     resources:
       - httpproxies
-    verbs: ["*"]
+      - httpproxies/finalizers
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
   - nonResourceURLs:
       - /version
     verbs:

--- a/charts/flagger/templates/rbac.yaml
+++ b/charts/flagger/templates/rbac.yaml
@@ -14,27 +14,61 @@ rules:
     resources:
       - events
       - configmaps
+      - configmaps/finalizers
       - secrets
+      - secrets/finalizers
       - services
-    verbs: ["*"]
+      - services/finalizers
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
   - apiGroups:
       - apps
     resources:
       - daemonsets
+      - daemonsets/finalizers
       - deployments
-    verbs: ["*"]
+      - deployments/finalizers
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
   - apiGroups:
       - autoscaling
     resources:
       - horizontalpodautoscalers
-    verbs: ["*"]
+      - horizontalpodautoscalers/finalizers
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
   - apiGroups:
       - extensions
       - networking.k8s.io
     resources:
       - ingresses
-      - ingresses/status
-    verbs: ["*"]
+      - ingresses/finalizers
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
   - apiGroups:
       - flagger.app
     resources:
@@ -44,50 +78,98 @@ rules:
       - metrictemplates/status
       - alertproviders
       - alertproviders/status
-    verbs: ["*"]
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
   - apiGroups:
       - networking.istio.io
     resources:
       - virtualservices
-      - virtualservices/status
+      - virtualservices/finalizers
       - destinationrules
-      - destinationrules/status
-    verbs: ["*"]
+      - destinationrules/finalizers
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
   - apiGroups:
       - appmesh.k8s.aws
     resources:
-      - meshes
-      - meshes/status
       - virtualnodes
-      - virtualnodes/status
+      - virtualnodes/finalizers
       - virtualservices
-      - virtualservices/status
-    verbs: ["*"]
+      - virtualservices/finalizers
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
   - apiGroups:
       - split.smi-spec.io
     resources:
       - trafficsplits
-    verbs: ["*"]
+      - trafficsplits/finalizers
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - specs.smi-spec.io
+    resources:
+      - httproutegroups
+      - httproutegroups/finalizers
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
   - apiGroups:
       - gloo.solo.io
     resources:
-      - settings
       - upstreams
+      - upstreams/finalizers
       - upstreamgroups
-      - proxies
-      - virtualservices
-    verbs: ["*"]
-  - apiGroups:
-      - gateway.solo.io
-    resources:
-      - virtualservices
-      - gateways
-    verbs: ["*"]
+      - upstreamgroups/finalizers
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
   - apiGroups:
       - projectcontour.io
     resources:
       - httpproxies
-    verbs: ["*"]
+      - httpproxies/finalizers
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
   - nonResourceURLs:
       - /version
     verbs:

--- a/kustomize/base/flagger/rbac.yaml
+++ b/kustomize/base/flagger/rbac.yaml
@@ -8,27 +8,61 @@ rules:
     resources:
       - events
       - configmaps
+      - configmaps/finalizers
       - secrets
+      - secrets/finalizers
       - services
-    verbs: ["*"]
+      - services/finalizers
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
   - apiGroups:
       - apps
     resources:
       - daemonsets
+      - daemonsets/finalizers
       - deployments
-    verbs: ["*"]
+      - deployments/finalizers
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
   - apiGroups:
       - autoscaling
     resources:
       - horizontalpodautoscalers
-    verbs: ["*"]
+      - horizontalpodautoscalers/finalizers
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
   - apiGroups:
       - extensions
       - networking.k8s.io
     resources:
       - ingresses
-      - ingresses/status
-    verbs: ["*"]
+      - ingresses/finalizers
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
   - apiGroups:
       - flagger.app
     resources:
@@ -38,50 +72,98 @@ rules:
       - metrictemplates/status
       - alertproviders
       - alertproviders/status
-    verbs: ["*"]
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
   - apiGroups:
       - networking.istio.io
     resources:
       - virtualservices
-      - virtualservices/status
+      - virtualservices/finalizers
       - destinationrules
-      - destinationrules/status
-    verbs: ["*"]
+      - destinationrules/finalizers
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
   - apiGroups:
       - appmesh.k8s.aws
     resources:
-      - meshes
-      - meshes/status
       - virtualnodes
-      - virtualnodes/status
+      - virtualnodes/finalizers
       - virtualservices
-      - virtualservices/status
-    verbs: ["*"]
+      - virtualservices/finalizers
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
   - apiGroups:
       - split.smi-spec.io
     resources:
       - trafficsplits
-    verbs: ["*"]
+      - trafficsplits/finalizers
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - specs.smi-spec.io
+    resources:
+      - httproutegroups
+      - httproutegroups/finalizers
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
   - apiGroups:
       - gloo.solo.io
     resources:
-      - settings
       - upstreams
+      - upstreams/finalizers
       - upstreamgroups
-      - proxies
-      - virtualservices
-    verbs: ["*"]
-  - apiGroups:
-      - gateway.solo.io
-    resources:
-      - virtualservices
-      - gateways
-    verbs: ["*"]
+      - upstreamgroups/finalizers
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
   - apiGroups:
       - projectcontour.io
     resources:
       - httpproxies
-    verbs: ["*"]
+      - httpproxies/finalizers
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
   - nonResourceURLs:
       - /version
     verbs:


### PR DESCRIPTION
This PR adds the finalizers sub-resource to Flagger's RBAC rules and expands the verbs sections.

Fix: #505