### PR TITLE
Implement NGINX ingress header regex matching

### DIFF
--- a/docs/gitbook/SUMMARY.md
+++ b/docs/gitbook/SUMMARY.md
@@ -29,7 +29,7 @@
 * [Contour Canary Deployments](tutorials/contour-progressive-delivery.md)
 * [Blue/Green Deployments](tutorials/kubernetes-blue-green.md)
 * [Crossover Canary Deployments](tutorials/crossover-progressive-delivery.md)
-* [SMI Istio Canary Deployments](tutorials/flagger-smi-istio.md)
+* [Canary analysis with Prometheus Operator](tutorials/prometheus-operator.md)
 * [Canaries with Helm charts and GitOps](tutorials/canary-helm-gitops.md)
 * [Zero downtime deployments](tutorials/zero-downtime-deployments.md)
 

--- a/pkg/router/ingress.go
+++ b/pkg/router/ingress.go
@@ -166,11 +166,8 @@ func (i *IngressRouter) SetRoutes(
 					cookie = v.Exact
 				} else {
 					header = k
-					if v.Regex != "" {
-						headerRegex = v.Regex
-					} else {
-						headerValue = v.Exact
-					}
+					headerRegex = v.Regex
+					headerValue = v.Exact
 				}
 			}
 		}
@@ -206,7 +203,6 @@ func (i *IngressRouter) makeAnnotations(annotations map[string]string) map[strin
 	}
 
 	res[i.GetAnnotationWithPrefix("canary")] = "false"
-	res[i.GetAnnotationWithPrefix("canary-weight")] = "0"
 
 	return res
 }
@@ -221,7 +217,6 @@ func (i *IngressRouter) makeHeaderAnnotations(annotations map[string]string,
 	}
 
 	res[i.GetAnnotationWithPrefix("canary")] = "true"
