### PR TITLE
chart: allow security context to be disabled on OpenShift

### DIFF
--- a/charts/flagger/templates/deployment.yaml
+++ b/charts/flagger/templates/deployment.yaml
@@ -50,9 +50,10 @@ spec:
         {{- end }}
       containers:
         - name: flagger
+          {{- if .Values.securityContext.enabled }}
           securityContext:
-            readOnlyRootFilesystem: true
-            runAsUser: 10001
+{{ toYaml .Values.securityContext.context | indent 12 }}
+          {{- end }}
           volumeMounts:
             {{- if .Values.istio.kubeconfig.secretName }}
             - name: kubeconfig

--- a/charts/flagger/values.yaml
+++ b/charts/flagger/values.yaml
@@ -30,6 +30,14 @@ selectorLabels: ""
 configTracking:
   enabled: true
 
+# when enabled, it will add a security context for the flagger pod. You may
+# need to disable this if you are running flagger on OpenShift
+securityContext:
+  enabled: true
+  context:
+    readOnlyRootFilesystem: true
+    runAsUser: 10001
+
 # when specified, flagger will publish events to the provided webhook
 eventWebhook: ""
 


### PR DESCRIPTION
A work in progress for changes to make running flagger on OpenShift easier.

Relates To: #542 