### PR TITLE
Rephrasing Canary Progressing message

### DIFF
--- a/docs/gitbook/tutorials/appmesh-progressive-delivery.md
+++ b/docs/gitbook/tutorials/appmesh-progressive-delivery.md
@@ -304,7 +304,7 @@ When the number of failed checks reaches the canary analysis threshold, the traf
 ```text
 kubectl -n appmesh-system logs deploy/flagger -f | jq .msg
 
-New revision detected! Starting canary analysis for podinfo.test
+New revision detected! progressing canary analysis for podinfo.test
 Pre-rollout check acceptance-test passed
 Advance podinfo.test canary weight 5
 Advance podinfo.test canary weight 10
@@ -374,7 +374,7 @@ Flagger detects that the deployment revision changed and starts the A/B test:
 ```text
 kubectl -n appmesh-system logs deploy/flagger -f | jq .msg
 
-New revision detected! Starting canary analysis for podinfo.test
+New revision detected! progressing canary analysis for podinfo.test
 Advance podinfo.test canary iteration 1/10
 Advance podinfo.test canary iteration 2/10
 Advance podinfo.test canary iteration 3/10

--- a/docs/gitbook/tutorials/contour-progressive-delivery.md
+++ b/docs/gitbook/tutorials/contour-progressive-delivery.md
@@ -319,7 +319,7 @@ the canary is scaled to zero and the rollout is marked as failed.
 ```text
 kubectl -n projectcontour logs deploy/flagger -f | jq .msg
 
-New revision detected! Starting canary analysis for podinfo.test
+New revision detected! progressing canary analysis for podinfo.test
 Pre-rollout check acceptance-test passed
 Advance podinfo.test canary weight 5
 Advance podinfo.test canary weight 10
@@ -392,7 +392,7 @@ Flagger detects that the deployment revision changed and starts the A/B test:
 ```text
 kubectl -n projectcontour logs deploy/flagger -f | jq .msg
 
-New revision detected! Starting canary analysis for podinfo.test
+New revision detected! Progressing canary analysis for podinfo.test
 Advance podinfo.test canary iteration 1/10
 Advance podinfo.test canary iteration 2/10
 Advance podinfo.test canary iteration 3/10

--- a/docs/gitbook/tutorials/crossover-progressive-delivery.md
+++ b/docs/gitbook/tutorials/crossover-progressive-delivery.md
@@ -337,7 +337,7 @@ the canary is scaled to zero and the rollout is marked as failed.
 ```text
 kubectl -n test logs deploy/flagger -f | jq .msg
 
-New revision detected! Starting canary analysis for podinfo.test
+New revision detected! progressing canary analysis for podinfo.test
 Pre-rollout check acceptance-test passed
 Advance podinfo.test canary weight 5
 Advance podinfo.test canary weight 10

--- a/pkg/canary/status.go
+++ b/pkg/canary/status.go
@@ -193,7 +193,7 @@ func MakeStatusConditions(cd *flaggerv1.Canary,
 		message = "Waiting for approval."
 	case flaggerv1.CanaryPhaseProgressing:
 		status = corev1.ConditionUnknown
-		message = "New revision detected, starting canary analysis."
+		message = "New revision detected, progressing canary analysis."
 	case flaggerv1.CanaryPhasePromoting:
 		status = corev1.ConditionUnknown
 		message = "Canary analysis completed, starting primary rolling update."

--- a/pkg/controller/scheduler.go
+++ b/pkg/controller/scheduler.go
@@ -718,7 +718,7 @@ func (c *Controller) checkCanaryStatus(canary *flaggerv1.Canary, canaryControlle
 		canaryPhaseProgressing := canary.DeepCopy()
 		canaryPhaseProgressing.Status.Phase = flaggerv1.CanaryPhaseProgressing
 		c.recordEventInfof(canaryPhaseProgressing, "New revision detected! Scaling up %s.%s", canaryPhaseProgressing.Spec.TargetRef.Name, canaryPhaseProgressing.Namespace)
-		c.alert(canaryPhaseProgressing, "New revision detected, starting canary analysis.",
+		c.alert(canaryPhaseProgressing, "New revision detected, progressing canary analysis.",
 			true, flaggerv1.SeverityInfo)
 
 		if err := canaryController.ScaleFromZero(canary); err != nil {


### PR DESCRIPTION
If applied, this commit will change the Canary Progressing state message
Using "progressing" instead of "starting" clarifies that the rollout is ongoing.

Fixes #606.

Also fixed the alert message to keep it consistent with the message,
along with the documentation.