### PR TITLE
Add securityContext parameter to loadtester chart

### DIFF
--- a/charts/loadtester/README.md
+++ b/charts/loadtester/README.md
@@ -68,6 +68,8 @@ Parameter | Description | Default
 `istio.tls.enabled` | Enable TLS in gateway ( TLS secrets should be in namespace ) | `false`
 `istio.tls.httpsRedirect` | Redirect traffic to TLS port | `false`
 `podPriorityClassName` | PriorityClass name for pod priority configuration | ""
+`securityContext.enabled` | Add securityContext to container | ""
+`securityContext.context` | securityContext to add | ""
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade`. For example,
 

--- a/charts/loadtester/templates/deployment.yaml
+++ b/charts/loadtester/templates/deployment.yaml
@@ -32,6 +32,10 @@ spec:
       {{- end }}           
       containers:
         - name: {{ .Chart.Name }}
+          {{- if .Values.securityContext.enabled }}
+          securityContext:
+{{ toYaml .Values.securityContext.context | indent 12 }}
+          {{- end }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:

--- a/charts/loadtester/values.yaml
+++ b/charts/loadtester/values.yaml
@@ -71,3 +71,11 @@ istio:
   tls:
     enabled: false
     httpsRedirect: false 
+
+# when enabled, it will add a security context for the loadtester pod
+securityContext:
+  enabled: false
+  context:
+    readOnlyRootFilesystem: true
+    runAsUser: 100
+    runAsGroup: 101


### PR DESCRIPTION
Default to `enabled: false` to avoid changing default behavior.

Allows using the chart on clusters with runAsNonRoot security policy

This is basically just a copy and paste from the flagger chart.