### PR TITLE
broken link in tutorials section of gitbook

### DIFF
--- a/docs/gitbook/README.md
+++ b/docs/gitbook/README.md
@@ -44,4 +44,4 @@ After install Flagger, you can follow one of the tutorials:
 
 * [Istio](https://github.com/stefanprodan/gitops-istio)
 * [Linkerd](https://helm.workshop.flagger.dev)
-* [AWS App Mesh](https://eks.hands-on.flagger.dev)
+* [AWS App Mesh](https://eks.handson.flagger.dev)


### PR DESCRIPTION
This change removes an errant hyphen in the link to the AWS App Mesh tutorial in the "Hands-on GitOps workshops" section of the gitbook. This broken link is also live on flagger.app.

Signed-off-by: Jesse Butler <butlerjl@amazon.com>