### PR TITLE
Release load tester v0.17.0

### DIFF
--- a/Dockerfile.loadtester
+++ b/Dockerfile.loadtester
@@ -5,12 +5,12 @@ RUN apk --no-cache add alpine-sdk perl curl
 RUN curl -sSLo hey "https://storage.googleapis.com/hey-release/hey_linux_amd64" && \
 chmod +x hey && mv hey /usr/local/bin/hey
 
-RUN HELM2_VERSION=2.16.5 && \
+RUN HELM2_VERSION=2.16.8 && \
 curl -sSL "https://get.helm.sh/helm-v${HELM2_VERSION}-linux-amd64.tar.gz" | tar xvz && \
 chmod +x linux-amd64/helm && mv linux-amd64/helm /usr/local/bin/helm && \
 chmod +x linux-amd64/tiller && mv linux-amd64/tiller /usr/local/bin/tiller
 
-RUN HELM3_VERSION=3.1.2 && \
+RUN HELM3_VERSION=3.2.3 && \
 curl -sSL "https://get.helm.sh/helm-v${HELM3_VERSION}-linux-amd64.tar.gz" | tar xvz && \
 chmod +x linux-amd64/helm && mv linux-amd64/helm /usr/local/bin/helmv3
 

--- a/charts/loadtester/Chart.yaml
+++ b/charts/loadtester/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: loadtester
-version: 0.16.0
-appVersion: 0.16.0
+version: 0.17.0
+appVersion: 0.17.0
 kubeVersion: ">=1.11.0-0"
 engine: gotpl
 description: Flagger's load testing services based on rakyll/hey and bojand/ghz that generates traffic during canary analysis when configured as a webhook.

--- a/charts/loadtester/README.md
+++ b/charts/loadtester/README.md
@@ -1,8 +1,9 @@
 # Flagger load testing service
 
 [Flagger's](https://github.com/weaveworks/flagger) load testing service is based on 
-[rakyll/hey](https://github.com/rakyll/hey) 
-and can be used to generates traffic during canary analysis when configured as a webhook.
+[rakyll/hey](https://github.com/rakyll/hey) and 
+[bojand/ghz](https://github.com/bojand/ghz).
+It can be used to generate HTTP and gRPC traffic during canary analysis when configured as a webhook.
 
 ## Prerequisites
 
@@ -24,7 +25,8 @@ helm upgrade -i flagger-loadtester flagger/loadtester
 
 The command deploys loadtester on the Kubernetes cluster in the default namespace.
 
-> **Tip**: Note that the namespace where you deploy the load tester should have the Istio or App Mesh sidecar injection enabled
+> **Tip**: Note that the namespace where you deploy the load tester should
+> have the Istio, App Mesh or Linkerd sidecar injection enabled
 
 The [configuration](#configuration) section lists the parameters that can be configured during installation.
 
@@ -33,7 +35,7 @@ The [configuration](#configuration) section lists the parameters that can be con
 To uninstall/delete the `flagger-loadtester` deployment:
 
 ```console
-helm delete --purge flagger-loadtester
+helm delete flagger-loadtester
 ```
 
 The command removes all the Kubernetes components associated with the chart and deletes the release.
@@ -58,13 +60,16 @@ Parameter | Description | Default
 `service.port` | ClusterIP port | `80`
 `cmd.timeout` | Command execution timeout | `1h`
 `logLevel` | Log level can be debug, info, warning, error or panic | `info`
-`meshName` | AWS App Mesh name | `none`
-`backends` | AWS App Mesh virtual services | `none`
+`appmesh.enabled` | Create AWS App Mesh v1beta2 virtual node | `false`
+`appmesh.backends` | AWS App Mesh virtual services | `none`
 
-Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
+Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade`. For example,
 
 ```console
-helm install flagger/loadtester --name flagger-loadtester
+helm upgrade -i flagger-loadtester flagger/loadtester \
+--set "appmesh.enabled=true" \
+--set "appmesh.backends[0]=podinfo" \
+--set "appmesh.backends[1]=podinfo-canary"
 ```
 
 Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the chart. For example,

--- a/charts/loadtester/templates/appmesh.yaml
+++ b/charts/loadtester/templates/appmesh.yaml
@@ -1,0 +1,27 @@
+{{- if .Values.appmesh.enabled }}
+apiVersion: appmesh.k8s.aws/v1beta2
+kind: VirtualNode
+metadata:
+  name: {{ include "loadtester.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "loadtester.name" . }}
+    helm.sh/chart: {{ include "loadtester.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  podSelector:
+    matchLabels:
+      app: {{ include "loadtester.name" . }}
+  logging:
+    accessLog:
+      file:
+        path: /dev/stdout
+  {{- if .Values.appmesh.backends }}
+  backends:
+    {{- range .Values.appmesh.backends }}
+    - virtualService:
+        virtualServiceRef:
+          name: {{ . }}
+    {{- end }}
+  {{- end }}
+{{- end }}

--- a/charts/loadtester/values.yaml
+++ b/charts/loadtester/values.yaml
@@ -2,7 +2,7 @@ replicaCount: 1
 
 image:
   repository: weaveworks/flagger-loadtester
-  tag: 0.15.0
+  tag: 0.17.0
   pullPolicy: IfNotPresent
 
 podAnnotations:
@@ -47,8 +47,15 @@ rbac:
 # name of an existing service account to use - if not creating rbac resources
 serviceAccountName: ""
 
-# App Mesh virtual node settings
+# App Mesh virtual node settings (to be used for AppMesh v1beta1)
 meshName: ""
 #backends:
 #  - app1.namespace
 #  - app2.namespace
+
+# App Mesh virtual node settings (to be used for AppMesh v1beta2)
+appmesh:
+  enabled: false
+  backends:
+  - podinfo
+  - podinfo-canary

--- a/cmd/loadtester/main.go
+++ b/cmd/loadtester/main.go
@@ -11,7 +11,7 @@ import (
 	"go.uber.org/zap"
 )
 
-var VERSION = "0.16.0"
+var VERSION = "0.17.0"
 var (
 	logLevel          string
 	port              string

--- a/kustomize/tester/deployment.yaml
+++ b/kustomize/tester/deployment.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
         - name: loadtester
-          image: weaveworks/flagger-loadtester:0.16.0
+          image: weaveworks/flagger-loadtester:0.17.0
           imagePullPolicy: IfNotPresent
           ports:
             - name: http


### PR DESCRIPTION
Changes:
- Update load tester Helm binaries (v2.16.8 and v3.2.3)
- Add AppMesh v1beta2 virtual node definition to Helm chart
