### PR TITLE
Add E2E cleanup script and add CircleCI steps for Skipper

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,7 +107,7 @@ jobs:
       - run: test/e2e-gloo.sh
       - run: test/e2e-gloo-tests.sh
 
-  e2e-nginx-testing:
+  e2e-skipper-testing:
     machine: true
     steps:
       - checkout
@@ -115,11 +115,9 @@ jobs:
           at: /tmp/bin
       - run: test/container-build.sh
       - run: test/e2e-kind.sh
-      - run: test/e2e-nginx.sh
-      - run: test/e2e-nginx-tests.sh
+      - run: test/e2e-skipper.sh
+      - run: test/e2e-skipper-tests.sh
       - run: test/e2e-nginx-cleanup.sh
-      - run: test/e2e-nginx-custom-annotations.sh
-      - run: test/e2e-nginx-tests.sh
 
   e2e-linkerd-testing:
     machine: true
@@ -142,6 +140,20 @@ jobs:
       - run: test/e2e-kind.sh
       - run: test/e2e-contour.sh
       - run: test/e2e-contour-tests.sh
+
+  e2e-nginx-testing:
+    machine: true
+    steps:
+      - checkout
+      - attach_workspace:
+          at: /tmp/bin
+      - run: test/container-build.sh
+      - run: test/e2e-kind.sh
+      - run: test/e2e-nginx.sh
+      - run: test/e2e-nginx-tests.sh
+      - run: test/e2e-nginx-cleanup.sh
+      - run: test/e2e-nginx-custom-annotations.sh
+      - run: test/e2e-nginx-tests.sh
 
   push-helm-charts:
     docker:
@@ -212,6 +224,9 @@ workflows:
       - e2e-contour-testing:
           requires:
             - build-binary
+      - e2e-skipper-testing:
+          requires:
+            - build-binary
       - push-container:
           requires:
             - build-binary
@@ -220,6 +235,7 @@ workflows:
             - e2e-gloo-testing
             - e2e-nginx-testing
             - e2e-linkerd-testing
