### PR TITLE
Fix installers for kustomize >= 3.6.0

### DIFF
--- a/docs/gitbook/install/flagger-install-on-kubernetes.md
+++ b/docs/gitbook/install/flagger-install-on-kubernetes.md
@@ -171,13 +171,13 @@ As an alternative to Helm, Flagger can be installed with Kustomize **3.5.0** or 
 Install Flagger for Istio:
 
 ```bash
-kustomize build github.com/weaveworks/flagger//kustomize/istio | kubectl apply -f -
+kustomize build https://github.com/weaveworks/flagger/kustomize/istio | kubectl apply -f -
 ```
 
 Install Flagger for AWS App Mesh:
 
 ```bash
-kustomize build github.com/weaveworks/flagger//kustomize/appmesh | kubectl apply -f -
+kustomize build https://github.com/weaveworks/flagger/kustomize/appmesh | kubectl apply -f -
 ```
 
 This deploys Flagger and sets the metrics server URL to App Mesh's Prometheus instance.
@@ -185,7 +185,7 @@ This deploys Flagger and sets the metrics server URL to App Mesh's Prometheus in
 Install Flagger for Linkerd:
 
 ```bash
-kustomize build github.com/weaveworks/flagger//kustomize/linkerd | kubectl apply -f -
+kustomize build https://github.com/weaveworks/flagger/kustomize/linkerd | kubectl apply -f -
 ```
 
 This deploys Flagger in the `linkerd` namespace and sets the metrics server URL to Linkerd's Prometheus instance.
@@ -193,7 +193,7 @@ This deploys Flagger in the `linkerd` namespace and sets the metrics server URL 
 If you want to install a specific Flagger release, add the version number to the URL:
 
 ```bash
-kustomize build github.com/weaveworks/flagger//kustomize/linkerd?ref=0.18.0 | kubectl apply -f -
+kustomize build https://github.com/weaveworks/flagger/kustomize/linkerd?ref=v1.0.0 | kubectl apply -f -
 ```
 
 **Generic installer**
@@ -201,7 +201,7 @@ kustomize build github.com/weaveworks/flagger//kustomize/linkerd?ref=0.18.0 | ku
 Install Flagger and Prometheus for Contour, Gloo or NGINX ingress:
 
 ```bash
-kustomize build github.com/weaveworks/flagger//kustomize/kubernetes | kubectl apply -f -
+kustomize build https://github.com/weaveworks/flagger/kustomize/kubernetes | kubectl apply -f -
 ```
 
 This deploys Flagger and Prometheus in the `flagger-system` namespace, sets the metrics server URL

--- a/kustomize/README.md
+++ b/kustomize/README.md
@@ -1,6 +1,6 @@
 # Flagger Kustomize installer
 
