### PR TITLE
Release v1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,36 @@
 
 All notable changes to this project are documented in this file.
 
+## 1.0.0 (2020-06-17) 
+
+This is the GA release for Flagger v1.0.0.
+
+The upgrade procedure from 0.x to 1.0 can be found [here](https://docs.flagger.app/dev/upgrade-guide).
+
+Two new resources were added to the API: `MetricTemplate` and `AlertProvider`.
+The analysis can reference [metric templates](https://docs.flagger.app//usage/metrics#custom-metrics)
+to query Prometheus, Datadog and AWS CloudWatch.
+[Alerting](https://docs.flagger.app/v/master/usage/alerting#canary-configuration) can be configured on a per
+canary basis for Slack, MS Teams, Discord and Rocket.
+
+#### Features
+
+- Implement progressive promotion
+    [#593](https://github.com/weaveworks/flagger/pull/593)
+
+#### Improvements
+
+- istio: Add source labels to analysis matching rules
+    [#594](https://github.com/weaveworks/flagger/pull/594)
+- istio: Add allow origins field to CORS spec
+    [#604](https://github.com/weaveworks/flagger/pull/604)
+- istio: Change builtin metrics to work with Istio telemetry v2
+    [#623](https://github.com/weaveworks/flagger/pull/623)
+- appmesh: Implement App Mesh v1beta2 timeout
+    [#611](https://github.com/weaveworks/flagger/pull/611)
+- metrics: Check metrics server availability during canary initialization
+    [#592](https://github.com/weaveworks/flagger/pull/592)
+
 ## 1.0.0-rc.5 (2020-05-14) 
 
 This is a release candidate for Flagger v1.0.0.

--- a/artifacts/flagger/deployment.yaml
+++ b/artifacts/flagger/deployment.yaml
@@ -22,7 +22,7 @@ spec:
       serviceAccountName: flagger
       containers:
       - name: flagger
-        image: weaveworks/flagger:1.0.0-rc.5
+        image: weaveworks/flagger:1.0.0
         imagePullPolicy: IfNotPresent
         ports:
         - name: http

--- a/charts/flagger/Chart.yaml
+++ b/charts/flagger/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: flagger
-version: 0.27.0
-appVersion: 1.0.0-rc.5
+version: 1.0.0
+appVersion: 1.0.0
 kubeVersion: ">=1.11.0-0"
 engine: gotpl
 description: Flagger is a progressive delivery operator for Kubernetes

--- a/charts/flagger/README.md
+++ b/charts/flagger/README.md
@@ -51,7 +51,7 @@ To install Flagger for **AWS App Mesh**:
 ```console
 $ helm upgrade -i flagger flagger/flagger \
     --namespace=appmesh-system \
-    --set meshProvider=appmesh \
+    --set meshProvider=appmesh:v1beta2 \
     --set metricsServer=http://appmesh-prometheus:9090
 ```
 

--- a/charts/flagger/values.yaml
+++ b/charts/flagger/values.yaml
@@ -2,7 +2,7 @@
 
 image:
   repository: weaveworks/flagger
-  tag: 1.0.0-rc.5
+  tag: 1.0.0
   pullPolicy: IfNotPresent
   pullSecret:
 

--- a/kustomize/base/flagger/kustomization.yaml
+++ b/kustomize/base/flagger/kustomization.yaml
@@ -8,4 +8,4 @@ resources:
   - deployment.yaml
 images:
   - name: weaveworks/flagger
-    newTag: 1.0.0-rc.5
+    newTag: 1.0.0

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,4 +1,4 @@
 package version
 
-var VERSION = "1.0.0-rc.5"
+var VERSION = "1.0.0"
 var REVISION = "unknown"


### PR DESCRIPTION
This is the GA release for Flagger v1.0.0.

The upgrade procedure from 0.x to 1.0 can be found [here](https://docs.flagger.app/dev/upgrade-guide).