### PR TITLE
remove unnecessary dependency on k/utils

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,6 @@ require (
 	k8s.io/apimachinery v0.18.0
 	k8s.io/client-go v0.18.0
 	k8s.io/code-generator v0.18.0
-	k8s.io/utils v0.0.0-20200324210504-a9aa75ae1b89
 )
 
 replace k8s.io/klog => github.com/stefanprodan/klog v0.0.0-20190418165334-9cbb78b20423

--- a/pkg/controller/webhook.go
+++ b/pkg/controller/webhook.go
@@ -12,8 +12,6 @@ import (
 	"strconv"
 	"time"
 
-	"k8s.io/utils/clock"
-
 	flaggerv1 "github.com/weaveworks/flagger/pkg/apis/flagger/v1beta1"
 )
 
@@ -86,7 +84,7 @@ func CallWebhook(name string, namespace string, phase flaggerv1.CanaryPhase, w f
 }
 
 func CallEventWebhook(r *flaggerv1.Canary, webhook, message, eventtype string) error {
-	t := clock.RealClock{}.Now()
+	t := time.Now()
 
 	payload := flaggerv1.CanaryWebhookPayload{
 		Name:      r.Name,


### PR DESCRIPTION
`RealClock` is just a wrapper over the `time` from stdlib.

I believe K8s uses it for testing and overriding purposes. It's not required in flagger's contexts.