### PR TITLE
controller: fix deployment alerts unit test

### DIFF
--- a/pkg/controller/scheduler_deployment_test.go
+++ b/pkg/controller/scheduler_deployment_test.go
@@ -613,6 +613,12 @@ func TestScheduler_DeploymentAlerts(t *testing.T) {
 	_, err := mocks.kubeClient.CoreV1().Secrets("default").Update(context.TODO(), secret, metav1.UpdateOptions{})
 	require.NoError(t, err)
 
-	// init canary and send alerts
+	// init canary
+	mocks.ctrl.advanceCanary("podinfo", "default")
+
+	// make primary ready
+	mocks.makePrimaryReady(t)
+
+	// initialization done - now send alert
 	mocks.ctrl.advanceCanary("podinfo", "default")
 }


### PR DESCRIPTION
I was going through the scheduler tests for deployments, and noticed this test.  This makes the primary ready in the TestScheduler_DeploymentAlerts test in order to send out an alert.  Previously, it did not reach a state to send an alert.