+            - e2e-skipper-testing
           filters:
             branches:
               only:

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ build:
 		-ldflags "-s -w -X github.com/weaveworks/flagger/pkg/version.REVISION=$${GIT_COMMIT}" \
 		-a -installsuffix cgo -o ./bin/flagger ./cmd/flagger/*
 	docker build -t weaveworks/flagger:$(TAG) . -f Dockerfile
+	docker tag weaveworks/flagger:$(TAG) test/flagger:latest
 
 push:
 	docker tag weaveworks/flagger:$(TAG) weaveworks/flagger:$(VERSION)

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,8 @@ require (
 	github.com/prometheus/client_golang v1.5.1
 	github.com/stretchr/testify v1.5.1
 	go.uber.org/zap v1.14.1
+	golang.org/x/net v0.0.0-20200301022130-244492dfa37a // indirect
+	golang.org/x/tools v0.0.0-20200227222343-706bc42d1f0d // indirect
 	gopkg.in/h2non/gock.v1 v1.0.15
 	k8s.io/api v0.18.2
 	k8s.io/apimachinery v0.18.2

--- a/go.sum
+++ b/go.sum
@@ -187,6 +187,7 @@ github.com/prometheus/procfs v0.0.8 h1:+fpWZdT24pJBiqJdAwYBjPSk+5YmQzYNPYzQsdzLk
 github.com/prometheus/procfs v0.0.8/go.mod h1:7Qr8sr6344vo1JqZ6HhLceV9o3AJ1Ff+GxbHq6oeK9A=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
+github.com/sirupsen/logrus v1.4.2 h1:SPIRibHv4MatM3XXNO2BJeFLZwZ2LvZgfQ5+UNI2im4=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/spf13/afero v1.2.2/go.mod h1:9ZxEEn6pIJ8Rxe320qSDBk6AsU0r9pR7Q4OcevTdifk=
 github.com/spf13/pflag v0.0.0-20170130214245-9ff6c6923cff/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
@@ -219,6 +220,7 @@ golang.org/x/crypto v0.0.0-20190211182817-74369b46fc67/go.mod h1:6SG95UA2DQfeDnf
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190510104115-cbcb75029529/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20190611184440-5c40567a22f8/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
+golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200220183623-bac4c82f6975 h1:/Tl7pH94bvbAAHBdZJT947M/+gp0+CqQXDtMRC0fseo=
 golang.org/x/crypto v0.0.0-20200220183623-bac4c82f6975/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
@@ -228,6 +230,8 @@ golang.org/x/lint v0.0.0-20190301231843-5614ed5bae6f/go.mod h1:UVdnD1Gm6xHRNCYTk
 golang.org/x/lint v0.0.0-20190930215403-16217165b5de h1:5hukYrvBGR8/eNkX5mdUezrA6JiaEZDtJb9Ei+1LlBs=
 golang.org/x/lint v0.0.0-20190930215403-16217165b5de/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
 golang.org/x/mod v0.0.0-20190513183733-4bf6d317e70e/go.mod h1:mXi4GBBbnImb6dmsKGUJ2LatrhH/nqhxcFungHvyanc=
+golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee h1:WG0RUwxtNT4qqaXX3DPA8zHFNm/D9xaBpxzHt1WcA/E=
+golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee/go.mod h1:QqPTAvyqsEbceGzBzNggFXnrqF1CaUcvgkdR5Ot7KZg=
 golang.org/x/net v0.0.0-20170114055629-f2499483f923/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -244,6 +248,8 @@ golang.org/x/net v0.0.0-20191004110552-13f9640d40b9 h1:rjwSpXsdiK0dV8/Naq3kAw9ym
 golang.org/x/net v0.0.0-20191004110552-13f9640d40b9/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200202094626-16171245cfb2 h1:CCH4IOTTfewWjGOlSp+zGcjutRKlBEZQ6wTn8ozI/nI=
 golang.org/x/net v0.0.0-20200202094626-16171245cfb2/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/net v0.0.0-20200301022130-244492dfa37a h1:GuSPYbZzB5/dcLNCwLQLsg3obCJtX9IJhpXkvY7kzk0=
+golang.org/x/net v0.0.0-20200301022130-244492dfa37a/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421 h1:Wo7BWFiOk0QRFMLYMqJGFMd9CgUAcGx7V+qEg/h5IBI=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
@@ -292,7 +298,10 @@ golang.org/x/tools v0.0.0-20190920225731-5eefd052ad72/go.mod h1:b+2E5dAYhXwXZwtn
 golang.org/x/tools v0.0.0-20191029041327-9cc4af7d6b2c/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191029190741-b9c20aec41a5 h1:hKsoRgsbwY1NafxrwTs+k64bikrLBkAgPir1TNCj3Zs=
 golang.org/x/tools v0.0.0-20191029190741-b9c20aec41a5/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
+golang.org/x/tools v0.0.0-20200227222343-706bc42d1f0d h1:7M9AXzLrJWWGdDYtBblPHBTnHtaN6KKQ98OYb35mLlY=
+golang.org/x/tools v0.0.0-20200227222343-706bc42d1f0d/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/api v0.4.0/go.mod h1:8k5glujaEP+g9n7WNsDg8QP6cUVNI86fCNMcbazEtwE=

--- a/pkg/apis/flagger/v1beta1/provider.go
+++ b/pkg/apis/flagger/v1beta1/provider.go
@@ -9,4 +9,5 @@ const (
 	GlooProvider       string = "gloo"
 	NGINXProvider      string = "nginx"
 	KubernetesProvider string = "kubernetes"
+	SkipperProvider    string = "skipper"
 )

--- a/pkg/metrics/observers/factory.go
+++ b/pkg/metrics/observers/factory.go
@@ -56,6 +56,10 @@ func (factory Factory) Observer(provider string) Interface {
 		return &HttpObserver{
 			client: factory.Client,
 		}
+	case provider == flaggerv1.SkipperProvider:
+		return &SkipperObserver{
+			client: factory.Client,
+		}
 	default:
 		return &IstioObserver{
 			client: factory.Client,

--- a/pkg/metrics/observers/skipper.go
+++ b/pkg/metrics/observers/skipper.go
@@ -1,0 +1,110 @@
+package observers
+
+import (
+	"fmt"
+	"regexp"
+	"time"
+
+	flaggerv1 "github.com/weaveworks/flagger/pkg/apis/flagger/v1beta1"
+	"github.com/weaveworks/flagger/pkg/metrics/providers"
+)
+
+var skipperQueries = map[string]string{
+	"request-success-rate": `
+	{{- $route := printf "kube_%s__%s.*__%s" namespace ingress service }}
+	sum(
+		rate(
+			skipper_response_duration_seconds_bucket{
+				namespace="{{ namespace }}",
+				route=~"{{ $route }}",
+				code!~"5..",
+				le="+Inf"
+			}[{{ interval }}]
+		)
+	)
+	/ 
+	sum(
+		rate(
+			skipper_response_duration_seconds_bucket{
+				namespace="{{ namespace }}",
+				route=~"{{ $route }}",
+				le="+Inf"
+			}[{{ interval }}]
+		)
+	)
+	* 100`,
+	"request-duration": `
+	{{- $route := printf "kube_%s__%s.*__%s" namespace ingress service }}
+	sum(
+		rate(
+			skipper_response_duration_seconds_sum{
+				namespace="{{ namespace }}",
+				route=~"{{ $route }}"
+			}[{{ interval }}]
+		)
+	) 
+	/ 
+	sum(
+		rate(
+			skipper_response_duration_seconds_count{
+				namespace="{{ namespace }}",
+				route=~"{{ $route }}"
+			}[{{ interval }}]
+		)
+	) 
+	* 1000`,
+}
+
+// SkipperObserver Implentation for Skipper (https://github.com/zalando/skipper)
+type SkipperObserver struct {
+	client providers.Interface
+}
+
+// GetRequestSuccessRate return value for Skipper Request Success Rate
+func (ob *SkipperObserver) GetRequestSuccessRate(model flaggerv1.MetricTemplateModel) (float64, error) {
+
+	model = encodeModelForSkipper(model)
+
+	query, err := RenderQuery(skipperQueries["request-success-rate"], model)
+	if err != nil {
+		return 0, fmt.Errorf("rendering query failed: %w", err)
+	}
+
+	value, err := ob.client.RunQuery(query)
+	if err != nil {
+		return 0, fmt.Errorf("running query failed: %w", err)
+	}
+
+	return value, nil
+}
+
+// GetRequestDuration return value for Skipper Request Duration
+func (ob *SkipperObserver) GetRequestDuration(model flaggerv1.MetricTemplateModel) (time.Duration, error) {
+
+	model = encodeModelForSkipper(model)
+
+	query, err := RenderQuery(skipperQueries["request-duration"], model)
+	if err != nil {
+		return 0, fmt.Errorf("rendering query failed: %w", err)
+	}
+
+	value, err := ob.client.RunQuery(query)
+	if err != nil {
+		return 0, fmt.Errorf("running query failed: %w", err)
+	}
+
+	ms := time.Duration(int64(value)) * time.Millisecond
+	return ms, nil
+}
+
+// encodeModelForSkipper replaces non word character in model with underscore to match route names
+// https://github.com/zalando/skipper/blob/dd70bd65e7f99cfb5dd6b6f71885d9fe3b2707f6/dataclients/kubernetes/ingress.go#L101
+func encodeModelForSkipper(model flaggerv1.MetricTemplateModel) flaggerv1.MetricTemplateModel {
+	nonWord := regexp.MustCompile(`\W`)
+	model.Ingress = nonWord.ReplaceAllString(model.Ingress, "_")
+	model.Name = nonWord.ReplaceAllString(model.Name, "_")
+	model.Namespace = nonWord.ReplaceAllString(model.Namespace, "_")
+	model.Service = nonWord.ReplaceAllString(model.Service, "_")
+	model.Target = nonWord.ReplaceAllString(model.Target, "_")
+	return model
+}

--- a/pkg/metrics/observers/skipper_test.go
+++ b/pkg/metrics/observers/skipper_test.go
@@ -1,0 +1,106 @@
+package observers
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	flaggerv1 "github.com/weaveworks/flagger/pkg/apis/flagger/v1beta1"
+	"github.com/weaveworks/flagger/pkg/metrics/providers"
+)
+
+func TestSkipperObserver_GetRequestSuccessRate(t *testing.T) {
+	t.Run("ok", func(t *testing.T) {
+		expected := ` sum( rate( skipper_response_duration_seconds_bucket{ namespace="skipper", route=~"kube_skipper__skipper_ingress.*__backend", code=~"[4|5]..", le="+Inf" }[1m] ) ) / sum( rate( skipper_response_duration_seconds_bucket{ namespace="skipper", route=~"kube_skipper__skipper_ingress.*__backend", le="+Inf" }[1m] ) ) * 100`
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			promql := r.URL.Query()["query"][0]
+			assert.Equal(t, expected, promql)
+
+			json := `{"status":"success","data":{"resultType":"vector","result":[{"metric":{},"value":[1,"100"]}]}}`
+			w.Write([]byte(json))
+		}))
+		defer ts.Close()
+
+		client, err := providers.NewPrometheusProvider(flaggerv1.MetricTemplateProvider{
+			Type:      "prometheus",
+			Address:   ts.URL,
+			SecretRef: nil,
+		}, nil)
+		require.NoError(t, err)
+
+		observer := &SkipperObserver{
+			client: client,
+		}
+
+		val, err := observer.GetRequestSuccessRate(flaggerv1.MetricTemplateModel{
+			Namespace: "skipper",
+			Interval:  "1m",
+			Service:   "backend",
+			Ingress:   "skipper-ingress",
+		})
+		require.NoError(t, err)
+
+		assert.Equal(t, float64(100), val)
+	})
+
+	t.Run("no values", func(t *testing.T) {
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			json := `{"status":"success","data":{"resultType":"vector","result":[]}}`
+			w.Write([]byte(json))
+		}))
+		defer ts.Close()
+
+		client, err := providers.NewPrometheusProvider(flaggerv1.MetricTemplateProvider{
+			Type:      "prometheus",
+			Address:   ts.URL,
+			SecretRef: nil,
+		}, nil)
+		require.NoError(t, err)
+
+		observer := &SkipperObserver{
+			client: client,
+		}
+
+		_, err = observer.GetRequestSuccessRate(flaggerv1.MetricTemplateModel{})
+		require.True(t, errors.Is(err, providers.ErrNoValuesFound))
+	})
+}
+
+func TestSkipperObserver_GetRequestDuration(t *testing.T) {
+	expected := ` sum( rate( skipper_response_duration_seconds_sum{ namespace="skipper", route=~"kube_skipper__skipper_ingress.*__backend" }[1m] ) ) / sum( rate( skipper_response_duration_seconds_count{ namespace="skipper", route=~"kube_skipper__skipper_ingress.*__backend" }[1m] ) ) * 1000`
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		promql := r.URL.Query()["query"][0]
+		assert.Equal(t, expected, promql)
+
+		json := `{"status":"success","data":{"resultType":"vector","result":[{"metric":{},"value":[1,"100"]}]}}`
+		w.Write([]byte(json))
+	}))
+	defer ts.Close()
+
+	client, err := providers.NewPrometheusProvider(flaggerv1.MetricTemplateProvider{
+		Type:      "prometheus",
+		Address:   ts.URL,
+		SecretRef: nil,
+	}, nil)
+	require.NoError(t, err)
+
+	observer := &SkipperObserver{
+		client: client,
+	}
+
+	val, err := observer.GetRequestDuration(flaggerv1.MetricTemplateModel{
+		Namespace: "skipper",
+		Interval:  "1m",
+		Service:   "backend",
+		Ingress:   "skipper-ingress",
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, 100*time.Millisecond, val)
+}

--- a/pkg/router/factory.go
+++ b/pkg/router/factory.go
@@ -122,6 +122,11 @@ func (factory *Factory) MeshRouter(provider string, labelSelector string) Interf
 			kubeClient:        factory.kubeClient,
 			annotationsPrefix: factory.ingressAnnotationsPrefix,
 		}
+	case provider == flaggerv1.SkipperProvider:
+		return &SkipperRouter{
+			logger:     factory.logger,
+			kubeClient: factory.kubeClient,
+		}
 	case provider == flaggerv1.KubernetesProvider:
 		return &NopRouter{}
 	default:

--- a/pkg/router/skipper.go
+++ b/pkg/router/skipper.go
@@ -1,0 +1,202 @@
+package router
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/google/go-cmp/cmp"
+	"go.uber.org/zap"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/kubernetes"
+
+	flaggerv1 "github.com/weaveworks/flagger/pkg/apis/flagger/v1beta1"
+)
+
+/*
+Skipper Principles:
+
+* if only one backend has a weight, only one backend will get 100% traffic
+* if two of three backends has a weight, only two should get traffic.
+* if two backends doesn't have any weight, they get equal amount of traffic.
+* weights can be int or float, but always relative.
+
+Implementation:
+* apex Ingress is immutable
+* new canary Ingress contains two paths for primary and canary service
+* canary Ingress manages weights on primary & canary service, hence no traffic to apex service
+
+*/
+
+const (
+	skipperBackendWeightsAnnotationKey = "zalando.org/backend-weights"
+	canaryPatternf                     = "%s-canary"
+)
+
+type SkipperRouter struct {
+	kubeClient kubernetes.Interface
+	logger     *zap.SugaredLogger
+}
+
+// Reconcile creates or updates the ingresses
+func (skp *SkipperRouter) Reconcile(canary *flaggerv1.Canary) error {
+	if canary.Spec.IngressRef == nil || canary.Spec.IngressRef.Name == "" {
+		return fmt.Errorf("ingress selector is empty")
+	}
+
+	apexSvcName, primarySvcName, canarySvcName := canary.GetServiceNames()
+	apexIngressName, canaryIngressName := skp.getIngressNames(canary.Spec.IngressRef.Name)
+
+	// retrieving apex ingress
+	apexIngress, err := skp.kubeClient.NetworkingV1beta1().Ingresses(canary.Namespace).Get(
+		context.TODO(), apexIngressName, metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("apexIngress %s.%s get query error: %w", apexIngressName, canary.Namespace, err)
+	}
+
+	// building the canary ingress from apex
+	iClone := apexIngress.DeepCopy()
+	for x := range iClone.Spec.Rules {
+		rule := &iClone.Spec.Rules[x] // ref not value
+		for y := range rule.HTTP.Paths {
+			path := &rule.HTTP.Paths[y] // ref not value
+			if path.Backend.ServiceName == apexSvcName {
+				// flipping to primary service
+				path.Backend.ServiceName = primarySvcName
+				// adding second canary service
+				canaryBackend := path.DeepCopy()
+				canaryBackend.Backend.ServiceName = canarySvcName
+				rule.HTTP.Paths = append(rule.HTTP.Paths, *canaryBackend)
+			}
+		}
+	}
+	if apexIngress.DeepCopy() == iClone {
+		return fmt.Errorf("backend %s not found in ingress %s", apexSvcName, apexIngressName)
+	}
+
+	iClone.Annotations = skp.makeAnnotations(iClone.Annotations, map[string]int{primarySvcName: 100, canarySvcName: 0})
+	iClone.Name = canaryIngressName
+	iClone.Namespace = canary.Namespace
+	iClone.OwnerReferences = []metav1.OwnerReference{
+		*metav1.NewControllerRef(canary, schema.GroupVersionKind{
+			Group:   flaggerv1.SchemeGroupVersion.Group,
+			Version: flaggerv1.SchemeGroupVersion.Version,
+			Kind:    flaggerv1.CanaryKind,
+		}),
+	}
+
+	// search for existence
+	canaryIngress, err := skp.kubeClient.NetworkingV1beta1().Ingresses(canary.Namespace).Get(
+		context.TODO(), canaryIngressName, metav1.GetOptions{})
+
+	// new ingress
+	if errors.IsNotFound(err) {
+		_, err := skp.kubeClient.NetworkingV1beta1().Ingresses(canary.Namespace).Create(context.TODO(), iClone, metav1.CreateOptions{})
+		if err != nil {
+			return fmt.Errorf("ingress %s.%s create error: %w", iClone.Name, iClone.Namespace, err)
+		}
+		skp.logger.With("canary", fmt.Sprintf("%s.%s", canary.Name, canary.Namespace)).
+			Infof("Ingress %s.%s created", iClone.GetName(), canary.Namespace)
+		return nil
+	} else if err != nil {
+		return fmt.Errorf("ingress %s.%s query error: %w", canaryIngressName, canary.Namespace, err)
+	}
+
+	// existant, updating
+	diffSpec := cmp.Diff(iClone.Spec, canaryIngress.Spec)
+	diffAnnotations := cmp.Diff(iClone.Annotations, canaryIngress.Annotations)
+	if diffSpec != "" || diffAnnotations != "" {
+		ingressClone := canaryIngress.DeepCopy()
+		ingressClone.Spec = iClone.Spec
+		ingressClone.Annotations = iClone.Annotations
+
+		_, err := skp.kubeClient.NetworkingV1beta1().Ingresses(canary.Namespace).Update(context.TODO(), ingressClone, metav1.UpdateOptions{})
+		if err != nil {
+			return fmt.Errorf("ingress %s.%s update error: %w", canaryIngressName, ingressClone.Namespace, err)
+		}
+		skp.logger.With("canary", fmt.Sprintf("%s.%s", canary.Name, canary.Namespace)).
+			Infof("Ingress %s updated", canaryIngressName)
+	}
+
+	return nil
+}
+
+func (skp *SkipperRouter) GetRoutes(canary *flaggerv1.Canary) (primaryWeight, canaryWeight int, mirrored bool, err error) {
+	_, primarySvcName, canarySvcName := canary.GetServiceNames()
+
+	_, canaryIngressName := skp.getIngressNames(canary.Spec.IngressRef.Name)
+	canaryIngress, err := skp.kubeClient.NetworkingV1beta1().Ingresses(canary.Namespace).Get(context.TODO(), canaryIngressName, metav1.GetOptions{})
+	if err != nil {
+		err = fmt.Errorf("ingress %s.%s get query error: %w", canaryIngressName, canary.Namespace, err)
+		return
+	}
+
+	weights, err := skp.backendWeights(canaryIngress.Annotations)
+	if err != nil {
+		err = fmt.Errorf("ingress %s.%s get backendWeights error: %w", canaryIngressName, canary.Namespace, err)
+		return
+	}
+	primaryWeight = weights[primarySvcName]
+	canaryWeight = weights[canarySvcName]
+	mirrored = false
+	return
+}
+
+func (skp *SkipperRouter) SetRoutes(canary *flaggerv1.Canary, primaryWeight, canaryWeight int, _ bool) (err error) {
+	_, primarySvcName, canarySvcName := canary.GetServiceNames()
+	_, canaryIngressName := skp.getIngressNames(canary.Spec.IngressRef.Name)
+	canaryIngress, err := skp.kubeClient.NetworkingV1beta1().Ingresses(canary.Namespace).Get(context.TODO(), canaryIngressName, metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("ingress %s.%s get query error: %w", canaryIngressName, canary.Namespace, err)
+	}
+
+	iClone := canaryIngress.DeepCopy()
+
+	// TODO: A/B testing
+
+	// Canary
+	iClone.Annotations = skp.makeAnnotations(iClone.Annotations, map[string]int{
+		primarySvcName: primaryWeight,
+		canarySvcName:  canaryWeight,
+	})
+
+	_, err = skp.kubeClient.NetworkingV1beta1().Ingresses(canary.Namespace).Update(context.TODO(), iClone, metav1.UpdateOptions{})
+	if err != nil {
+		return fmt.Errorf("ingress %s.%s update error %v", iClone.Name, iClone.Namespace, err)
+	}
+
+	return nil
+}
+
+func (skp *SkipperRouter) Finalize(_ *flaggerv1.Canary) error {
+	return nil
+}
+
+func (skp *SkipperRouter) makeAnnotations(annotations map[string]string, backendWeights map[string]int) map[string]string {
+	b, err := json.Marshal(backendWeights)
+	if err != nil {
+		skp.logger.Errorf("Skipper:makeAnnotations: unable to marshal backendWeights %w", err)
+		return annotations
+	}
+	annotations[skipperBackendWeightsAnnotationKey] = string(b)
+	return annotations
+}
+
+// parse backend-weights annotation if it exists
+func (skp *SkipperRouter) backendWeights(annotation map[string]string) (backendWeights map[string]int, err error) {
+	backends, ok := annotation[skipperBackendWeightsAnnotationKey]
+	if ok {
+		err = json.Unmarshal([]byte(backends), &backendWeights)
+	} else {
+		err = errors.NewNotFound(schema.GroupResource{Group: "Skipper Canary Ingress", Resource: "Annotation"},
+			skipperBackendWeightsAnnotationKey)
+	}
+	return
+}
+
+// getIngressNames returns the primary and canary Kubernetes Ingress names
+func (skp *SkipperRouter) getIngressNames(name string) (apexName, canaryName string) {
+	return name, fmt.Sprintf(canaryPatternf, name)
+}

