### PR TITLE
Add threadiness to helm chart

### DIFF
--- a/charts/flagger/Chart.yaml
+++ b/charts/flagger/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: flagger
-version: 1.0.0
+version: 1.1.0
 appVersion: 1.0.0
 kubeVersion: ">=1.11.0-0"
 engine: gotpl

--- a/charts/flagger/README.md
+++ b/charts/flagger/README.md
@@ -134,6 +134,7 @@ Parameter | Description | Default
 `resources.limits/memory` | Pod memory limit | `512Mi`
 `affinity` | Node/pod affinities | None
 `nodeSelector` | Node labels for pod assignment | `{}`
+`threadiness` | Number of controller workers | `2`
 `tolerations` | List of node taints to tolerate | `[]`
 `istio.kubeconfig.secretName` | The name of the Kubernetes secret containing the Istio shared control plane kubeconfig | None
 `istio.kubeconfig.key` | The name of Kubernetes secret data key that contains the Istio control plane kubeconfig | `kubeconfig`

--- a/charts/flagger/templates/deployment.yaml
+++ b/charts/flagger/templates/deployment.yaml
@@ -112,6 +112,9 @@ spec:
           {{- if .Values.istio.kubeconfig.secretName }}
           - -kubeconfig-service-mesh=/tmp/istio-host/{{ .Values.istio.kubeconfig.key }}
           {{- end }}
+          {{- if .Values.threadiness }}
+          - -threadiness={{ .Values.threadiness }}
+          {{- end }}
           livenessProbe:
             exec:
               command:


### PR DESCRIPTION
Add threadiness as an option to the helm chart to increase the value beyond the default of 2 threads.  Bump chart version to 1.1.0 to reflect the new chart feature.