### PR TITLE
support podinfo charts canary enable/disable transition

### DIFF
--- a/charts/podinfo/templates/canary.yaml
+++ b/charts/podinfo/templates/canary.yaml
@@ -9,6 +9,7 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
+  revertOnDeletion: true
   targetRef:
     apiVersion: apps/v1
     kind: Deployment

--- a/charts/podinfo/templates/pdb.yaml
+++ b/charts/podinfo/templates/pdb.yaml
@@ -1,5 +1,5 @@
-apiVersion: v1
-kind: Service
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
 metadata:
   name: {{ template "podinfo.fullname" . }}
   labels:
@@ -8,11 +8,7 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
-  type: {{ .Values.service.type }}
-  ports:
-    - port: {{ .Values.service.port }}
-      targetPort: http
-      protocol: TCP
-      name: http
+  maxUnavailable: {{ .Values.pdb }}
   selector:
-    app: {{ template "podinfo.fullname" . }}
+    matchLabels:
+      app: {{ template "podinfo.fullname" . }}{{ if .Values.canary.enabled }}-primary{{ end }}

--- a/charts/podinfo/values.yaml
+++ b/charts/podinfo/values.yaml
@@ -11,6 +11,8 @@ service:
   type: ClusterIP
   port: 9898
 
+pdb: 1
+
 hpa:
   enabled: true
   minReplicas: 2


### PR DESCRIPTION
by enabling finalizer and always declare service so helm do not stay stuck.

Also adding a flagger compatible PDB.