--- a/pkg/router/skipper_test.go
+++ b/pkg/router/skipper_test.go
@@ -1,0 +1,102 @@
+package router
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestSkipperRouter_Reconcile(t *testing.T) {
+	assert := assert.New(t)
+	mocks := newFixture(nil)
+
+	tests := []struct {
+		name    string
+		mocks   func() fixture
+		wantErr bool
+	}{
+		{
+			"creating new canary ingress w/ default settings",
+			func() fixture { return mocks },
+			false,
+		}, {
+			"updating existing canary ingress",
+			func() fixture {
+				ti := newTestIngress()
+				ti.Annotations["something"] = "changed"
+				_, err := mocks.kubeClient.NetworkingV1beta1().Ingresses("default").Update(
+					context.TODO(), ti, metav1.UpdateOptions{})
+				assert.NoError(err)
+				return mocks
+			},
+			false,
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			mocks := tt.mocks()
+			router := &SkipperRouter{
+				kubeClient: mocks.kubeClient,
+				logger:     mocks.logger,
+			}
+			assert.NoError(router.Reconcile(mocks.ingressCanary))
+			canaryName := fmt.Sprintf("%s-canary", mocks.ingressCanary.Spec.IngressRef.Name)
+			inCanary, err := router.kubeClient.NetworkingV1beta1().Ingresses("default").Get(
+				context.TODO(), canaryName, metav1.GetOptions{})
+			assert.NoError(err)
+			// test initialisation
+			assert.JSONEq(inCanary.Annotations["zalando.org/backend-weights"], `{"podinfo-primary":100,"podinfo-canary":0}`)
+			assert.Equal(inCanary.Spec.Rules[0].HTTP.Paths[0].Backend.ServiceName, "podinfo-primary", "backend flipped over")
+			assert.Equal(inCanary.Spec.Rules[0].HTTP.Paths[1].Backend.ServiceName, "podinfo-canary", "backend flipped over")
+			assert.Equal(inCanary.Spec.Rules[0].HTTP.Paths[0].Backend.ServicePort,
+				inCanary.Spec.Rules[0].HTTP.Paths[1].Backend.ServicePort, "canary backend not cloned")
+		})
+	}
+}
+
+func TestSkipperRouter_GetSetRoutes(t *testing.T) {
+	assert := assert.New(t)
+	mocks := newFixture(nil)
+
+	router := &SkipperRouter{logger: mocks.logger, kubeClient: mocks.kubeClient}
+	assert.NoError(router.Reconcile(mocks.ingressCanary))
+
+	p, c, m, err := router.GetRoutes(mocks.ingressCanary)
+	assert.NoError(err)
+	assert.Equal(100, p)
+	assert.Equal(0, c)
+	assert.Equal(false, m)
+
+	tests := []struct {
+		name            string
+		primary, canary int
+	}{
+		{name: "0%", primary: 100, canary: 0},
+		{name: "10%", primary: 90, canary: 10},
+		{name: "20%", primary: 80, canary: 20},
+		{name: "30%", primary: 70, canary: 30},
+		{name: "85%", primary: 15, canary: 85},
+		{name: "100%", primary: 0, canary: 100},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			assert.NoError(router.SetRoutes(mocks.ingressCanary, tt.primary, tt.canary, false))
+			inCanary, err := router.kubeClient.NetworkingV1beta1().Ingresses("default").Get(
+				context.TODO(), fmt.Sprintf("%s-canary", mocks.ingressCanary.Spec.IngressRef.Name), metav1.GetOptions{})
+			assert.NoError(err)
+			assert.JSONEq(inCanary.Annotations["zalando.org/backend-weights"],
+				fmt.Sprintf(`{"podinfo-primary": %d,"podinfo-canary": %d}`, tt.primary, tt.canary))
+			p, c, m, err = router.GetRoutes(mocks.ingressCanary)
+			assert.NoError(err)
+			assert.Equal(tt.primary, p)
+			assert.Equal(tt.canary, c)
+			assert.Equal(false, m)
+		})
+	}
+
+}

