### PR TITLE
Update Istio, Linkerd and Contour e2e to latest version

### DIFF
--- a/test/e2e-contour.sh
+++ b/test/e2e-contour.sh
@@ -4,7 +4,7 @@ set -o errexit
 
 REPO_ROOT=$(git rev-parse --show-toplevel)
 
-CONTOUR_VER="v1.5.0"
+CONTOUR_VER="v1.7.0"
 
 echo '>>> Installing Contour'
 kubectl apply -f https://projectcontour.io/quickstart/${CONTOUR_VER}/contour.yaml

--- a/test/e2e-istio.sh
+++ b/test/e2e-istio.sh
@@ -2,7 +2,7 @@
 
 set -o errexit
 
-ISTIO_VER="1.6.1"
+ISTIO_VER="1.6.7"
 REPO_ROOT=$(git rev-parse --show-toplevel)
 
 echo ">>> Downloading Istio ${ISTIO_VER}"

--- a/test/e2e-linkerd.sh
+++ b/test/e2e-linkerd.sh
@@ -2,7 +2,7 @@
 
 set -o errexit
 
-LINKERD_VER="stable-2.8.0"
+LINKERD_VER="stable-2.8.1"
 REPO_ROOT=$(git rev-parse --show-toplevel)
 
 curl -SsL https://github.com/linkerd/linkerd2/releases/download/${LINKERD_VER}/linkerd2-cli-${LINKERD_VER}-linux > ${REPO_ROOT}/bin/linkerd


### PR DESCRIPTION
Changes to e2e testing:

* Contour 1.7.0
* Istio 1.6.7
* Linkerd 2.8.1
