### PR TITLE
pkg/canary: add unit test of configIsDisabled and its optimization

### DIFF
--- a/pkg/canary/config_tracker.go
+++ b/pkg/canary/config_tracker.go
@@ -30,6 +30,8 @@ type ConfigRefType string
 const (
 	ConfigRefMap    ConfigRefType = "configmap"
 	ConfigRefSecret ConfigRefType = "secret"
+
+	configTrackingDisabledAnnotationKey = "flagger.app/config-tracking"
 )
 
 // ConfigRef holds the reference to a tracked Kubernetes ConfigMap or Secret
@@ -52,12 +54,7 @@ func checksum(data interface{}) string {
 }
 
 func configIsDisabled(annotations map[string]string) bool {
-	for k, v := range annotations {
-		if k == "flagger.app/config-tracking" && strings.HasPrefix(v, "disable") {
-			return true
-		}
-	}
-	return false
+	return strings.HasPrefix(annotations[configTrackingDisabledAnnotationKey], "disable")
 }
 
 // getRefFromConfigMap transforms a Kubernetes ConfigMap into a ConfigRef

--- a/pkg/canary/config_tracker_test.go
+++ b/pkg/canary/config_tracker_test.go
@@ -10,6 +10,19 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+func TestConfigIsDisabled(t *testing.T) {
+	for _, c := range []struct {
+		annotations map[string]string
+		exp         bool
+	}{
+		{annotations: map[string]string{configTrackingDisabledAnnotationKey: "disable"}, exp: true},
+		{annotations: map[string]string{"app": "disable"}, exp: false},
+		{annotations: map[string]string{}, exp: false},
+	} {
+		assert.Equal(t, configIsDisabled(c.annotations), c.exp)
+	}
+}
+
 func TestConfigTracker_ConfigMaps(t *testing.T) {
 	t.Run("deployment", func(t *testing.T) {
 		mocks := newDeploymentFixture()


### PR DESCRIPTION
related to #671 

___


I added the unittest for `configIsDisabled` and modified it so that we do not need to do linear search