### PR TITLE
Add priorityClassName to flagger and loadtester chart

### DIFF
--- a/charts/flagger/README.md
+++ b/charts/flagger/README.md
@@ -140,6 +140,7 @@ Parameter | Description | Default
 `istio.kubeconfig.key` | The name of Kubernetes secret data key that contains the Istio control plane kubeconfig | `kubeconfig`
 `ingressAnnotationsPrefix` | Annotations prefix for NGINX ingresses | None
 `ingressClass` | Ingress class used for annotating HTTPProxy objects, e.g. `contour` | None
+`podPriorityClassName` | PriorityClass name for pod priority configuration | ""
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade`. For example,
 

--- a/charts/flagger/templates/deployment.yaml
+++ b/charts/flagger/templates/deployment.yaml
@@ -48,6 +48,9 @@ spec:
           secret:
             secretName: "{{ .Values.istio.kubeconfig.secretName }}"
         {{- end }}
+      {{- if .Values.podPriorityClassName }}
+      priorityClassName: {{ .Values.podPriorityClassName }}
+      {{- end }}                  
       containers:
         - name: flagger
           {{- if .Values.securityContext.enabled }}

--- a/charts/flagger/values.yaml
+++ b/charts/flagger/values.yaml
@@ -14,6 +14,9 @@ podAnnotations:
   prometheus.io/port: "8080"
   appmesh.k8s.aws/sidecarInjectorWebhook: disabled
 
+# priority class name for pod priority configuration
+podPriorityClassName: ""
+
 metricsServer: "http://prometheus:9090"
 
 # accepted values are kubernetes, istio, linkerd, appmesh, nginx, gloo or supergloo:mesh.namespace (defaults to istio)

--- a/charts/loadtester/README.md
+++ b/charts/loadtester/README.md
@@ -67,6 +67,7 @@ Parameter | Description | Default
 `istio.gateway.enabled` | Create Istio gateway in namespace | `false`
 `istio.tls.enabled` | Enable TLS in gateway ( TLS secrets should be in namespace ) | `false`
 `istio.tls.httpsRedirect` | Redirect traffic to TLS port | `false`
+`podPriorityClassName` | PriorityClass name for pod priority configuration | ""
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade`. For example,
 

--- a/charts/loadtester/templates/deployment.yaml
+++ b/charts/loadtester/templates/deployment.yaml
@@ -27,6 +27,9 @@ spec:
       {{- else if .Values.rbac.create }}
       serviceAccountName: {{ include "loadtester.fullname" . }}
       {{- end }}
+      {{- if .Values.podPriorityClassName }}
+      priorityClassName: {{ .Values.podPriorityClassName }}
+      {{- end }}           
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/charts/loadtester/values.yaml
+++ b/charts/loadtester/values.yaml
@@ -9,6 +9,8 @@ podAnnotations:
   prometheus.io/scrape: "true"
   prometheus.io/port: "8080"
 
+podPriorityClassName: ""  
+
 logLevel: info
 cmd:
   timeout: 1h


### PR DESCRIPTION
Changes:
* Add `podPriorityClassName` to values.yaml 
* Add optional `priorityClassName` field to deployment

These applies for flagger and loadtester charts.

Solve #645