-As an alternative to Helm, Flagger can be installed with [Kustomize](https:/kustomize.io/).
+As an alternative to Helm, Flagger can be installed with [Kustomize](https://kustomize.io/).
 
 **Prerequisites**
 

--- a/kustomize/README.md
+++ b/kustomize/README.md
@@ -1,18 +1,18 @@
 # Flagger Kustomize installer
 
-As an alternative to Helm, Flagger can be installed with [Kustomize](https://kustomize.io/).
+As an alternative to Helm, Flagger can be installed with [Kustomize](https:/kustomize.io/).
 
 **Prerequisites**
 
 - Kubernetes cluster **>=1.13.0**
-- Kustomize **>=3.5.0**
+- Kustomize **>=3.6.0**
 
 ## Service mesh specific installers
 
 Install Flagger for Istio:
 
 ```bash
-kustomize build github.com/weaveworks/flagger//kustomize/istio | kubectl apply -f -
+kustomize build https://github.com/weaveworks/flagger/kustomize/istio | kubectl apply -f -
 ```
 
 This deploys Flagger in the `istio-system` namespace and sets the metrics server URL to Istio's Prometheus instance.
@@ -20,7 +20,7 @@ This deploys Flagger in the `istio-system` namespace and sets the metrics server
 Install Flagger for AWS App Mesh:
 
 ```bash
-kustomize build github.com/weaveworks/flagger//kustomize/appmesh | kubectl apply -f -
+kustomize build https://github.com/weaveworks/flagger/kustomize/appmesh | kubectl apply -f -
 ```
 
 This deploys Flagger in the `appmesh-system` namespace and sets the metrics server URL to App Mesh Prometheus instance.
@@ -28,7 +28,7 @@ This deploys Flagger in the `appmesh-system` namespace and sets the metrics serv
 Install Flagger for Linkerd:
 
 ```bash
-kustomize build github.com/weaveworks/flagger//kustomize/linkerd | kubectl apply -f -
+kustomize build https://github.com/weaveworks/flagger/kustomize/linkerd | kubectl apply -f -
 ```
 
 This deploys Flagger in the `linkerd` namespace and sets the metrics server URL to Linkerd's Prometheus instance.
@@ -36,13 +36,13 @@ This deploys Flagger in the `linkerd` namespace and sets the metrics server URL 
 If you want to install a specific Flagger release, add the version number to the URL:
 
 ```bash
-kustomize build github.com/weaveworks/flagger//kustomize/linkerd?ref=0.18.0 | kubectl apply -f -
+kustomize build https://github.com/weaveworks/flagger/kustomize/linkerd?ref=v1.0.0 | kubectl apply -f -
 ```
 
 Install Flagger for Contour:
 
 ```bash
-kustomize build github.com/weaveworks/flagger//kustomize/contour | kubectl apply -f -
+kustomize build https://github.com/weaveworks/flagger/kustomize/contour | kubectl apply -f -
 ```
 
 This deploys Flagger and Prometheus in the `projectcontour` namespace and sets Prometheus to scrape Contour's Envoy instances.
@@ -52,7 +52,7 @@ This deploys Flagger and Prometheus in the `projectcontour` namespace and sets P
 Install Flagger and Prometheus:
 
 ```bash
-kustomize build github.com/weaveworks/flagger//kustomize/kubernetes | kubectl apply -f -
+kustomize build https://github.com/weaveworks/flagger/kustomize/kubernetes | kubectl apply -f -
 ```
 
 This deploys Flagger and Prometheus in the `flagger-system` namespace,


### PR DESCRIPTION
The current installers are broken  for kustomize >= 3.6.0:

```
$ kustomize build github.com/weaveworks/flagger//kustomize/kubernetes?ref=v1.0.0 | kubectl apply -f -

Error: accumulating resources: accumulateFile "accumulating resources from '../base/flagger/': evalsymlink failure on '/private/var/folders/77/3y6x_p2j2g9fspdkzjbm5_s40000gn/T/kustomize-948385415/base/flagger' : lstat /private/var/folders/77/3y6x_p2j2g9fspdkzjbm5_s40000gn/T/kustomize-948385415/base: no such file or directory", loader.New "Error loading ../base/flagger/ with git: url lacks host: ../base/flagger/, dir: evalsymlink failure on '/private/var/folders/77/3y6x_p2j2g9fspdkzjbm5_s40000gn/T/kustomize-948385415/base/flagger' : lstat /private/var/folders/77/3y6x_p2j2g9fspdkzjbm5_s40000gn/T/kustomize-948385415/base: no such file or directory, get: invalid source string: ../base/flagger/"
```

This PR adds the `https://` prefix to the base URL and removes the `//`:

```
 $ kustomize build https://github.com/weaveworks/flagger/kustomize/kubernetes?ref=v1.0.0 | kubectl apply -f -

namespace/flagger-system created
customresourcedefinition.apiextensions.k8s.io/alertproviders.flagger.app configured
customresourcedefinition.apiextensions.k8s.io/canaries.flagger.app configured
customresourcedefinition.apiextensions.k8s.io/metrictemplates.flagger.app configured
serviceaccount/flagger created
serviceaccount/flagger-prometheus created
clusterrole.rbac.authorization.k8s.io/flagger configured
clusterrole.rbac.authorization.k8s.io/flagger-prometheus created
clusterrolebinding.rbac.authorization.k8s.io/flagger configured
clusterrolebinding.rbac.authorization.k8s.io/flagger-prometheus created
configmap/flagger-prometheus-5hdhmkhck9 created
service/flagger-prometheus created
deployment.apps/flagger created
deployment.apps/flagger-prometheus created
```