--- a/test/README.md
+++ b/test/README.md
@@ -54,3 +54,19 @@ The e2e testing infrastructure is powered by CircleCI and [Kubernetes Kind](http
 * cleanup test environment [e2e-nginx-cleanup.sh](e2e-nginx-cleanup.sh)
 * install NGINX Ingress and Flagger with custom ingress annotations prefix [e2e-nginx-custom-annotations.sh](e2e-nginx-custom-annotations.sh)
 * repeat the canary and A/B testing workflow [e2e-nginx-tests.sh](e2e-nginx-tests.sh)
+
+### CircleCI e2e Skipper ingress workflow
+
+* install latest stable kubectl [e2e-kind.sh](e2e-kind.sh)
+* install Kubernetes Kind [e2e-kind.sh](e2e-kind.sh)
+* create local Kubernetes cluster with kind [e2e-kind.sh](e2e-kind.sh)
+* install Skipper ingress with Kustomize [e2e-skipper.sh](e2e-skipper.sh)
+* load Flagger image onto the local cluster [e2e-skipper.sh](e2e-skipper.sh)
+* install Flagger and Prometheus in the flagger-system namespace [e2e-skipper.sh](e2e-skipper.sh)
+* create a test namespace [e2e-skipper-tests.sh](e2e-skipper-tests.sh)
+* deploy the load tester in the test namespace [e2e-skipper-tests.sh](e2e-skipper-tests.sh)
+* deploy the demo workload (podinfo) and ingress in the test namespace [e2e-skipper-tests.sh](e2e-skipper-tests.sh)
+* test the canary initialization [e2e-skipper-tests.sh](e2e-skipper-tests.sh)
+* test the canary analysis and promotion using weighted traffic and the load testing webhook [e2e-skipper-tests.sh]e2e-skipper-tests.sh)
+* test the A/B testing analysis and promotion using header filters and pre/post rollout webhooks [e2e-skipper-tests.sh]e2e-skipper-tests.sh)
+* cleanup test environment [e2e-skipper-cleanup.sh](e2e-skipper-cleanup.sh)

