### PR TITLE
Release v1.0.0-rc.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,34 @@
 
 All notable changes to this project are documented in this file.
 
+## 1.0.0-rc.5 (2020-05-14) 
+
+This is a release candidate for Flagger v1.0.0.
+
+The upgrade procedure from 0.x to 1.0 can be found [here](https://docs.flagger.app/dev/upgrade-guide).
+
+#### Features
+
+- Add support for AWS AppMesh v1beta2 API
+    [#584](https://github.com/weaveworks/flagger/pull/584)
+- Add support for Contour v1.4 ingress class
+    [#588](https://github.com/weaveworks/flagger/pull/588)
+- Add user-specified labels/annotations to the generated Services
+    [#538](https://github.com/weaveworks/flagger/pull/538)
+
+#### Improvements
+
+- Support compatible Prometheus service
+    [#557](https://github.com/weaveworks/flagger/pull/557)
+- Update e2e tests and packages to Kubernetes v1.18
+    [#549](https://github.com/weaveworks/flagger/pull/549)
+    [#576](https://github.com/weaveworks/flagger/pull/576)
+
+#### Fixes
+
+- pkg/controller: retry canary initialization on conflict
+    [#586](https://github.com/weaveworks/flagger/pull/586)
+
 ## 1.0.0-rc.4 (2020-04-03) 
 
 This is a release candidate for Flagger v1.0.0.

--- a/artifacts/flagger/deployment.yaml
+++ b/artifacts/flagger/deployment.yaml
@@ -22,7 +22,7 @@ spec:
       serviceAccountName: flagger
       containers:
       - name: flagger
-        image: weaveworks/flagger:1.0.0-rc.4
+        image: weaveworks/flagger:1.0.0-rc.5
         imagePullPolicy: IfNotPresent
         ports:
         - name: http

--- a/charts/flagger/Chart.yaml
+++ b/charts/flagger/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: flagger
 version: 0.27.0
-appVersion: 1.0.0-rc.4
+appVersion: 1.0.0-rc.5
 kubeVersion: ">=1.11.0-0"
 engine: gotpl
 description: Flagger is a progressive delivery operator for Kubernetes
@@ -19,5 +19,7 @@ keywords:
   - appmesh
   - linkerd
   - gloo
+  - contour
+  - nginx
   - gitops
   - canary

--- a/charts/flagger/values.yaml
+++ b/charts/flagger/values.yaml
@@ -2,7 +2,7 @@
 
 image:
   repository: weaveworks/flagger
-  tag: 1.0.0-rc.4
+  tag: 1.0.0-rc.5
   pullPolicy: IfNotPresent
   pullSecret:
 
@@ -121,7 +121,7 @@ tolerations: []
 prometheus:
   # to be used with ingress controllers
   install: false
-  image: docker.io/prom/prometheus:v2.17.1
+  image: docker.io/prom/prometheus:v2.18.1
 
 #  Istio multi-cluster service mesh (shared control plane single-network)
 # https://istio.io/docs/setup/install/multicluster/shared-vpn/

--- a/docs/gitbook/dev/upgrade-guide.md
+++ b/docs/gitbook/dev/upgrade-guide.md
@@ -14,6 +14,7 @@ Canary CRD changes in `canaries.flagger.app/v1beta1`:
 * the `metric.query` field has been deprecated and replaced with `metric.templateRef`
 * the `spec.ingressRef.apiVersion` accepts `networking.k8s.io/v1beta1`
 * the `spec.targetRef` can reference `DaemonSet` kind
+* the `spec.service.meshName` field has been deprecated and no longer used for `provider: appmesh:v1beta2`
 
 Upgrade procedure:
 * install the `v1beta1` CRDs

--- a/docs/gitbook/tutorials/contour-progressive-delivery.md
+++ b/docs/gitbook/tutorials/contour-progressive-delivery.md
@@ -24,7 +24,7 @@ kubectl apply -k github.com/weaveworks/flagger//kustomize/contour
 
 The above command will deploy Flagger and Prometheus configured to scrape the Contour's Envoy instances.
 
-Or you can install Flagger using Helm:
+Or you can install Flagger using Helm v3:
 
 ```bash
 helm repo add flagger https://flagger.app
@@ -32,6 +32,7 @@ helm repo add flagger https://flagger.app
 helm upgrade -i flagger flagger/flagger \
 --namespace projectcontour \
 --set meshProvider=contour \
+--set ingressClass=contour \
 --set prometheus.install=true
 ```
 

--- a/docs/gitbook/usage/how-it-works.md
+++ b/docs/gitbook/usage/how-it-works.md
@@ -150,7 +150,30 @@ This ensures that traffic to `podinfo.test:9898` will be routed to the latest st
 The `podinfo-canary.test:9898` address is available only during the 
 canary analysis and can be used for conformance testing or load testing.
 
-Besides the port mapping, the service specification can contain URI match and rewrite rules,
+You can configure Flagger to set annotations and labels for the generated services with:
+
+```yaml
+spec:
+  service:
+    port: 9898
+    apex:
+      annotations:
+        test: "test"
+      labels:
+        test: "test"
+    canary:
+      annotations:
+        test: "test"
+      labels:
+        test: "test"
+    primary:
+      annotations:
+        test: "test"
+      labels:
+        test: "test"
+```
+
+Besides port mapping and metadata, the service specification can contain URI match and rewrite rules,
 timeout and retry polices:
 
 ```yaml

--- a/kustomize/base/flagger/kustomization.yaml
+++ b/kustomize/base/flagger/kustomization.yaml
@@ -8,4 +8,4 @@ resources:
   - deployment.yaml
 images:
   - name: weaveworks/flagger
-    newTag: 1.0.0-rc.4
+    newTag: 1.0.0-rc.5

--- a/kustomize/base/prometheus/deployment.yaml
+++ b/kustomize/base/prometheus/deployment.yaml
@@ -19,7 +19,7 @@ spec:
       serviceAccountName: flagger-prometheus
       containers:
           - name: prometheus
-            image: prom/prometheus:v2.17.1
+            image: prom/prometheus:v2.18.1
             imagePullPolicy: IfNotPresent
             args:
               - '--storage.tsdb.retention=2h'

--- a/kustomize/contour/patch.yaml
+++ b/kustomize/contour/patch.yaml
@@ -10,6 +10,7 @@ spec:
           args:
             - -log-level=info
             - -mesh-provider=contour
+            - -ingress-class=contour
             - -metrics-server=http://flagger-prometheus:9090
             - -slack-user=flagger
             - -slack-channel=

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,4 +1,4 @@
 package version
 
-var VERSION = "1.0.0-rc.4"
+var VERSION = "1.0.0-rc.5"
 var REVISION = "unknown"


### PR DESCRIPTION
#### Features

- Add support for AWS AppMesh v1beta2 API
- Add support for Contour v1.4 ingress class
- Add user-specified labels/annotations to the generated Services

#### Improvements

- Support compatible Prometheus service
- Update e2e tests and packages to Kubernetes v1.18

#### Fixes

- pkg/controller: retry canary initialization on conflict