### PR TITLE
Support per-config configTracker disable via ConfigMap/Secret annotation

### DIFF
--- a/docs/gitbook/usage/how-it-works.md
+++ b/docs/gitbook/usage/how-it-works.md
@@ -75,15 +75,10 @@ Based on the above configuration, Flagger generates the following Kubernetes obj
 * `deployment/<targetRef.name>-primary`
 * `hpa/<autoscalerRef.name>-primary`
 
-The primary deployment is considered the stable release of your app, by default all traffic is routed to this version 
+The primary deployment is considered the stable release of your app, by default all traffic is routed to this version
 and the target deployment is scaled to zero.
 Flagger will detect changes to the target deployment (including secrets and configmaps) and will perform a
 canary analysis before promoting the new version as primary.
-
-If the target deployment uses secrets and/or configmaps, Flagger will create a copy of each object using the `-primary`
-prefix and will reference these objects in the primary deployment. You can disable the secrets/configmaps tracking 
-with the `-enable-config-tracking=false` command flag in the Flagger deployment manifest under containers args
-or by setting `--set configTracking.enabled=false` when installing Flagger with Helm.
 
 **Note** that the target deployment must have a single label selector in the format `app: <DEPLOYMENT-NAME>`:
 
@@ -102,10 +97,19 @@ spec:
         app: podinfo
 ```
 
-Besides `app` Flagger supports `name` and `app.kubernetes.io/name` selectors.
+In addition to `app`, Flagger supports `name` and `app.kubernetes.io/name` selectors.
 If you use a different convention you can specify your label with
 the `-selector-labels=my-app-label` command flag in the Flagger deployment manifest under containers args
 or by setting `--set selectorLabels=my-app-label` when installing Flagger with Helm.
+
+If the target deployment uses secrets and/or configmaps, Flagger will create a copy of each object using the `-primary`
+suffix and will reference these objects in the primary deployment. If you annotate your ConfigMap or Secret with
+`flagger.app/config-tracking: disabled`, Flagger will use the same object for the primary deployment instead of making
+a primary copy.
+You can disable the secrets/configmaps tracking globally with the `-enable-config-tracking=false` command flag in
+the Flagger deployment manifest under containers args or by setting `--set configTracking.enabled=false` when
+installing Flagger with Helm, but disabling config-tracking using the the per Secret/ConfigMap annotation may fit your
+use-case better.
 
 The autoscaler reference is optional, when specified, Flagger will pause the traffic increase while the 
 target and primary deployments are scaled up or down. HPA can help reduce the resource usage during the canary analysis.

--- a/pkg/canary/daemonset_fixture_test.go
+++ b/pkg/canary/daemonset_fixture_test.go
@@ -35,10 +35,14 @@ func newDaemonSetFixture() daemonSetControllerFixture {
 		newDaemonSetControllerTestConfigMapEnv(),
 		newDaemonSetControllerTestConfigMapVol(),
 		newDaemonSetControllerTestConfigProjected(),
+		newDaemonSetControllerTestConfigMapTrackerEnabled(),
+		newDaemonSetControllerTestConfigMapTrackerDisabled(),
 		newDaemonSetControllerTestSecret(),
 		newDaemonSetControllerTestSecretEnv(),
 		newDaemonSetControllerTestSecretVol(),
 		newDaemonSetControllerTestSecretProjected(),
+		newDaemonSetControllerTestSecretTrackerEnabled(),
+		newDaemonSetControllerTestSecretTrackerDisabled(),
 	)
 
 	logger, _ := logger.NewLogger("debug")
@@ -130,6 +134,42 @@ func newDaemonSetControllerTestConfigMapVol() *corev1.ConfigMap {
 	}
 }
 
+func newDaemonSetControllerTestConfigMapTrackerEnabled() *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		TypeMeta: metav1.TypeMeta{APIVersion: corev1.SchemeGroupVersion.String()},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "podinfo-config-tracker-enabled",
+			Annotations: map[string]string{
+				"unrelated-annotation-1":      ":)",
+				"flagger.app/config-tracking": "enabled",
+				"unrelated-annotation-2":      "<3",
+			},
+		},
+		Data: map[string]string{
+			"color": "red",
+		},
+	}
+}
+
+func newDaemonSetControllerTestConfigMapTrackerDisabled() *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		TypeMeta: metav1.TypeMeta{APIVersion: corev1.SchemeGroupVersion.String()},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "podinfo-config-tracker-disabled",
+			Annotations: map[string]string{
+				"unrelated-annotation-1":      "c:",
+				"flagger.app/config-tracking": "disabled",
+				"unrelated-annotation-2":      "^-^",
+			},
+		},
+		Data: map[string]string{
+			"color": "red",
+		},
+	}
+}
+
 func newDaemonSetControllerTestSecret() *corev1.Secret {
 	return &corev1.Secret{
 		TypeMeta: metav1.TypeMeta{APIVersion: corev1.SchemeGroupVersion.String()},
@@ -178,6 +218,44 @@ func newDaemonSetControllerTestSecretVol() *corev1.Secret {
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "default",
 			Name:      "podinfo-secret-vol",
+		},
+		Type: corev1.SecretTypeOpaque,
+		Data: map[string][]byte{
+			"apiKey": []byte("test"),
+		},
+	}
+}
+
+func newDaemonSetControllerTestSecretTrackerEnabled() *corev1.Secret {
+	return &corev1.Secret{
+		TypeMeta: metav1.TypeMeta{APIVersion: corev1.SchemeGroupVersion.String()},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "podinfo-secret-tracker-enabled",
+			Annotations: map[string]string{
+				"unrelated-annotation-1":      ":)",
+				"flagger.app/config-tracking": "enabled",
+				"unrelated-annotation-2":      "<3",
+			},
+		},
+		Type: corev1.SecretTypeOpaque,
+		Data: map[string][]byte{
+			"apiKey": []byte("test"),
+		},
+	}
+}
+
+func newDaemonSetControllerTestSecretTrackerDisabled() *corev1.Secret {
+	return &corev1.Secret{
+		TypeMeta: metav1.TypeMeta{APIVersion: corev1.SchemeGroupVersion.String()},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "podinfo-secret-tracker-disabled",
+			Annotations: map[string]string{
+				"unrelated-annotation-1":      "c:",
+				"flagger.app/config-tracking": "disabled",
+				"unrelated-annotation-2":      "^-^",
+			},
 		},
 		Type: corev1.SecretTypeOpaque,
 		Data: map[string][]byte{
@@ -297,6 +375,26 @@ func newDaemonSetControllerTestPodInfo() *appsv1.DaemonSet {
 									MountPath: "/etc/podinfo/secret",
 									ReadOnly:  true,
 								},
+								{
+									Name:      "config-tracker-enabled",
+									MountPath: "/etc/podinfo/config-tracker-enabled",
+									ReadOnly:  true,
+								},
+								{
+									Name:      "config-tracker-disabled",
+									MountPath: "/etc/podinfo/config-tracker-disabled",
+									ReadOnly:  true,
+								},
+								{
+									Name:      "secret-tracker-enabled",
+									MountPath: "/etc/podinfo/secret-tracker-enabled",
+									ReadOnly:  true,
+								},
+								{
+									Name:      "secret-tracker-disabled",
+									MountPath: "/etc/podinfo/secret-tracker-disabled",
+									ReadOnly:  true,
+								},
 							},
 						},
 					},
@@ -351,6 +449,42 @@ func newDaemonSetControllerTestPodInfo() *appsv1.DaemonSet {
 											},
 										},
 									},
+								},
+							},
+						},
+						{
+							Name: "config-tracker-enabled",
+							VolumeSource: corev1.VolumeSource{
+								ConfigMap: &corev1.ConfigMapVolumeSource{
+									LocalObjectReference: corev1.LocalObjectReference{
+										Name: "podinfo-config-tracker-enabled",
+									},
+								},
+							},
+						},
+						{
+							Name: "config-tracker-disabled",
+							VolumeSource: corev1.VolumeSource{
+								ConfigMap: &corev1.ConfigMapVolumeSource{
+									LocalObjectReference: corev1.LocalObjectReference{
+										Name: "podinfo-config-tracker-disabled",
+									},
+								},
+							},
+						},
+						{
+							Name: "secret-tracker-enabled",
+							VolumeSource: corev1.VolumeSource{
+								Secret: &corev1.SecretVolumeSource{
+									SecretName: "podinfo-secret-tracker-enabled",
+								},
+							},
+						},
+						{
+							Name: "secret-tracker-disabled",
+							VolumeSource: corev1.VolumeSource{
+								Secret: &corev1.SecretVolumeSource{
+									SecretName: "podinfo-secret-tracker-disabled",
 								},
 							},
 						},
@@ -441,6 +575,26 @@ func newDaemonSetControllerTestPodInfoV2() *appsv1.DaemonSet {
 									MountPath: "/etc/podinfo/secret",
 									ReadOnly:  true,
 								},
+								{
+									Name:      "config-tracker-enabled",
+									MountPath: "/etc/podinfo/config-tracker-enabled",
+									ReadOnly:  true,
+								},
+								{
+									Name:      "config-tracker-disabled",
+									MountPath: "/etc/podinfo/config-tracker-disabled",
+									ReadOnly:  true,
+								},
+								{
+									Name:      "secret-tracker-enabled",
+									MountPath: "/etc/podinfo/secret-tracker-enabled",
+									ReadOnly:  true,
+								},
+								{
+									Name:      "secret-tracker-disabled",
+									MountPath: "/etc/podinfo/secret-tracker-disabled",
+									ReadOnly:  true,
+								},
 							},
 						},
 					},
@@ -495,6 +649,42 @@ func newDaemonSetControllerTestPodInfoV2() *appsv1.DaemonSet {
 											},
 										},
 									},
+								},
+							},
+						},
+						{
+							Name: "config-tracker-enabled",
+							VolumeSource: corev1.VolumeSource{
+								ConfigMap: &corev1.ConfigMapVolumeSource{
+									LocalObjectReference: corev1.LocalObjectReference{
+										Name: "podinfo-config-tracker-enabled",
+									},
+								},
+							},
+						},
+						{
+							Name: "config-tracker-disabled",
+							VolumeSource: corev1.VolumeSource{
+								ConfigMap: &corev1.ConfigMapVolumeSource{
+									LocalObjectReference: corev1.LocalObjectReference{
+										Name: "podinfo-config-tracker-disabled",
+									},
+								},
+							},
+						},
+						{
+							Name: "secret-tracker-enabled",
+							VolumeSource: corev1.VolumeSource{
+								Secret: &corev1.SecretVolumeSource{
+									SecretName: "podinfo-secret-tracker-enabled",
+								},
+							},
+						},
+						{
+							Name: "secret-tracker-disabled",
+							VolumeSource: corev1.VolumeSource{
+								Secret: &corev1.SecretVolumeSource{
+									SecretName: "podinfo-secret-tracker-disabled",
 								},
 							},
 						},

--- a/pkg/canary/deployment_fixture_test.go
+++ b/pkg/canary/deployment_fixture_test.go
@@ -64,10 +64,14 @@ func newDeploymentFixture() deploymentControllerFixture {
 		newDeploymentControllerTestConfigMapEnv(),
 		newDeploymentControllerTestConfigMapVol(),
 		newDeploymentControllerTestConfigProjected(),
+		newDeploymentControllerTestConfigMapTrackerEnabled(),
+		newDeploymentControllerTestConfigMapTrackerDisabled(),
 		newDeploymentControllerTestSecret(),
 		newDeploymentControllerTestSecretEnv(),
 		newDeploymentControllerTestSecretVol(),
 		newDeploymentControllerTestSecretProjected(),
+		newDeploymentControllerTestSecretTrackerEnabled(),
+		newDeploymentControllerTestSecretTrackerDisabled(),
 	)
 
 	logger, _ := logger.NewLogger("debug")
@@ -146,6 +150,42 @@ func newDeploymentControllerTestConfigMapEnv() *corev1.ConfigMap {
 	}
 }
 
+func newDeploymentControllerTestConfigMapTrackerEnabled() *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		TypeMeta: metav1.TypeMeta{APIVersion: corev1.SchemeGroupVersion.String()},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "podinfo-config-tracker-enabled",
+			Annotations: map[string]string{
+				"unrelated-annotation-1":      ":)",
+				"flagger.app/config-tracking": "enabled",
+				"unrelated-annotation-2":      "<3",
+			},
+		},
+		Data: map[string]string{
+			"color": "red",
+		},
+	}
+}
+
+func newDeploymentControllerTestConfigMapTrackerDisabled() *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		TypeMeta: metav1.TypeMeta{APIVersion: corev1.SchemeGroupVersion.String()},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "podinfo-config-tracker-disabled",
+			Annotations: map[string]string{
+				"unrelated-annotation-1":      "c:",
+				"flagger.app/config-tracking": "disabled",
+				"unrelated-annotation-2":      "^-^",
+			},
+		},
+		Data: map[string]string{
+			"color": "red",
+		},
+	}
+}
+
 func newDeploymentControllerTestConfigMapVol() *corev1.ConfigMap {
 	return &corev1.ConfigMap{
 		TypeMeta: metav1.TypeMeta{APIVersion: corev1.SchemeGroupVersion.String()},
@@ -207,6 +247,44 @@ func newDeploymentControllerTestSecretVol() *corev1.Secret {
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "default",
 			Name:      "podinfo-secret-vol",
+		},
+		Type: corev1.SecretTypeOpaque,
+		Data: map[string][]byte{
+			"apiKey": []byte("test"),
+		},
+	}
+}
+
+func newDeploymentControllerTestSecretTrackerEnabled() *corev1.Secret {
+	return &corev1.Secret{
+		TypeMeta: metav1.TypeMeta{APIVersion: corev1.SchemeGroupVersion.String()},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "podinfo-secret-tracker-enabled",
+			Annotations: map[string]string{
+				"unrelated-annotation-1":      ":)",
+				"flagger.app/config-tracking": "enabled",
+				"unrelated-annotation-2":      "<3",
+			},
+		},
+		Type: corev1.SecretTypeOpaque,
+		Data: map[string][]byte{
+			"apiKey": []byte("test"),
+		},
+	}
+}
+
+func newDeploymentControllerTestSecretTrackerDisabled() *corev1.Secret {
+	return &corev1.Secret{
+		TypeMeta: metav1.TypeMeta{APIVersion: corev1.SchemeGroupVersion.String()},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "podinfo-secret-tracker-disabled",
+			Annotations: map[string]string{
+				"unrelated-annotation-1":      "c:",
+				"flagger.app/config-tracking": "disabled",
+				"unrelated-annotation-2":      "^-^",
+			},
 		},
 		Type: corev1.SecretTypeOpaque,
 		Data: map[string][]byte{
@@ -337,6 +415,26 @@ func newDeploymentControllerTest() *appsv1.Deployment {
 									MountPath: "/etc/podinfo/secret",
 									ReadOnly:  true,
 								},
+								{
+									Name:      "config-tracker-enabled",
+									MountPath: "/etc/podinfo/config-tracker-enabled",
+									ReadOnly:  true,
+								},
+								{
+									Name:      "config-tracker-disabled",
+									MountPath: "/etc/podinfo/config-tracker-disabled",
+									ReadOnly:  true,
+								},
+								{
+									Name:      "secret-tracker-enabled",
+									MountPath: "/etc/podinfo/secret-tracker-enabled",
+									ReadOnly:  true,
+								},
+								{
+									Name:      "secret-tracker-disabled",
+									MountPath: "/etc/podinfo/secret-tracker-disabled",
+									ReadOnly:  true,
+								},
 							},
 						},
 					},
@@ -391,6 +489,42 @@ func newDeploymentControllerTest() *appsv1.Deployment {
 											},
 										},
 									},
+								},
+							},
+						},
+						{
+							Name: "config-tracker-enabled",
+							VolumeSource: corev1.VolumeSource{
+								ConfigMap: &corev1.ConfigMapVolumeSource{
+									LocalObjectReference: corev1.LocalObjectReference{
+										Name: "podinfo-config-tracker-enabled",
+									},
+								},
+							},
+						},
+						{
+							Name: "config-tracker-disabled",
+							VolumeSource: corev1.VolumeSource{
+								ConfigMap: &corev1.ConfigMapVolumeSource{
+									LocalObjectReference: corev1.LocalObjectReference{
+										Name: "podinfo-config-tracker-disabled",
+									},
+								},
+							},
+						},
+						{
+							Name: "secret-tracker-enabled",
+							VolumeSource: corev1.VolumeSource{
+								Secret: &corev1.SecretVolumeSource{
+									SecretName: "podinfo-secret-tracker-enabled",
+								},
+							},
+						},
+						{
+							Name: "secret-tracker-disabled",
+							VolumeSource: corev1.VolumeSource{
+								Secret: &corev1.SecretVolumeSource{
+									SecretName: "podinfo-secret-tracker-disabled",
 								},
 							},
 						},
@@ -482,6 +616,26 @@ func newDeploymentControllerTestV2() *appsv1.Deployment {
 									MountPath: "/etc/podinfo/secret",
 									ReadOnly:  true,
 								},
+								{
+									Name:      "config-tracker-enabled",
+									MountPath: "/etc/podinfo/config-tracker-enabled",
+									ReadOnly:  true,
+								},
+								{
+									Name:      "config-tracker-disabled",
+									MountPath: "/etc/podinfo/config-tracker-disabled",
+									ReadOnly:  true,
+								},
+								{
+									Name:      "secret-tracker-enabled",
+									MountPath: "/etc/podinfo/secret-tracker-enabled",
+									ReadOnly:  true,
+								},
+								{
+									Name:      "secret-tracker-disabled",
+									MountPath: "/etc/podinfo/secret-tracker-disabled",
+									ReadOnly:  true,
+								},
 							},
 						},
 					},
@@ -536,6 +690,42 @@ func newDeploymentControllerTestV2() *appsv1.Deployment {
 											},
 										},
 									},
+								},
+							},
+						},
+						{
+							Name: "config-tracker-enabled",
+							VolumeSource: corev1.VolumeSource{
+								ConfigMap: &corev1.ConfigMapVolumeSource{
+									LocalObjectReference: corev1.LocalObjectReference{
+										Name: "podinfo-config-tracker-enabled",
+									},
+								},
+							},
+						},
+						{
+							Name: "config-tracker-disabled",
+							VolumeSource: corev1.VolumeSource{
+								ConfigMap: &corev1.ConfigMapVolumeSource{
+									LocalObjectReference: corev1.LocalObjectReference{
+										Name: "podinfo-config-tracker-disabled",
+									},
+								},
+							},
+						},
+						{
+							Name: "secret-tracker-enabled",
+							VolumeSource: corev1.VolumeSource{
+								Secret: &corev1.SecretVolumeSource{
+									SecretName: "podinfo-secret-tracker-enabled",
+								},
+							},
+						},
+						{
+							Name: "secret-tracker-disabled",
+							VolumeSource: corev1.VolumeSource{
+								Secret: &corev1.SecretVolumeSource{
+									SecretName: "podinfo-secret-tracker-disabled",
 								},
 							},
 						},


### PR DESCRIPTION
This allows a user to annotate a specific ConfigMap or Secret to be disabled/ignored via the
configTracking logic that tracks config changes makes configuration copies for the primary Deploy

This is the minimum implementation necessary to support the use-case of using the same db or apiKey
secret for a Canary target. This allows these Secret values to change without triggering a new
Canary analysis. One example where this is helpful is with systems that auto-provision and rotate
secrets. Note the secret manager needs to be able to configure and preserve the flagger specific
annotation.

Annotating a configmap/secret will affect all Canaries with targets referencing them the same way.
Per Canary and per Target API's were discussed but seemed excessive.
We could not think of many scenarios where you would want to enable config-tracking for a specific
config in one workload but disable it for that same exact config in another workload.
It is still possible to implement these per-workload API's on top of this simpler mechanism in the future.

Closes #435