--- a/test/e2e-skipper-cleanup.sh
+++ b/test/e2e-skipper-cleanup.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+set -o errexit
+
+REPO_ROOT=$(git rev-parse --show-toplevel)
+
+echo '>>> Deleting Skipper Ingress'
+kustomize build test/skipper/ | kubectl delete -f -
+
+echo '>>> Deleting Flagger'
+kubectl delete -k ${REPO_ROOT}/kustomize/kubernetes
+
+echo '>>> Cleanup test namespace'
+kubectl delete namespace test --ignore-not-found=true

--- a/test/e2e-skipper-test-ingress.yaml
+++ b/test/e2e-skipper-test-ingress.yaml
@@ -1,0 +1,17 @@
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  name: podinfo
+  namespace: test
+  labels:
+    app: podinfo
+  annotations:
+    kubernetes.io/ingress.class: "skipper"
+spec:
+  rules:
+    - host: app.example.com
+      http:
+        paths:
+          - backend:
+              serviceName: podinfo
+              servicePort: 80

--- a/test/e2e-skipper-tests.sh
+++ b/test/e2e-skipper-tests.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+
+# This script runs e2e tests for Canary initialization, analysis and promotion
+# Prerequisites: Kubernetes Kind and Skipper ingress controller
+
+set -o errexit
+
+REPO_ROOT=$(git rev-parse --show-toplevel)
+
+echo '>>> Creating test namespace'
+kubectl create namespace test
+
+echo '>>> Installing load tester'
+kubectl apply -k ${REPO_ROOT}/kustomize/tester
+kubectl -n test rollout status deployment/flagger-loadtester
+
+echo '>>> Initialising canary'
+kubectl apply -f ${REPO_ROOT}/test/e2e-workload.yaml
+kubectl apply -f ${REPO_ROOT}/test/e2e-skipper-test-ingress.yaml
+
+echo '>>> Create canary CRD'
+cat <<EOF | kubectl apply -f -
+apiVersion: flagger.app/v1beta1
+kind: Canary
+metadata:
+  name: podinfo
+  namespace: test
+spec:
+  provider: skipper
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: podinfo
+  ingressRef:
+    apiVersion: networking.k8s.io/v1beta1
+    kind: Ingress
+    name: podinfo
+  progressDeadlineSeconds: 60
+  service:
+    port: 80
+    targetPort: http
+  analysis:
+    interval: 15s
+    threshold: 5
+    maxWeight: 40
+    stepWeight: 20
+    metrics:
+    - name: request-success-rate
+      interval: 1m
+      # minimum req success rate (non 5xx responses)
+      # percentage (0-100)
+      thresholdRange:
+        min: 99
+    - name: request-duration
+      interval: 1m
+      # maximum req duration P99
+      # milliseconds
+      thresholdRange:
+        max: 500
+    webhooks:
+      - name: load-test
+        url: http://flagger-loadtester.test/
+        metadata:
+          type: cmd
+          cmd: "hey -z 2m -q 10 -c 2 -host app.example.com http://skipper.kube-system"
+EOF
+
+echo '>>> Waiting for primary to be ready'
+retries=50
+count=0
+ok=false
+until ${ok}; do
+  kubectl -n test get canary/podinfo | grep 'Initialized' && ok=true || ok=false
+  sleep 5
+  count=$(($count + 1))
+  if [[ ${count} -eq ${retries} ]]; then
+    kubectl -n flagger-system logs deployment/flagger
+    echo "No more retries left"
+    exit 1
+  fi
+done
+
+echo '✔ Canary initialization test passed'
+
+echo '>>> Triggering canary deployment'
+kubectl -n test set image deployment/podinfo podinfod=stefanprodan/podinfo:3.1.1
+
+echo '>>> Waiting for canary promotion'
+retries=50
+count=0
+ok=false
+failed=false
+until ${ok}; do
+  kubectl -n test get canary/podinfo | grep 'Failed' && failed=true || failed=false
+  if ${failed}; then
+    kubectl -n flagger-system logs deployment/flagger
+    echo "Canary failed!"
+    exit 1
+  fi
+  kubectl -n test describe deployment/podinfo-primary | grep '3.1.1' && ok=true || ok=false
+  sleep 10
+  kubectl -n flagger-system logs deployment/flagger --tail 1
+  count=$(($count + 1))
+  if [[ ${count} -eq ${retries} ]]; then
+    kubectl -n test describe deployment/podinfo
+    kubectl -n test describe deployment/podinfo-primary
+    kubectl -n flagger-system logs deployment/flagger
+    echo "No more retries left"
+    exit 1
+  fi
+done
+
+echo '>>> Waiting for canary finalization'
+retries=50
+count=0
+ok=false
+until ${ok}; do
+  kubectl -n test get canary/podinfo | grep 'Succeeded' && ok=true || ok=false
+  sleep 5
+  count=$(($count + 1))
+  if [[ ${count} -eq ${retries} ]]; then
+    kubectl -n flagger-system logs deployment/flagger
+    echo "No more retries left"
+    exit 1
+  fi
+done
+
+echo '✔ Canary promotion test passed'

