### PR TITLE
Fix multiple paths per rule on canary ingress

### DIFF
--- a/pkg/router/ingress.go
+++ b/pkg/router/ingress.go
@@ -46,7 +46,6 @@ func (i *IngressRouter) Reconcile(canary *flaggerv1.Canary) error {
 			if y.Backend.ServiceName == apexName {
 				ingressClone.Spec.Rules[k].HTTP.Paths[x].Backend.ServiceName = canaryName
 				backendExists = true
-				break
 			}
 		}
 	}


### PR DESCRIPTION
Remove the `break` that stopped from updating all path's backends inside a rule.

Fix: #629 