### PR TITLE
istio: Add source labels to analysis matching rules

### DIFF
--- a/artifacts/flagger/crd.yaml
+++ b/artifacts/flagger/crd.yaml
@@ -599,8 +599,15 @@ spec:
                               format: string
                               type: string
                             regex:
+                              description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax)
                               format: string
                               type: string
+                      sourceLabels:
+                        description: Applicable only when the 'mesh' gateway is included in the service.gateways list
+                        type: object
+                        additionalProperties:
+                          format: string
+                          type: string
                 metrics:
                   description: Metric check list for this canary
                   type: array

--- a/charts/flagger/crds/crd.yaml
+++ b/charts/flagger/crds/crd.yaml
@@ -599,8 +599,15 @@ spec:
                               format: string
                               type: string
                             regex:
+                              description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax)
                               format: string
                               type: string
+                      sourceLabels:
+                        description: Applicable only when the 'mesh' gateway is included in the service.gateways list
+                        type: object
+                        additionalProperties:
+                          format: string
+                          type: string
                 metrics:
                   description: Metric check list for this canary
                   type: array

--- a/docs/gitbook/usage/deployment-strategies.md
+++ b/docs/gitbook/usage/deployment-strategies.md
@@ -159,6 +159,34 @@ And the time it takes for a canary to be rollback when the metrics or webhook ch
 interval * threshold 
 ```
 
+Istio example:
+
+```yaml
+  analysis:
+    interval: 1m
+    threshold: 10
+    iterations: 2
+    match:
+      - headers:
+          x-canary:
+            exact: "insider"
+      - headers:
+          cookie:
+            regex: "^(.*?;)?(canary=always)(;.*)?$"
+      - sourceLabels:
+          app.kubernetes.io/name: "scheduler"
+```
+
+The header keys must be lowercase and use hyphen as the separator.
+Header values are case-sensitive and formatted as follows:
+- `exact: "value"` for exact string match
+- `prefix: "value"` for prefix-based match
+- `suffix: "value"` for suffix-based match
+- `regex: "value"` for [RE2](https://github.com/google/re2/wiki/Syntax) style regex-based match
+
+Note that the `sourceLabels` match conditions are applicable only when the `mesh` gateway
+is included in the `canary.service.gateways` list.
+
 App Mesh example:
 
 ```yaml
@@ -205,7 +233,8 @@ NGINX example:
             exact: "canary"
 ```
 
-Note that the NGINX ingress controller supports only exact matching for a single header and the cookie value is set to `always`.
+Note that the NGINX ingress controller supports only exact matching for cookies names where the value must be set to `always`.
+Starting with NGINX ingress v0.31, regex matching is supported for header values.
 
 The above configurations will route users with the x-canary header or canary cookie to the canary instance during analysis:
 

--- a/kustomize/base/flagger/crd.yaml
+++ b/kustomize/base/flagger/crd.yaml
@@ -599,8 +599,15 @@ spec:
                               format: string
                               type: string
                             regex:
+                              description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax)
                               format: string
                               type: string
+                      sourceLabels:
+                        description: Applicable only when the 'mesh' gateway is included in the service.gateways list
+                        type: object
+                        additionalProperties:
+                          format: string
+                          type: string
                 metrics:
                   description: Metric check list for this canary
                   type: array

--- a/test/e2e-istio.sh
+++ b/test/e2e-istio.sh
@@ -2,7 +2,7 @@
 
 set -o errexit
 
-ISTIO_VER="1.5.2"
+ISTIO_VER="1.5.4"
 REPO_ROOT=$(git rev-parse --show-toplevel)
 
 echo ">>> Downloading Istio ${ISTIO_VER}"


### PR DESCRIPTION
This PR adds the `sourceLabels` filed to the Canary CRD. This allows running an A/B test using source labels matches when a service is attached to the Istio `mesh` gateway.

Example:

```yaml
kind: Canary
metadata:
  name: backend
spec:
  provider: istio
  service:
    port: 9898
    gateways:
      - mesh
  analysis:
    interval: 15s
    threshold: 10
    iterations: 10
    match:
    - sourceLabels:
        app: frontend
```

Fix: #580

For testing update the CRD with `kubectl apply -f https://raw.githubusercontent.com/weaveworks/flagger/istio-source-labels/artifacts/flagger/crd.yaml` before using sourceLabels.