--- a/test/e2e-skipper.sh
+++ b/test/e2e-skipper.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -o errexit
+
+REPO_ROOT=$(git rev-parse --show-toplevel)
+
+echo '>>> Installing Skipper Ingress'
+kustomize build test/skipper/ | kubectl apply -f -
+kubectl rollout status deployment/skipper-ingress -n kube-system
+kubectl get all --all-namespaces
+
+echo '>>> Loading Flagger image'
+kind load docker-image test/flagger:latest
+
+echo '>>> Installing Flagger'
+kubectl apply -k ${REPO_ROOT}/kustomize/kubernetes
+
+kubectl -n flagger-system set image deployment/flagger flagger=test/flagger:latest
+
+kubectl -n flagger-system rollout status deployment/flagger
+kubectl -n flagger-system rollout status deployment/flagger-prometheus

--- a/test/skipper/kustomization.yaml
+++ b/test/skipper/kustomization.yaml
@@ -1,0 +1,36 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - https://raw.githubusercontent.com/zalando/skipper/master/docs/kubernetes/deploy/deployment/rbac.yaml
+  - https://raw.githubusercontent.com/zalando/skipper/master/docs/kubernetes/deploy/deployment/deployment.yaml
+
+patches:
+  - target:
+      kind: Deployment
+      name: skipper-ingress
+    patch: |-
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: skipper-ingress
+      spec:
+        template:
+          metadata:
+            annotations:
+              prometheus.io/path: /metrics
+              prometheus.io/port: "9911"
+              prometheus.io/scrape: "true"
+          spec:
+            nodeSelector:
+              $patch: delete
+            affinity:
+              $patch: delete
+            containers:
+              - name: skipper-ingress
+                image: registry.opensource.zalan.do/pathfinder/skipper:v0.11.135
+                ports:
+                  - name: metrics-port
+                    containerPort: 9911
+                resources:
+                  $patch: delete


### PR DESCRIPTION
**👷 add e2e-skipper-cleanup script**

This was already described in the Readme but missing.
This is meant to cleanup all resources created from e2e-skipper-tests.sh

**👷 add skipper e2e tests to CircleCI pipeline**

This commit adds e2e testing for skipper ingress to the pipeline.
This will help to ensure changes work.