-	res[i.GetAnnotationWithPrefix("canary-weight")] = "0"
 
 	if cookie != "" {
 		res[i.GetAnnotationWithPrefix("canary-by-cookie")] = cookie

--- a/pkg/router/ingress_test.go
+++ b/pkg/router/ingress_test.go
@@ -25,7 +25,6 @@ func TestIngressRouter_Reconcile(t *testing.T) {
 	require.NoError(t, err)
 
 	canaryAn := "custom.ingress.kubernetes.io/canary"
-	canaryWeightAn := "custom.ingress.kubernetes.io/canary-weight"
 
 	canaryName := fmt.Sprintf("%s-canary", mocks.ingressCanary.Spec.IngressRef.Name)
 	inCanary, err := router.kubeClient.NetworkingV1beta1().Ingresses("default").Get(canaryName, metav1.GetOptions{})
@@ -33,7 +32,6 @@ func TestIngressRouter_Reconcile(t *testing.T) {
 
 	// test initialisation
 	assert.Equal(t, "false", inCanary.Annotations[canaryAn])
-	assert.Equal(t, "0", inCanary.Annotations[canaryWeightAn])
 }
 
 func TestIngressRouter_GetSetRoutes(t *testing.T) {
@@ -80,7 +78,6 @@ func TestIngressRouter_GetSetRoutes(t *testing.T) {
 
 	// test promotion
 	assert.Equal(t, "false", inCanary.Annotations[canaryAn])
-	assert.Equal(t, "0", inCanary.Annotations[canaryWeightAn])
 }
 
 func TestIngressRouter_ABTest(t *testing.T) {

--- a/pkg/router/ingress_test.go
+++ b/pkg/router/ingress_test.go
@@ -6,8 +6,11 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	flaggerv1 "github.com/weaveworks/flagger/pkg/apis/flagger/v1beta1"
+	istiov1alpha1 "github.com/weaveworks/flagger/pkg/apis/istio/common/v1alpha1"
+	istiov1alpha3 "github.com/weaveworks/flagger/pkg/apis/istio/v1alpha3"
 )
 
 func TestIngressRouter_Reconcile(t *testing.T) {
@@ -78,4 +81,89 @@ func TestIngressRouter_GetSetRoutes(t *testing.T) {
 	// test promotion
 	assert.Equal(t, "false", inCanary.Annotations[canaryAn])
 	assert.Equal(t, "0", inCanary.Annotations[canaryWeightAn])
+}
+
+func TestIngressRouter_ABTest(t *testing.T) {
+	mocks := newFixture(nil)
+	router := &IngressRouter{
+		logger:            mocks.logger,
+		kubeClient:        mocks.kubeClient,
+		annotationsPrefix: "nginx.ingress.kubernetes.io",
+	}
+
+	tables := []struct {
+		makeCanary func() *flaggerv1.Canary
+		annotation string
+	}{
+		// Header exact match
+		{
+			makeCanary: func() *flaggerv1.Canary {
+				mocks.ingressCanary.Spec.Analysis.Iterations = 1
+				mocks.ingressCanary.Spec.Analysis.Match = []istiov1alpha3.HTTPMatchRequest{
+					{
+						Headers: map[string]istiov1alpha1.StringMatch{
+							"x-user-type": {
+								Exact: "test",
+							},
+						},
+					},
+				}
+				return mocks.ingressCanary
+			},
+			annotation: router.GetAnnotationWithPrefix("canary-by-header-value"),
+		},
+		// Header regex match
+		{
+			makeCanary: func() *flaggerv1.Canary {
+				mocks.ingressCanary.Spec.Analysis.Iterations = 1
+				mocks.ingressCanary.Spec.Analysis.Match = []istiov1alpha3.HTTPMatchRequest{
+					{
+						Headers: map[string]istiov1alpha1.StringMatch{
+							"x-user-type": {
+								Regex: "test",
+							},
+						},
+					},
+				}
+				return mocks.ingressCanary
+			},
+			annotation: router.GetAnnotationWithPrefix("canary-by-header-pattern"),
+		},
+		// Cookie exact match
+		{
+			makeCanary: func() *flaggerv1.Canary {
+				mocks.ingressCanary.Spec.Analysis.Iterations = 1
+				mocks.ingressCanary.Spec.Analysis.Match = []istiov1alpha3.HTTPMatchRequest{
+					{
+						Headers: map[string]istiov1alpha1.StringMatch{
+							"cookie": {
+								Exact: "test",
+							},
+						},
+					},
+				}
+				return mocks.ingressCanary
+			},
+			annotation: router.GetAnnotationWithPrefix("canary-by-cookie"),
+		},
+	}
+
+	for _, table := range tables {
+		err := router.Reconcile(table.makeCanary())
+		require.NoError(t, err)
+
+		err = router.SetRoutes(table.makeCanary(), 50, 50, false)
+		require.NoError(t, err)
+
+		canaryAn := router.GetAnnotationWithPrefix("canary")
+
+		canaryName := fmt.Sprintf("%s-canary", table.makeCanary().Spec.IngressRef.Name)
+		inCanary, err := router.kubeClient.NetworkingV1beta1().Ingresses("default").Get(canaryName, metav1.GetOptions{})
+		require.NoError(t, err)
+
+		// test initialisation
+		assert.Equal(t, "true", inCanary.Annotations[canaryAn])
+		assert.Equal(t, "test", inCanary.Annotations[table.annotation])
+	}
+
 }

--- a/test/e2e-nginx.sh
+++ b/test/e2e-nginx.sh
@@ -3,7 +3,7 @@
 set -o errexit
 
 REPO_ROOT=$(git rev-parse --show-toplevel)
-NGINX_HELM_VERSION=1.34.2 # ingress v0.30.0
+NGINX_HELM_VERSION=1.34.3 # ingress v0.30.0
 
 echo '>>> Installing NGINX Ingress'
 kubectl create ns ingress-nginx


### PR DESCRIPTION
This PR allows specifying a header regex expression in the canary analysis that will translate to `canary-by-header-pattern` annotation on the canary ingress object.

Example:

```yaml
apiVersion: flagger.app/v1beta1
kind: Canary
spec:
  ingressRef:
    apiVersion: networking.k8s.io/v1beta1
    kind: Ingress
    name: podinfo
  analysis:
    match:
    - headers:
        x-user:
          regex: ".*insider.*"
```

Note that the `canary-by-header-pattern` feature is not yet released but it's scheduled for v0.31.0 https://github.com/kubernetes/ingress-nginx/pull/5114

Fix: #545 