### PR TITLE
Derive the label selector value from the target matchLabels

### DIFF
--- a/pkg/canary/config_tracker_test.go
+++ b/pkg/canary/config_tracker_test.go
@@ -25,7 +25,8 @@ func TestConfigIsDisabled(t *testing.T) {
 
 func TestConfigTracker_ConfigMaps(t *testing.T) {
 	t.Run("deployment", func(t *testing.T) {
-		mocks := newDeploymentFixture()
+		depConfig := deploymentConfigs{name: "podinfo", label: "name", labelValue: "podinfo"}
+		mocks := newDeploymentFixture(depConfig)
 		configMap := newDeploymentControllerTestConfigMap()
 		configMapProjected := newDeploymentControllerTestConfigProjected()
 
@@ -156,7 +157,8 @@ func TestConfigTracker_ConfigMaps(t *testing.T) {
 
 func TestConfigTracker_Secrets(t *testing.T) {
 	t.Run("deployment", func(t *testing.T) {
-		mocks := newDeploymentFixture()
+		depConfig := deploymentConfigs{name: "podinfo", label: "name", labelValue: "podinfo"}
+		mocks := newDeploymentFixture(depConfig)
 		secret := newDeploymentControllerTestSecret()
 		secretProjected := newDeploymentControllerTestSecretProjected()
 

--- a/pkg/canary/config_tracker_test.go
+++ b/pkg/canary/config_tracker_test.go
@@ -25,8 +25,8 @@ func TestConfigIsDisabled(t *testing.T) {
 
 func TestConfigTracker_ConfigMaps(t *testing.T) {
 	t.Run("deployment", func(t *testing.T) {
-		depConfig := deploymentConfigs{name: "podinfo", label: "name", labelValue: "podinfo"}
-		mocks := newDeploymentFixture(depConfig)
+		dc := deploymentConfigs{name: "podinfo", label: "name", labelValue: "podinfo"}
+		mocks := newDeploymentFixture(dc)
 		configMap := newDeploymentControllerTestConfigMap()
 		configMapProjected := newDeploymentControllerTestConfigProjected()
 
@@ -90,7 +90,8 @@ func TestConfigTracker_ConfigMaps(t *testing.T) {
 	})
 
 	t.Run("daemonset", func(t *testing.T) {
-		mocks := newDaemonSetFixture()
+		dc := daemonsetConfigs{name: "podinfo", label: "name", labelValue: "podinfo"}
+		mocks := newDaemonSetFixture(dc)
 		configMap := newDaemonSetControllerTestConfigMap()
 		configMapProjected := newDaemonSetControllerTestConfigProjected()
 
@@ -157,8 +158,8 @@ func TestConfigTracker_ConfigMaps(t *testing.T) {
 
 func TestConfigTracker_Secrets(t *testing.T) {
 	t.Run("deployment", func(t *testing.T) {
-		depConfig := deploymentConfigs{name: "podinfo", label: "name", labelValue: "podinfo"}
-		mocks := newDeploymentFixture(depConfig)
+		dc := deploymentConfigs{name: "podinfo", label: "name", labelValue: "podinfo"}
+		mocks := newDeploymentFixture(dc)
 		secret := newDeploymentControllerTestSecret()
 		secretProjected := newDeploymentControllerTestSecretProjected()
 
@@ -222,7 +223,8 @@ func TestConfigTracker_Secrets(t *testing.T) {
 	})
 
 	t.Run("daemonset", func(t *testing.T) {
-		mocks := newDaemonSetFixture()
+		dc := daemonsetConfigs{name: "podinfo", label: "name", labelValue: "podinfo"}
+		mocks := newDaemonSetFixture(dc)
 		secret := newDaemonSetControllerTestSecret()
 		secretProjected := newDaemonSetControllerTestSecretProjected()
 

--- a/pkg/canary/controller.go
+++ b/pkg/canary/controller.go
@@ -7,7 +7,7 @@ import (
 type Controller interface {
 	IsPrimaryReady(canary *flaggerv1.Canary) error
 	IsCanaryReady(canary *flaggerv1.Canary) (bool, error)
-	GetMetadata(canary *flaggerv1.Canary) (string, map[string]int32, error)
+	GetMetadata(canary *flaggerv1.Canary) (string, string, map[string]int32, error)
 	SyncStatus(canary *flaggerv1.Canary, status flaggerv1.CanaryStatus) error
 	SetStatusFailedChecks(canary *flaggerv1.Canary, val int) error
 	SetStatusWeight(canary *flaggerv1.Canary, val int) error

--- a/pkg/canary/daemonset_controller.go
+++ b/pkg/canary/daemonset_controller.go
@@ -108,7 +108,7 @@ func (c *DaemonSetController) Promote(cd *flaggerv1.Canary) error {
 	}
 
 	label, labelValue, err := c.getSelectorLabel(canary)
-	primaryLabelValue := fmt.Sprintf("%s-primary", labelValue);
+	primaryLabelValue := fmt.Sprintf("%s-primary", labelValue)
 	if err != nil {
 		return fmt.Errorf("getSelectorLabel failed: %w", err)
 	}
@@ -216,7 +216,7 @@ func (c *DaemonSetController) createPrimaryDaemonSet(cd *flaggerv1.Canary) error
 	}
 
 	label, labelValue, err := c.getSelectorLabel(canaryDae)
-	primaryLabelValue := fmt.Sprintf("%s-primary", labelValue);
+	primaryLabelValue := fmt.Sprintf("%s-primary", labelValue)
 	if err != nil {
 		return fmt.Errorf("getSelectorLabel failed: %w", err)
 	}

--- a/pkg/canary/daemonset_controller.go
+++ b/pkg/canary/daemonset_controller.go
@@ -108,6 +108,7 @@ func (c *DaemonSetController) Promote(cd *flaggerv1.Canary) error {
 	}
 
 	label, labelValue, err := c.getSelectorLabel(canary)
+	primaryLabelValue := fmt.Sprintf("%s-primary", labelValue);
 	if err != nil {
 		return fmt.Errorf("getSelectorLabel failed: %w", err)
 	}
@@ -146,7 +147,7 @@ func (c *DaemonSetController) Promote(cd *flaggerv1.Canary) error {
 	}
 
 	primaryCopy.Spec.Template.Annotations = annotations
-	primaryCopy.Spec.Template.Labels = makePrimaryLabels(canary.Spec.Template.Labels, labelValue, label)
+	primaryCopy.Spec.Template.Labels = makePrimaryLabels(canary.Spec.Template.Labels, primaryLabelValue, label)
 
 	// apply update
 	_, err = c.kubeClient.AppsV1().DaemonSets(cd.Namespace).Update(context.TODO(), primaryCopy, metav1.UpdateOptions{})

--- a/pkg/canary/daemonset_controller.go
+++ b/pkg/canary/daemonset_controller.go
@@ -107,7 +107,7 @@ func (c *DaemonSetController) Promote(cd *flaggerv1.Canary) error {
 		return fmt.Errorf("damonset %s.%s get query error: %v", targetName, cd.Namespace, err)
 	}
 
-	label, err := c.getSelectorLabel(canary)
+	label, labelValue, err := c.getSelectorLabel(canary)
 	if err != nil {
 		return fmt.Errorf("getSelectorLabel failed: %w", err)
 	}
@@ -146,7 +146,7 @@ func (c *DaemonSetController) Promote(cd *flaggerv1.Canary) error {
 	}
 
 	primaryCopy.Spec.Template.Annotations = annotations
-	primaryCopy.Spec.Template.Labels = makePrimaryLabels(canary.Spec.Template.Labels, primaryName, label)
+	primaryCopy.Spec.Template.Labels = makePrimaryLabels(canary.Spec.Template.Labels, labelValue, label)
 
 	// apply update
 	_, err = c.kubeClient.AppsV1().DaemonSets(cd.Namespace).Update(context.TODO(), primaryCopy, metav1.UpdateOptions{})
@@ -179,24 +179,24 @@ func (c *DaemonSetController) HasTargetChanged(cd *flaggerv1.Canary) (bool, erro
 }
 
 // GetMetadata returns the pod label selector and svc ports
-func (c *DaemonSetController) GetMetadata(cd *flaggerv1.Canary) (string, map[string]int32, error) {
+func (c *DaemonSetController) GetMetadata(cd *flaggerv1.Canary) (string, string, map[string]int32, error) {
 	targetName := cd.Spec.TargetRef.Name
 
 	canaryDae, err := c.kubeClient.AppsV1().DaemonSets(cd.Namespace).Get(context.TODO(), targetName, metav1.GetOptions{})
 	if err != nil {
-		return "", nil, fmt.Errorf("daemonset %s.%s get query error: %w", targetName, cd.Namespace, err)
+		return "", "", nil, fmt.Errorf("daemonset %s.%s get query error: %w", targetName, cd.Namespace, err)
 	}
 
-	label, err := c.getSelectorLabel(canaryDae)
+	label, labelValue, err := c.getSelectorLabel(canaryDae)
 	if err != nil {
-		return "", nil, fmt.Errorf("getSelectorLabel failed: %w", err)
+		return "", "", nil, fmt.Errorf("getSelectorLabel failed: %w", err)
 	}
 
 	var ports map[string]int32
 	if cd.Spec.Service.PortDiscovery {
 		ports = getPorts(cd, canaryDae.Spec.Template.Spec.Containers)
 	}
-	return label, ports, nil
+	return label, labelValue, ports, nil
 }
 
 func (c *DaemonSetController) createPrimaryDaemonSet(cd *flaggerv1.Canary) error {
@@ -214,7 +214,7 @@ func (c *DaemonSetController) createPrimaryDaemonSet(cd *flaggerv1.Canary) error
 			targetName, cd.Namespace, canaryDae.Spec.UpdateStrategy.Type)
 	}
 
-	label, err := c.getSelectorLabel(canaryDae)
+	label, labelValue, err := c.getSelectorLabel(canaryDae)
 	if err != nil {
 		return fmt.Errorf("getSelectorLabel failed: %w", err)
 	}
@@ -240,7 +240,7 @@ func (c *DaemonSetController) createPrimaryDaemonSet(cd *flaggerv1.Canary) error
 				Name:      primaryName,
 				Namespace: cd.Namespace,
 				Labels: map[string]string{
-					label: primaryName,
+					label: labelValue,
 				},
 				OwnerReferences: []metav1.OwnerReference{
 					*metav1.NewControllerRef(cd, schema.GroupVersionKind{
@@ -256,12 +256,12 @@ func (c *DaemonSetController) createPrimaryDaemonSet(cd *flaggerv1.Canary) error
 				UpdateStrategy:       canaryDae.Spec.UpdateStrategy,
 				Selector: &metav1.LabelSelector{
 					MatchLabels: map[string]string{
-						label: primaryName,
+						label: labelValue,
 					},
 				},
 				Template: corev1.PodTemplateSpec{
 					ObjectMeta: metav1.ObjectMeta{
-						Labels:      makePrimaryLabels(canaryDae.Spec.Template.Labels, primaryName, label),
+						Labels:      makePrimaryLabels(canaryDae.Spec.Template.Labels, labelValue, label),
 						Annotations: annotations,
 					},
 					// update spec with the primary secrets and config maps
@@ -281,14 +281,14 @@ func (c *DaemonSetController) createPrimaryDaemonSet(cd *flaggerv1.Canary) error
 }
 
 // getSelectorLabel returns the selector match label
-func (c *DaemonSetController) getSelectorLabel(daemonSet *appsv1.DaemonSet) (string, error) {
+func (c *DaemonSetController) getSelectorLabel(daemonSet *appsv1.DaemonSet) (string, string, error) {
 	for _, l := range c.labels {
 		if _, ok := daemonSet.Spec.Selector.MatchLabels[l]; ok {
-			return l, nil
+			return l, daemonSet.Spec.Selector.MatchLabels[l], nil
 		}
 	}
 
-	return "", fmt.Errorf(
+	return "", "", fmt.Errorf(
 		"daemonset %s.%s spec.selector.matchLabels must contain one of %v'",
 		daemonSet.Name, daemonSet.Namespace, c.labels,
 	)

--- a/pkg/canary/daemonset_controller.go
+++ b/pkg/canary/daemonset_controller.go
@@ -215,6 +215,7 @@ func (c *DaemonSetController) createPrimaryDaemonSet(cd *flaggerv1.Canary) error
 	}
 
 	label, labelValue, err := c.getSelectorLabel(canaryDae)
+	primaryLabelValue := fmt.Sprintf("%s-primary", labelValue);
 	if err != nil {
 		return fmt.Errorf("getSelectorLabel failed: %w", err)
 	}
@@ -240,7 +241,7 @@ func (c *DaemonSetController) createPrimaryDaemonSet(cd *flaggerv1.Canary) error
 				Name:      primaryName,
 				Namespace: cd.Namespace,
 				Labels: map[string]string{
-					label: labelValue,
+					label: primaryLabelValue,
 				},
 				OwnerReferences: []metav1.OwnerReference{
 					*metav1.NewControllerRef(cd, schema.GroupVersionKind{
@@ -256,12 +257,12 @@ func (c *DaemonSetController) createPrimaryDaemonSet(cd *flaggerv1.Canary) error
 				UpdateStrategy:       canaryDae.Spec.UpdateStrategy,
 				Selector: &metav1.LabelSelector{
 					MatchLabels: map[string]string{
-						label: labelValue,
+						label: primaryLabelValue,
 					},
 				},
 				Template: corev1.PodTemplateSpec{
 					ObjectMeta: metav1.ObjectMeta{
-						Labels:      makePrimaryLabels(canaryDae.Spec.Template.Labels, labelValue, label),
+						Labels:      makePrimaryLabels(canaryDae.Spec.Template.Labels, primaryLabelValue, label),
 						Annotations: annotations,
 					},
 					// update spec with the primary secrets and config maps

--- a/pkg/canary/daemonset_controller_test.go
+++ b/pkg/canary/daemonset_controller_test.go
@@ -15,21 +15,23 @@ import (
 )
 
 func TestDaemonSetController_Sync(t *testing.T) {
-	mocks := newDaemonSetFixture()
+	dc := daemonsetConfigs{name: "podinfo", label: "name", labelValue: "podinfo"}
+	mocks := newDaemonSetFixture(dc)
 	err := mocks.controller.Initialize(mocks.canary)
 	require.NoError(t, err)
 
 	daePrimary, err := mocks.kubeClient.AppsV1().DaemonSets("default").Get(context.TODO(), "podinfo-primary", metav1.GetOptions{})
 	require.NoError(t, err)
 
-	dae := newDaemonSetControllerTestPodInfo()
+	dae := newDaemonSetControllerTestPodInfo(dc)
 	primaryImage := daePrimary.Spec.Template.Spec.Containers[0].Image
 	sourceImage := dae.Spec.Template.Spec.Containers[0].Image
 	assert.Equal(t, primaryImage, sourceImage)
 }
 
 func TestDaemonSetController_Promote(t *testing.T) {
-	mocks := newDaemonSetFixture()
+	dc := daemonsetConfigs{name: "podinfo", label: "name", labelValue: "podinfo"}
+	mocks := newDaemonSetFixture(dc)
 	err := mocks.controller.Initialize(mocks.canary)
 	require.NoError(t, err)
 
@@ -58,7 +60,8 @@ func TestDaemonSetController_Promote(t *testing.T) {
 }
 
 func TestDaemonSetController_NoConfigTracking(t *testing.T) {
-	mocks := newDaemonSetFixture()
+	dc := daemonsetConfigs{name: "podinfo", label: "name", labelValue: "podinfo"}
+	mocks := newDaemonSetFixture(dc)
 	mocks.controller.configTracker = &NopTracker{}
 
 	err := mocks.controller.Initialize(mocks.canary)
@@ -75,7 +78,8 @@ func TestDaemonSetController_NoConfigTracking(t *testing.T) {
 }
 
 func TestDaemonSetController_HasTargetChanged(t *testing.T) {
-	mocks := newDaemonSetFixture()
+	dc := daemonsetConfigs{name: "podinfo", label: "name", labelValue: "podinfo"}
+	mocks := newDaemonSetFixture(dc)
 	err := mocks.controller.Initialize(mocks.canary)
 	require.NoError(t, err)
 
@@ -163,7 +167,8 @@ func TestDaemonSetController_HasTargetChanged(t *testing.T) {
 
 func TestDaemonSetController_Scale(t *testing.T) {
 	t.Run("ScaleToZero", func(t *testing.T) {
-		mocks := newDaemonSetFixture()
+		dc := daemonsetConfigs{name: "podinfo", label: "name", labelValue: "podinfo"}
+		mocks := newDaemonSetFixture(dc)
 		err := mocks.controller.Initialize(mocks.canary)
 		require.NoError(t, err)
 
@@ -179,7 +184,8 @@ func TestDaemonSetController_Scale(t *testing.T) {
 		}
 	})
 	t.Run("ScaleFromZeo", func(t *testing.T) {
-		mocks := newDaemonSetFixture()
+		dc := daemonsetConfigs{name: "podinfo", label: "name", labelValue: "podinfo"}
+		mocks := newDaemonSetFixture(dc)
 		err := mocks.controller.Initialize(mocks.canary)
 		require.NoError(t, err)
 
@@ -197,7 +203,8 @@ func TestDaemonSetController_Scale(t *testing.T) {
 }
 
 func TestDaemonSetController_Finalize(t *testing.T) {
-	mocks := newDaemonSetFixture()
+	dc := daemonsetConfigs{name: "podinfo", label: "name", labelValue: "podinfo"}
+	mocks := newDaemonSetFixture(dc)
 	err := mocks.controller.Initialize(mocks.canary)
 	require.NoError(t, err)
 

--- a/pkg/canary/daemonset_fixture_test.go
+++ b/pkg/canary/daemonset_fixture_test.go
@@ -23,14 +23,20 @@ type daemonSetControllerFixture struct {
 	logger        *zap.SugaredLogger
 }
 
-func newDaemonSetFixture() daemonSetControllerFixture {
+type daemonsetConfigs struct {
+	name       string
+	labelValue string
+	label      string
+}
+
+func newDaemonSetFixture(dc daemonsetConfigs) daemonSetControllerFixture {
 	// init canary
 	canary := newDaemonSetControllerTestCanary()
 	flaggerClient := fakeFlagger.NewSimpleClientset(canary)
 
 	// init kube clientset and register mock objects
 	kubeClient := fake.NewSimpleClientset(
-		newDaemonSetControllerTestPodInfo(),
+		newDaemonSetControllerTestPodInfo(dc),
 		newDaemonSetControllerTestConfigMap(),
 		newDaemonSetControllerTestConfigMapEnv(),
 		newDaemonSetControllerTestConfigMapVol(),
@@ -282,23 +288,23 @@ func newDaemonSetControllerTestCanary() *flaggerv1.Canary {
 	return cd
 }
 
-func newDaemonSetControllerTestPodInfo() *appsv1.DaemonSet {
+func newDaemonSetControllerTestPodInfo(dc daemonsetConfigs) *appsv1.DaemonSet {
 	d := &appsv1.DaemonSet{
 		TypeMeta: metav1.TypeMeta{APIVersion: appsv1.SchemeGroupVersion.String()},
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "default",
-			Name:      "podinfo",
+			Name:      dc.name,
 		},
 		Spec: appsv1.DaemonSetSpec{
 			Selector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
-					"name": "podinfo",
+					dc.label: dc.labelValue,
 				},
 			},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
-						"name": "podinfo",
+						dc.label: dc.labelValue,
 					},
 				},
 				Spec: corev1.PodSpec{

--- a/pkg/canary/daemonset_fixture_test.go
+++ b/pkg/canary/daemonset_fixture_test.go
@@ -31,7 +31,7 @@ type daemonsetConfigs struct {
 
 func newDaemonSetFixture(dc daemonsetConfigs) daemonSetControllerFixture {
 	// init canary
-	canary := newDaemonSetControllerTestCanary()
+	canary := newDaemonSetControllerTestCanary(dc)
 	flaggerClient := fakeFlagger.NewSimpleClientset(canary)
 
 	// init kube clientset and register mock objects
@@ -270,7 +270,7 @@ func newDaemonSetControllerTestSecretTrackerDisabled() *corev1.Secret {
 	}
 }
 
-func newDaemonSetControllerTestCanary() *flaggerv1.Canary {
+func newDaemonSetControllerTestCanary(dc daemonsetConfigs) *flaggerv1.Canary {
 	cd := &flaggerv1.Canary{
 		TypeMeta: metav1.TypeMeta{APIVersion: flaggerv1.SchemeGroupVersion.String()},
 		ObjectMeta: metav1.ObjectMeta{
@@ -279,7 +279,7 @@ func newDaemonSetControllerTestCanary() *flaggerv1.Canary {
 		},
 		Spec: flaggerv1.CanarySpec{
 			TargetRef: flaggerv1.CrossNamespaceObjectReference{
-				Name:       "podinfo",
+				Name:       dc.name,
 				APIVersion: "apps/v1",
 				Kind:       "DaemonSet",
 			},

--- a/pkg/canary/daemonset_ready_test.go
+++ b/pkg/canary/daemonset_ready_test.go
@@ -12,7 +12,8 @@ import (
 )
 
 func TestDaemonSetController_IsReady(t *testing.T) {
-	mocks := newDaemonSetFixture()
+	dc := daemonsetConfigs{name: "podinfo", label: "name", labelValue: "podinfo"}
+	mocks := newDaemonSetFixture(dc)
 	err := mocks.controller.Initialize(mocks.canary)
 	require.NoError(t, err)
 
@@ -24,7 +25,8 @@ func TestDaemonSetController_IsReady(t *testing.T) {
 }
 
 func TestDaemonSetController_isDaemonSetReady(t *testing.T) {
-	mocks := newDaemonSetFixture()
+	dc := daemonsetConfigs{name: "podinfo", label: "name", labelValue: "podinfo"}
+	mocks := newDaemonSetFixture(dc)
 	cd := &flaggerv1.Canary{}
 
 	// observed generation is less than desired generation

--- a/pkg/canary/daemonset_status_test.go
+++ b/pkg/canary/daemonset_status_test.go
@@ -12,7 +12,8 @@ import (
 )
 
 func TestDaemonSetController_SyncStatus(t *testing.T) {
-	mocks := newDaemonSetFixture()
+	dc := daemonsetConfigs{name: "podinfo", label: "name", labelValue: "podinfo"}
+	mocks := newDaemonSetFixture(dc)
 	err := mocks.controller.Initialize(mocks.canary)
 	require.NoError(t, err)
 
@@ -36,7 +37,8 @@ func TestDaemonSetController_SyncStatus(t *testing.T) {
 }
 
 func TestDaemonSetController_SetFailedChecks(t *testing.T) {
-	mocks := newDaemonSetFixture()
+	dc := daemonsetConfigs{name: "podinfo", label: "name", labelValue: "podinfo"}
+	mocks := newDaemonSetFixture(dc)
 	err := mocks.controller.Initialize(mocks.canary)
 	require.NoError(t, err)
 
@@ -49,7 +51,8 @@ func TestDaemonSetController_SetFailedChecks(t *testing.T) {
 }
 
 func TestDaemonSetController_SetState(t *testing.T) {
-	mocks := newDaemonSetFixture()
+	dc := daemonsetConfigs{name: "podinfo", label: "name", labelValue: "podinfo"}
+	mocks := newDaemonSetFixture(dc)
 	err := mocks.controller.Initialize(mocks.canary)
 	require.NoError(t, err)
 

--- a/pkg/canary/deployment_controller.go
+++ b/pkg/canary/deployment_controller.go
@@ -73,6 +73,7 @@ func (c *DeploymentController) Promote(cd *flaggerv1.Canary) error {
 	}
 
 	label, labelValue, err := c.getSelectorLabel(canary)
+	primaryLabelValue := fmt.Sprintf("%s-primary", labelValue);
 	if err != nil {
 		return fmt.Errorf("getSelectorLabel failed: %w", err)
 	}
@@ -107,7 +108,7 @@ func (c *DeploymentController) Promote(cd *flaggerv1.Canary) error {
 	}
 
 	primaryCopy.Spec.Template.Annotations = annotations
-	primaryCopy.Spec.Template.Labels = makePrimaryLabels(canary.Spec.Template.Labels, labelValue, label)
+	primaryCopy.Spec.Template.Labels = makePrimaryLabels(canary.Spec.Template.Labels, primaryLabelValue, label)
 
 	// apply update
 	_, err = c.kubeClient.AppsV1().Deployments(cd.Namespace).Update(context.TODO(), primaryCopy, metav1.UpdateOptions{})

--- a/pkg/canary/deployment_controller.go
+++ b/pkg/canary/deployment_controller.go
@@ -211,6 +211,7 @@ func (c *DeploymentController) createPrimaryDeployment(cd *flaggerv1.Canary) err
 	}
 
 	label, labelValue, err := c.getSelectorLabel(canaryDep)
+	primaryLabelValue := fmt.Sprintf("%s-primary", labelValue);
 	if err != nil {
 		return fmt.Errorf("getSelectorLabel failed: %w", err)
 	}
@@ -241,7 +242,7 @@ func (c *DeploymentController) createPrimaryDeployment(cd *flaggerv1.Canary) err
 				Name:      primaryName,
 				Namespace: cd.Namespace,
 				Labels: map[string]string{
-					label: labelValue,
+					label: primaryLabelValue,
 				},
 				OwnerReferences: []metav1.OwnerReference{
 					*metav1.NewControllerRef(cd, schema.GroupVersionKind{
@@ -259,12 +260,12 @@ func (c *DeploymentController) createPrimaryDeployment(cd *flaggerv1.Canary) err
 				Strategy:                canaryDep.Spec.Strategy,
 				Selector: &metav1.LabelSelector{
 					MatchLabels: map[string]string{
-						label: labelValue,
+						label: primaryLabelValue,
 					},
 				},
 				Template: corev1.PodTemplateSpec{
 					ObjectMeta: metav1.ObjectMeta{
-						Labels:      makePrimaryLabels(canaryDep.Spec.Template.Labels, primaryName, label),
+						Labels:      makePrimaryLabels(canaryDep.Spec.Template.Labels, primaryLabelValue, label),
 						Annotations: annotations,
 					},
 					// update spec with the primary secrets and config maps

--- a/pkg/canary/deployment_controller.go
+++ b/pkg/canary/deployment_controller.go
@@ -73,7 +73,7 @@ func (c *DeploymentController) Promote(cd *flaggerv1.Canary) error {
 	}
 
 	label, labelValue, err := c.getSelectorLabel(canary)
-	primaryLabelValue := fmt.Sprintf("%s-primary", labelValue);
+	primaryLabelValue := fmt.Sprintf("%s-primary", labelValue)
 	if err != nil {
 		return fmt.Errorf("getSelectorLabel failed: %w", err)
 	}
@@ -212,7 +212,7 @@ func (c *DeploymentController) createPrimaryDeployment(cd *flaggerv1.Canary) err
 	}
 
 	label, labelValue, err := c.getSelectorLabel(canaryDep)
-	primaryLabelValue := fmt.Sprintf("%s-primary", labelValue);
+	primaryLabelValue := fmt.Sprintf("%s-primary", labelValue)
 	if err != nil {
 		return fmt.Errorf("getSelectorLabel failed: %w", err)
 	}

--- a/pkg/canary/deployment_controller_test.go
+++ b/pkg/canary/deployment_controller_test.go
@@ -15,13 +15,14 @@ import (
 )
 
 func TestDeploymentController_Sync(t *testing.T) {
-	mocks := newDeploymentFixture()
+	depConfig := deploymentConfigs{name: "podinfo", label: "name", labelValue: "podinfo"}
+	mocks := newDeploymentFixture(depConfig)
 	mocks.initializeCanary(t)
 
 	depPrimary, err := mocks.kubeClient.AppsV1().Deployments("default").Get(context.TODO(), "podinfo-primary", metav1.GetOptions{})
 	require.NoError(t, err)
 
-	dep := newDeploymentControllerTest()
+	dep := newDeploymentControllerTest(depConfig)
 	primaryImage := depPrimary.Spec.Template.Spec.Containers[0].Image
 	sourceImage := dep.Spec.Template.Spec.Containers[0].Image
 	assert.Equal(t, sourceImage, primaryImage)
@@ -32,7 +33,8 @@ func TestDeploymentController_Sync(t *testing.T) {
 }
 
 func TestDeploymentController_Promote(t *testing.T) {
-	mocks := newDeploymentFixture()
+	depConfig := deploymentConfigs{name: "podinfo", label: "name", labelValue: "podinfo"}
+	mocks := newDeploymentFixture(depConfig)
 	mocks.initializeCanary(t)
 
 	dep2 := newDeploymentControllerTestV2()
@@ -72,7 +74,8 @@ func TestDeploymentController_Promote(t *testing.T) {
 }
 
 func TestDeploymentController_ScaleToZero(t *testing.T) {
-	mocks := newDeploymentFixture()
+	depConfig := deploymentConfigs{name: "podinfo", label: "name", labelValue: "podinfo"}
+	mocks := newDeploymentFixture(depConfig)
 	mocks.initializeCanary(t)
 
 	err := mocks.controller.ScaleToZero(mocks.canary)
@@ -84,7 +87,8 @@ func TestDeploymentController_ScaleToZero(t *testing.T) {
 }
 
 func TestDeploymentController_NoConfigTracking(t *testing.T) {
-	mocks := newDeploymentFixture()
+	depConfig := deploymentConfigs{name: "podinfo", label: "name", labelValue: "podinfo"}
+	mocks := newDeploymentFixture(depConfig)
 	mocks.controller.configTracker = &NopTracker{}
 	mocks.initializeCanary(t)
 
@@ -99,7 +103,8 @@ func TestDeploymentController_NoConfigTracking(t *testing.T) {
 }
 
 func TestDeploymentController_HasTargetChanged(t *testing.T) {
-	mocks := newDeploymentFixture()
+	depConfig := deploymentConfigs{name: "podinfo", label: "name", labelValue: "podinfo"}
+	mocks := newDeploymentFixture(depConfig)
 	mocks.initializeCanary(t)
 
 	// save last applied hash
@@ -185,7 +190,8 @@ func TestDeploymentController_HasTargetChanged(t *testing.T) {
 }
 
 func TestDeploymentController_Finalize(t *testing.T) {
-	mocks := newDeploymentFixture()
+	depConfig := deploymentConfigs{name: "podinfo", label: "name", labelValue: "podinfo"}
+	mocks := newDeploymentFixture(depConfig)
 
 	for _, tc := range []struct {
 		mocks          deploymentControllerFixture

--- a/pkg/canary/deployment_controller_test.go
+++ b/pkg/canary/deployment_controller_test.go
@@ -29,8 +29,7 @@ func TestDeploymentController_Sync_ConsistentNaming(t *testing.T) {
 	assert.Equal(t, sourceImage, primaryImage)
 
 	primarySelectorValue := depPrimary.Spec.Selector.MatchLabels[dc.label]
-	sourceSelectorValue := dep.Spec.Selector.MatchLabels[dc.label]
-	assert.Equal(t, primarySelectorValue, fmt.Sprintf("%s-primary", sourceSelectorValue))
+	assert.Equal(t, primarySelectorValue, fmt.Sprintf("%s-primary", dc.labelValue))
 
 	hpaPrimary, err := mocks.kubeClient.AutoscalingV2beta1().HorizontalPodAutoscalers("default").Get(context.TODO(), "podinfo-primary", metav1.GetOptions{})
 	require.NoError(t, err)
@@ -51,8 +50,7 @@ func TestDeploymentController_Sync_InconsistentNaming(t *testing.T) {
 	assert.Equal(t, sourceImage, primaryImage)
 
 	primarySelectorValue := depPrimary.Spec.Selector.MatchLabels[dc.label]
-	sourceSelectorValue := dep.Spec.Selector.MatchLabels[dc.label]
-	assert.Equal(t, primarySelectorValue, fmt.Sprintf("%s-primary", sourceSelectorValue))
+	assert.Equal(t, primarySelectorValue, fmt.Sprintf("%s-primary", dc.labelValue))
 
 	hpaPrimary, err := mocks.kubeClient.AutoscalingV2beta1().HorizontalPodAutoscalers("default").Get(context.TODO(), "podinfo-primary", metav1.GetOptions{})
 	require.NoError(t, err)

--- a/pkg/canary/deployment_controller_test.go
+++ b/pkg/canary/deployment_controller_test.go
@@ -15,14 +15,14 @@ import (
 )
 
 func TestDeploymentController_Sync(t *testing.T) {
-	depConfig := deploymentConfigs{name: "podinfo", label: "name", labelValue: "podinfo"}
-	mocks := newDeploymentFixture(depConfig)
+	dc := deploymentConfigs{name: "podinfo", label: "name", labelValue: "podinfo"}
+	mocks := newDeploymentFixture(dc)
 	mocks.initializeCanary(t)
 
 	depPrimary, err := mocks.kubeClient.AppsV1().Deployments("default").Get(context.TODO(), "podinfo-primary", metav1.GetOptions{})
 	require.NoError(t, err)
 
-	dep := newDeploymentControllerTest(depConfig)
+	dep := newDeploymentControllerTest(dc)
 	primaryImage := depPrimary.Spec.Template.Spec.Containers[0].Image
 	sourceImage := dep.Spec.Template.Spec.Containers[0].Image
 	assert.Equal(t, sourceImage, primaryImage)
@@ -33,8 +33,8 @@ func TestDeploymentController_Sync(t *testing.T) {
 }
 
 func TestDeploymentController_Promote(t *testing.T) {
-	depConfig := deploymentConfigs{name: "podinfo", label: "name", labelValue: "podinfo"}
-	mocks := newDeploymentFixture(depConfig)
+	dc := deploymentConfigs{name: "podinfo", label: "name", labelValue: "podinfo"}
+	mocks := newDeploymentFixture(dc)
 	mocks.initializeCanary(t)
 
 	dep2 := newDeploymentControllerTestV2()
@@ -74,8 +74,8 @@ func TestDeploymentController_Promote(t *testing.T) {
 }
 
 func TestDeploymentController_ScaleToZero(t *testing.T) {
-	depConfig := deploymentConfigs{name: "podinfo", label: "name", labelValue: "podinfo"}
-	mocks := newDeploymentFixture(depConfig)
+	dc := deploymentConfigs{name: "podinfo", label: "name", labelValue: "podinfo"}
+	mocks := newDeploymentFixture(dc)
 	mocks.initializeCanary(t)
 
 	err := mocks.controller.ScaleToZero(mocks.canary)
@@ -87,8 +87,8 @@ func TestDeploymentController_ScaleToZero(t *testing.T) {
 }
 
 func TestDeploymentController_NoConfigTracking(t *testing.T) {
-	depConfig := deploymentConfigs{name: "podinfo", label: "name", labelValue: "podinfo"}
-	mocks := newDeploymentFixture(depConfig)
+	dc := deploymentConfigs{name: "podinfo", label: "name", labelValue: "podinfo"}
+	mocks := newDeploymentFixture(dc)
 	mocks.controller.configTracker = &NopTracker{}
 	mocks.initializeCanary(t)
 
@@ -103,8 +103,8 @@ func TestDeploymentController_NoConfigTracking(t *testing.T) {
 }
 
 func TestDeploymentController_HasTargetChanged(t *testing.T) {
-	depConfig := deploymentConfigs{name: "podinfo", label: "name", labelValue: "podinfo"}
-	mocks := newDeploymentFixture(depConfig)
+	dc := deploymentConfigs{name: "podinfo", label: "name", labelValue: "podinfo"}
+	mocks := newDeploymentFixture(dc)
 	mocks.initializeCanary(t)
 
 	// save last applied hash
@@ -190,8 +190,8 @@ func TestDeploymentController_HasTargetChanged(t *testing.T) {
 }
 
 func TestDeploymentController_Finalize(t *testing.T) {
-	depConfig := deploymentConfigs{name: "podinfo", label: "name", labelValue: "podinfo"}
-	mocks := newDeploymentFixture(depConfig)
+	dc := deploymentConfigs{name: "podinfo", label: "name", labelValue: "podinfo"}
+	mocks := newDeploymentFixture(dc)
 
 	for _, tc := range []struct {
 		mocks          deploymentControllerFixture

--- a/pkg/canary/deployment_fixture_test.go
+++ b/pkg/canary/deployment_fixture_test.go
@@ -29,6 +29,10 @@ type deploymentControllerFixture struct {
 	logger        *zap.SugaredLogger
 }
 
+type canaryConfigs struct {
+	targetName string
+}
+
 type deploymentConfigs struct {
 	name       string
 	labelValue string
@@ -59,7 +63,8 @@ func (d deploymentControllerFixture) initializeCanary(t *testing.T) {
 
 func newDeploymentFixture(dc deploymentConfigs) deploymentControllerFixture {
 	// init canary
-	canary := newDeploymentControllerTestCanary()
+	cc := canaryConfigs{targetName: dc.name}
+	canary := newDeploymentControllerTestCanary(cc)
 	flaggerClient := fakeFlagger.NewSimpleClientset(canary)
 
 	// init kube clientset and register mock objects
@@ -299,7 +304,7 @@ func newDeploymentControllerTestSecretTrackerDisabled() *corev1.Secret {
 	}
 }
 
-func newDeploymentControllerTestCanary() *flaggerv1.Canary {
+func newDeploymentControllerTestCanary(cc canaryConfigs) *flaggerv1.Canary {
 	cd := &flaggerv1.Canary{
 		TypeMeta: metav1.TypeMeta{APIVersion: flaggerv1.SchemeGroupVersion.String()},
 		ObjectMeta: metav1.ObjectMeta{
@@ -308,7 +313,7 @@ func newDeploymentControllerTestCanary() *flaggerv1.Canary {
 		},
 		Spec: flaggerv1.CanarySpec{
 			TargetRef: flaggerv1.CrossNamespaceObjectReference{
-				Name:       "podinfo",
+				Name:       cc.targetName,
 				APIVersion: "apps/v1",
 				Kind:       "Deployment",
 			},

--- a/pkg/canary/deployment_ready_test.go
+++ b/pkg/canary/deployment_ready_test.go
@@ -12,7 +12,8 @@ import (
 )
 
 func TestDeploymentController_IsReady(t *testing.T) {
-	mocks := newDeploymentFixture()
+	depConfig := deploymentConfigs{name: "podinfo", label: "name", labelValue: "podinfo"}
+	mocks := newDeploymentFixture(depConfig)
 	mocks.controller.Initialize(mocks.canary)
 
 	err := mocks.controller.IsPrimaryReady(mocks.canary)
@@ -23,7 +24,8 @@ func TestDeploymentController_IsReady(t *testing.T) {
 }
 
 func TestDeploymentController_isDeploymentReady(t *testing.T) {
-	mocks := newDeploymentFixture()
+	depConfig := deploymentConfigs{name: "podinfo", label: "name", labelValue: "podinfo"}
+	mocks := newDeploymentFixture(depConfig)
 
 	// observed generation is less than desired generation
 	dp := &appsv1.Deployment{Status: appsv1.DeploymentStatus{ObservedGeneration: -1}}

--- a/pkg/canary/deployment_ready_test.go
+++ b/pkg/canary/deployment_ready_test.go
@@ -12,8 +12,8 @@ import (
 )
 
 func TestDeploymentController_IsReady(t *testing.T) {
-	depConfig := deploymentConfigs{name: "podinfo", label: "name", labelValue: "podinfo"}
-	mocks := newDeploymentFixture(depConfig)
+	dc := deploymentConfigs{name: "podinfo", label: "name", labelValue: "podinfo"}
+	mocks := newDeploymentFixture(dc)
 	mocks.controller.Initialize(mocks.canary)
 
 	err := mocks.controller.IsPrimaryReady(mocks.canary)
@@ -24,8 +24,8 @@ func TestDeploymentController_IsReady(t *testing.T) {
 }
 
 func TestDeploymentController_isDeploymentReady(t *testing.T) {
-	depConfig := deploymentConfigs{name: "podinfo", label: "name", labelValue: "podinfo"}
-	mocks := newDeploymentFixture(depConfig)
+	dc := deploymentConfigs{name: "podinfo", label: "name", labelValue: "podinfo"}
+	mocks := newDeploymentFixture(dc)
 
 	// observed generation is less than desired generation
 	dp := &appsv1.Deployment{Status: appsv1.DeploymentStatus{ObservedGeneration: -1}}

--- a/pkg/canary/deployment_status_test.go
+++ b/pkg/canary/deployment_status_test.go
@@ -12,8 +12,8 @@ import (
 )
 
 func TestDeploymentController_SyncStatus(t *testing.T) {
-	depConfig := deploymentConfigs{name: "podinfo", label: "name", labelValue: "podinfo"}
-	mocks := newDeploymentFixture(depConfig)
+	dc := deploymentConfigs{name: "podinfo", label: "name", labelValue: "podinfo"}
+	mocks := newDeploymentFixture(dc)
 	mocks.initializeCanary(t)
 
 	status := flaggerv1.CanaryStatus{
@@ -36,8 +36,8 @@ func TestDeploymentController_SyncStatus(t *testing.T) {
 }
 
 func TestDeploymentController_SetFailedChecks(t *testing.T) {
-	depConfig := deploymentConfigs{name: "podinfo", label: "name", labelValue: "podinfo"}
-	mocks := newDeploymentFixture(depConfig)
+	dc := deploymentConfigs{name: "podinfo", label: "name", labelValue: "podinfo"}
+	mocks := newDeploymentFixture(dc)
 	mocks.initializeCanary(t)
 
 	err := mocks.controller.SetStatusFailedChecks(mocks.canary, 1)
@@ -49,8 +49,8 @@ func TestDeploymentController_SetFailedChecks(t *testing.T) {
 }
 
 func TestDeploymentController_SetState(t *testing.T) {
-	depConfig := deploymentConfigs{name: "podinfo", label: "name", labelValue: "podinfo"}
-	mocks := newDeploymentFixture(depConfig)
+	dc := deploymentConfigs{name: "podinfo", label: "name", labelValue: "podinfo"}
+	mocks := newDeploymentFixture(dc)
 	mocks.initializeCanary(t)
 
 	err := mocks.controller.SetStatusPhase(mocks.canary, flaggerv1.CanaryPhaseProgressing)

--- a/pkg/canary/deployment_status_test.go
+++ b/pkg/canary/deployment_status_test.go
@@ -12,7 +12,8 @@ import (
 )
 
 func TestDeploymentController_SyncStatus(t *testing.T) {
-	mocks := newDeploymentFixture()
+	depConfig := deploymentConfigs{name: "podinfo", label: "name", labelValue: "podinfo"}
+	mocks := newDeploymentFixture(depConfig)
 	mocks.initializeCanary(t)
 
 	status := flaggerv1.CanaryStatus{
@@ -35,7 +36,8 @@ func TestDeploymentController_SyncStatus(t *testing.T) {
 }
 
 func TestDeploymentController_SetFailedChecks(t *testing.T) {
-	mocks := newDeploymentFixture()
+	depConfig := deploymentConfigs{name: "podinfo", label: "name", labelValue: "podinfo"}
+	mocks := newDeploymentFixture(depConfig)
 	mocks.initializeCanary(t)
 
 	err := mocks.controller.SetStatusFailedChecks(mocks.canary, 1)
@@ -47,7 +49,8 @@ func TestDeploymentController_SetFailedChecks(t *testing.T) {
 }
 
 func TestDeploymentController_SetState(t *testing.T) {
-	mocks := newDeploymentFixture()
+	depConfig := deploymentConfigs{name: "podinfo", label: "name", labelValue: "podinfo"}
+	mocks := newDeploymentFixture(depConfig)
 	mocks.initializeCanary(t)
 
 	err := mocks.controller.SetStatusPhase(mocks.canary, flaggerv1.CanaryPhaseProgressing)

--- a/pkg/canary/service_controller.go
+++ b/pkg/canary/service_controller.go
@@ -42,9 +42,9 @@ func (c *ServiceController) SetStatusPhase(cd *flaggerv1.Canary, phase flaggerv1
 	return setStatusPhase(c.flaggerClient, cd, phase)
 }
 
-// GetMetadata returns the pod label selector and svc ports
-func (c *ServiceController) GetMetadata(_ *flaggerv1.Canary) (string, map[string]int32, error) {
-	return "", nil, nil
+// GetMetadata returns the pod label selector, label value and svc ports
+func (c *ServiceController) GetMetadata(_ *flaggerv1.Canary) (string, string, map[string]int32, error) {
+	return "", "", nil, nil
 }
 
 // Initialize creates or updates the primary and canary services to prepare for the canary release process targeted on the K8s service

--- a/pkg/canary/util.go
+++ b/pkg/canary/util.go
@@ -75,14 +75,14 @@ func makeAnnotations(annotations map[string]string) (map[string]string, error) {
 	return res, nil
 }
 
-func makePrimaryLabels(labels map[string]string, primaryName string, label string) map[string]string {
+func makePrimaryLabels(labels map[string]string, labelValue string, label string) map[string]string {
 	res := make(map[string]string)
 	for k, v := range labels {
 		if k != label {
 			res[k] = v
 		}
 	}
-	res[label] = primaryName
+	res[label] = labelValue
 
 	return res
 }

--- a/pkg/controller/finalizer.go
+++ b/pkg/controller/finalizer.go
@@ -50,13 +50,13 @@ func (c *Controller) finalize(old interface{}) error {
 		return fmt.Errorf("canary not ready during finalizing: %w", err)
 	}
 
-	labelSelector, ports, err := canaryController.GetMetadata(canary)
+	labelSelector, labelValue, ports, err := canaryController.GetMetadata(canary)
 	if err != nil {
 		return fmt.Errorf("failed to get metadata for router finalizing: %w", err)
 	}
 
 	// Revert the Kubernetes service
-	router := c.routerFactory.KubernetesRouter(canary.Spec.TargetRef.Kind, labelSelector, ports)
+	router := c.routerFactory.KubernetesRouter(canary.Spec.TargetRef.Kind, labelSelector, labelValue, ports)
 	if err := router.Finalize(canary); err != nil {
 		return fmt.Errorf("failed revert router: %w", err)
 	}

--- a/pkg/controller/scheduler.go
+++ b/pkg/controller/scheduler.go
@@ -100,14 +100,14 @@ func (c *Controller) advanceCanary(name string, namespace string) {
 
 	// init controller based on target kind
 	canaryController := c.canaryFactory.Controller(cd.Spec.TargetRef.Kind)
-	labelSelector, ports, err := canaryController.GetMetadata(cd)
+	labelSelector, labelValue, ports, err := canaryController.GetMetadata(cd)
 	if err != nil {
 		c.recordEventWarningf(cd, "%v", err)
 		return
 	}
 
 	// init Kubernetes router
-	kubeRouter := c.routerFactory.KubernetesRouter(cd.Spec.TargetRef.Kind, labelSelector, ports)
+	kubeRouter := c.routerFactory.KubernetesRouter(cd.Spec.TargetRef.Kind, labelSelector, labelValue, ports)
 
 	// reconcile the canary/primary services
 	if err := kubeRouter.Initialize(cd); err != nil {

--- a/pkg/router/factory.go
+++ b/pkg/router/factory.go
@@ -39,7 +39,7 @@ func NewFactory(kubeConfig *restclient.Config, kubeClient kubernetes.Interface,
 }
 
 // KubernetesRouter returns a KubernetesRouter interface implementation
-func (factory *Factory) KubernetesRouter(kind string, labelSelector string, ports map[string]int32) KubernetesRouter {
+func (factory *Factory) KubernetesRouter(kind string, labelSelector string, labelValue string, ports map[string]int32) KubernetesRouter {
 	switch kind {
 	case "Service":
 		return &KubernetesNoopRouter{}
@@ -49,6 +49,7 @@ func (factory *Factory) KubernetesRouter(kind string, labelSelector string, port
 			flaggerClient: factory.flaggerClient,
 			kubeClient:    factory.kubeClient,
 			labelSelector: labelSelector,
+			labelValue:    labelValue,
 			ports:         ports,
 		}
 	}

--- a/pkg/router/kubernetes_default.go
+++ b/pkg/router/kubernetes_default.go
@@ -25,6 +25,7 @@ type KubernetesDefaultRouter struct {
 	flaggerClient clientset.Interface
 	logger        *zap.SugaredLogger
 	labelSelector string
+	labelValue    string
 	ports         map[string]int32
 }
 
@@ -33,13 +34,13 @@ func (c *KubernetesDefaultRouter) Initialize(canary *flaggerv1.Canary) error {
 	_, primaryName, canaryName := canary.GetServiceNames()
 
 	// canary svc
-	err := c.reconcileService(canary, canaryName, canary.Spec.TargetRef.Name, canary.Spec.Service.Canary)
+	err := c.reconcileService(canary, canaryName, c.labelValue, canary.Spec.Service.Canary)
 	if err != nil {
 		return fmt.Errorf("reconcileService failed: %w", err)
 	}
 
 	// primary svc
-	err = c.reconcileService(canary, primaryName, fmt.Sprintf("%s-primary", canary.Spec.TargetRef.Name), canary.Spec.Service.Primary)
+	err = c.reconcileService(canary, primaryName, fmt.Sprintf("%s-primary", c.labelValue), canary.Spec.Service.Primary)
 	if err != nil {
 		return fmt.Errorf("reconcileService failed: %w", err)
 	}
@@ -52,7 +53,7 @@ func (c *KubernetesDefaultRouter) Reconcile(canary *flaggerv1.Canary) error {
 	apexName, _, _ := canary.GetServiceNames()
 
 	// main svc
-	err := c.reconcileService(canary, apexName, fmt.Sprintf("%s-primary", canary.Spec.TargetRef.Name), canary.Spec.Service.Apex)
+	err := c.reconcileService(canary, apexName, fmt.Sprintf("%s-primary", c.labelValue), canary.Spec.Service.Apex)
 	if err != nil {
 		return fmt.Errorf("reconcileService failed: %w", err)
 	}

--- a/test/e2e-contour-tests.sh
+++ b/test/e2e-contour-tests.sh
@@ -100,11 +100,6 @@ spec:
   service:
     port: 9898
     portDiscovery: true
-    apex:
-      annotations:
-        test: "annotations-test"
-      labels:
-        test: "labels-test"
     headers:
       request:
         add:
@@ -116,26 +111,6 @@ spec:
     threshold: 15
     maxWeight: 30
     stepWeight: 10
-    metrics:
-    - name: request-success-rate
-      thresholdRange:
-        min: 99
-      interval: 1m
-    - name: latency
-      templateRef:
-        name: latency
-        namespace: istio-system
-      thresholdRange:
-        max: 500
-      interval: 1m
-    webhooks:
-      - name: load-test
-        url: http://flagger-loadtester.test/
-        timeout: 5s
-        metadata:
-          type: cmd
-          cmd: "hey -z 10m -q 10 -c 2 http://podinfo.test:9898/"
-          logCmdOutput: "true"
 EOF
 
 echo '>>> Waiting for primary to be ready'

--- a/test/e2e-contour-tests.sh
+++ b/test/e2e-contour-tests.sh
@@ -85,6 +85,59 @@ spec:
           logCmdOutput: "true"
 EOF
 
+cat <<EOF | kubectl apply -f -
+apiVersion: flagger.app/v1beta1
+kind: Canary
+metadata:
+  name: podinfo-service
+  namespace: test
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: podinfo-service
+  progressDeadlineSeconds: 60
+  service:
+    port: 9898
+    portDiscovery: true
+    apex:
+      annotations:
+        test: "annotations-test"
+      labels:
+        test: "labels-test"
+    headers:
+      request:
+        add:
+          x-envoy-upstream-rq-timeout-ms: "15000"
+          x-envoy-max-retries: "10"
+          x-envoy-retry-on: "gateway-error,connect-failure,refused-stream"
+  analysis:
+    interval: 15s
+    threshold: 15
+    maxWeight: 30
+    stepWeight: 10
+    metrics:
+    - name: request-success-rate
+      thresholdRange:
+        min: 99
+      interval: 1m
+    - name: latency
+      templateRef:
+        name: latency
+        namespace: istio-system
+      thresholdRange:
+        max: 500
+      interval: 1m
+    webhooks:
+      - name: load-test
+        url: http://flagger-loadtester.test/
+        timeout: 5s
+        metadata:
+          type: cmd
+          cmd: "hey -z 10m -q 10 -c 2 http://podinfo.test:9898/"
+          logCmdOutput: "true"
+EOF
+
 echo '>>> Waiting for primary to be ready'
 retries=50
 count=0
@@ -103,6 +156,19 @@ done
 kubectl -n test get httpproxy podinfo -oyaml | grep 'projectcontour.io/ingress.class: contour'
 
 echo '✔ Canary initialization test passed'
+
+passed=$(kubectl -n test get svc/podinfo -o jsonpath='{.spec.selector.app}' 2>&1 | { grep podinfo-primary || true; })
+if [ -z "$passed" ]; then
+  echo -e '\u2716 podinfo selector test failed'
+  exit 1
+fi
+passed=$(kubectl -n test get svc/podinfo-service-canary -o jsonpath='{.spec.selector.app}' 2>&1 | { grep podinfo || true; })
+if [ -z "$passed" ]; then
+  echo -e '\u2716 podinfo-service selector test failed'
+  exit 1
+fi
+
+echo '✔ Canary service custom metadata test passed'
 
 echo '>>> Triggering canary deployment'
 kubectl -n test set image deployment/podinfo podinfod=stefanprodan/podinfo:3.1.1

--- a/test/e2e-gloo-tests.sh
+++ b/test/e2e-gloo-tests.sh
@@ -103,11 +103,6 @@ spec:
   service:
     port: 9898
     portDiscovery: true
-    apex:
-      annotations:
-        test: "annotations-test"
-      labels:
-        test: "labels-test"
     headers:
       request:
         add:
@@ -119,26 +114,6 @@ spec:
     threshold: 15
     maxWeight: 30
     stepWeight: 10
-    metrics:
-    - name: request-success-rate
-      thresholdRange:
-        min: 99
-      interval: 1m
-    - name: latency
-      templateRef:
-        name: latency
-        namespace: istio-system
-      thresholdRange:
-        max: 500
-      interval: 1m
-    webhooks:
-      - name: load-test
-        url: http://flagger-loadtester.test/
-        timeout: 5s
-        metadata:
-          type: cmd
-          cmd: "hey -z 10m -q 10 -c 2 http://podinfo.test:9898/"
-          logCmdOutput: "true"
 EOF
 
 echo '>>> Waiting for primary to be ready'

--- a/test/e2e-istio-tests.sh
+++ b/test/e2e-istio-tests.sh
@@ -44,7 +44,7 @@ spec:
     )
 EOF
 
-echo '>>> Initialising canary'
+echo '>>> Initialising canaries'
 cat <<EOF | kubectl apply -f -
 apiVersion: flagger.app/v1beta1
 kind: Canary
@@ -98,12 +98,66 @@ spec:
           logCmdOutput: "true"
 EOF
 
+cat <<EOF | kubectl apply -f -
+apiVersion: flagger.app/v1beta1
+kind: Canary
+metadata:
+  name: podinfo-service
+  namespace: test
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: podinfo-service
+  progressDeadlineSeconds: 60
+  service:
+    port: 9898
+    portDiscovery: true
+    apex:
+      annotations:
+        test: "annotations-test"
+      labels:
+        test: "labels-test"
+    headers:
+      request:
+        add:
+          x-envoy-upstream-rq-timeout-ms: "15000"
+          x-envoy-max-retries: "10"
+          x-envoy-retry-on: "gateway-error,connect-failure,refused-stream"
+  analysis:
+    interval: 15s
+    threshold: 15
+    maxWeight: 30
+    stepWeight: 10
+    metrics:
+    - name: request-success-rate
+      thresholdRange:
+        min: 99
+      interval: 1m
+    - name: latency
+      templateRef:
+        name: latency
+        namespace: istio-system
+      thresholdRange:
+        max: 500
+      interval: 1m
+    webhooks:
+      - name: load-test
+        url: http://flagger-loadtester.test/
+        timeout: 5s
+        metadata:
+          type: cmd
+          cmd: "hey -z 10m -q 10 -c 2 http://podinfo.test:9898/"
+          logCmdOutput: "true"
+EOF
+
 echo '>>> Waiting for primary to be ready'
 retries=50
 count=0
 ok=false
 until ${ok}; do
     kubectl -n test get canary/podinfo | grep 'Initialized' && ok=true || ok=false
+    kubectl -n test get canary/podinfo-service | grep 'Initialized' && ok=true || ok=false
     sleep 5
     count=$(($count + 1))
     if [[ ${count} -eq ${retries} ]]; then
@@ -115,8 +169,26 @@ done
 
 echo '✔ Canary initialization test passed'
 
-kubectl -n test get svc/podinfo -oyaml | grep annotations-test
-kubectl -n test get svc/podinfo -oyaml | grep labels-test
+passed=$(kubectl -n test get svc/podinfo -oyaml 2>&1 | { grep annotations-test || true; })
+if [ -z "$passed" ]; then
+  echo -e '\u2716 podinfo annotations test failed'
+  exit 1
+fi
+passed=$(kubectl -n test get svc/podinfo -oyaml 2>&1 | { grep labels-test || true; })
+if [ -z "$passed" ]; then
+  echo -e '\u2716 podinfo labels test failed'
+  exit 1
+fi
+passed=$(kubectl -n test get svc/podinfo -o jsonpath='{.spec.selector.app}' 2>&1 | { grep podinfo-primary || true; })
+if [ -z "$passed" ]; then
+  echo -e '\u2716 podinfo selector test failed'
+  exit 1
+fi
+passed=$(kubectl -n test get svc/podinfo-service -o jsonpath='{.spec.selector.app}' 2>&1 | { grep podinfo-primary || true; })
+if [ -z "$passed" ]; then
+  echo -e '\u2716 podinfo-service selector test failed'
+  exit 1
+fi
 
 echo '✔ Canary service custom metadata test passed'
 

--- a/test/e2e-istio-tests.sh
+++ b/test/e2e-istio-tests.sh
@@ -184,7 +184,7 @@ if [ -z "$passed" ]; then
   echo -e '\u2716 podinfo selector test failed'
   exit 1
 fi
-passed=$(kubectl -n test get svc/podinfo-service -o jsonpath='{.spec.selector.app}' 2>&1 | { grep podinfo-primary || true; })
+passed=$(kubectl -n test get svc/podinfo-service-canary -o jsonpath='{.spec.selector.app}' 2>&1 | { grep podinfo || true; })
 if [ -z "$passed" ]; then
   echo -e '\u2716 podinfo-service selector test failed'
   exit 1

--- a/test/e2e-istio-tests.sh
+++ b/test/e2e-istio-tests.sh
@@ -113,11 +113,6 @@ spec:
   service:
     port: 9898
     portDiscovery: true
-    apex:
-      annotations:
-        test: "annotations-test"
-      labels:
-        test: "labels-test"
     headers:
       request:
         add:
@@ -129,26 +124,6 @@ spec:
     threshold: 15
     maxWeight: 30
     stepWeight: 10
-    metrics:
-    - name: request-success-rate
-      thresholdRange:
-        min: 99
-      interval: 1m
-    - name: latency
-      templateRef:
-        name: latency
-        namespace: istio-system
-      thresholdRange:
-        max: 500
-      interval: 1m
-    webhooks:
-      - name: load-test
-        url: http://flagger-loadtester.test/
-        timeout: 5s
-        metadata:
-          type: cmd
-          cmd: "hey -z 10m -q 10 -c 2 http://podinfo.test:9898/"
-          logCmdOutput: "true"
 EOF
 
 echo '>>> Waiting for primary to be ready'

--- a/test/e2e-linkerd-tests.sh
+++ b/test/e2e-linkerd-tests.sh
@@ -115,11 +115,6 @@ spec:
   service:
     port: 9898
     portDiscovery: true
-    apex:
-      annotations:
-        test: "annotations-test"
-      labels:
-        test: "labels-test"
     headers:
       request:
         add:
@@ -131,26 +126,6 @@ spec:
     threshold: 15
     maxWeight: 30
     stepWeight: 10
-    metrics:
-    - name: request-success-rate
-      thresholdRange:
-        min: 99
-      interval: 1m
-    - name: latency
-      templateRef:
-        name: latency
-        namespace: istio-system
-      thresholdRange:
-        max: 500
-      interval: 1m
-    webhooks:
-      - name: load-test
-        url: http://flagger-loadtester.test/
-        timeout: 5s
-        metadata:
-          type: cmd
-          cmd: "hey -z 10m -q 10 -c 2 http://podinfo.test:9898/"
-          logCmdOutput: "true"
 EOF
 
 echo '>>> Waiting for primary to be ready'

--- a/test/e2e-linkerd-tests.sh
+++ b/test/e2e-linkerd-tests.sh
@@ -100,6 +100,59 @@ spec:
           logCmdOutput: "true"
 EOF
 
+cat <<EOF | kubectl apply -f -
+apiVersion: flagger.app/v1beta1
+kind: Canary
+metadata:
+  name: podinfo-service
+  namespace: test
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: podinfo-service
+  progressDeadlineSeconds: 60
+  service:
+    port: 9898
+    portDiscovery: true
+    apex:
+      annotations:
+        test: "annotations-test"
+      labels:
+        test: "labels-test"
+    headers:
+      request:
+        add:
+          x-envoy-upstream-rq-timeout-ms: "15000"
+          x-envoy-max-retries: "10"
+          x-envoy-retry-on: "gateway-error,connect-failure,refused-stream"
+  analysis:
+    interval: 15s
+    threshold: 15
+    maxWeight: 30
+    stepWeight: 10
+    metrics:
+    - name: request-success-rate
+      thresholdRange:
+        min: 99
+      interval: 1m
+    - name: latency
+      templateRef:
+        name: latency
+        namespace: istio-system
+      thresholdRange:
+        max: 500
+      interval: 1m
+    webhooks:
+      - name: load-test
+        url: http://flagger-loadtester.test/
+        timeout: 5s
+        metadata:
+          type: cmd
+          cmd: "hey -z 10m -q 10 -c 2 http://podinfo.test:9898/"
+          logCmdOutput: "true"
+EOF
+
 echo '>>> Waiting for primary to be ready'
 retries=50
 count=0
@@ -116,6 +169,19 @@ until ${ok}; do
 done
 
 echo '✔ Canary initialization test passed'
+
+passed=$(kubectl -n test get svc/podinfo -o jsonpath='{.spec.selector.app}' 2>&1 | { grep podinfo-primary || true; })
+if [ -z "$passed" ]; then
+  echo -e '\u2716 podinfo selector test failed'
+  exit 1
+fi
+passed=$(kubectl -n test get svc/podinfo-service-canary -o jsonpath='{.spec.selector.app}' 2>&1 | { grep podinfo || true; })
+if [ -z "$passed" ]; then
+  echo -e '\u2716 podinfo-service selector test failed'
+  exit 1
+fi
+
+echo '✔ Canary service custom metadata test passed'
 
 echo '>>> Triggering canary deployment'
 kubectl -n test set image deployment/podinfo podinfod=stefanprodan/podinfo:3.1.1

--- a/test/e2e-nginx-tests.sh
+++ b/test/e2e-nginx-tests.sh
@@ -139,11 +139,6 @@ spec:
   service:
     port: 9898
     portDiscovery: true
-    apex:
-      annotations:
-        test: "annotations-test"
-      labels:
-        test: "labels-test"
     headers:
       request:
         add:
@@ -155,26 +150,6 @@ spec:
     threshold: 15
     maxWeight: 30
     stepWeight: 10
-    metrics:
-    - name: request-success-rate
-      thresholdRange:
-        min: 99
-      interval: 1m
-    - name: latency
-      templateRef:
-        name: latency
-        namespace: istio-system
-      thresholdRange:
-        max: 500
-      interval: 1m
-    webhooks:
-      - name: load-test
-        url: http://flagger-loadtester.test/
-        timeout: 5s
-        metadata:
-          type: cmd
-          cmd: "hey -z 10m -q 10 -c 2 http://podinfo.test:9898/"
-          logCmdOutput: "true"
 EOF
 
 echo '>>> Waiting for primary to be ready'

--- a/test/e2e-nginx-tests.sh
+++ b/test/e2e-nginx-tests.sh
@@ -124,6 +124,59 @@ spec:
           cmd: "hey -z 2m -q 10 -c 2 -host app.example.com http://nginx-ingress-controller.ingress-nginx"
 EOF
 
+cat <<EOF | kubectl apply -f -
+apiVersion: flagger.app/v1beta1
+kind: Canary
+metadata:
+  name: podinfo-service
+  namespace: test
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: podinfo-service
+  progressDeadlineSeconds: 60
+  service:
+    port: 9898
+    portDiscovery: true
+    apex:
+      annotations:
+        test: "annotations-test"
+      labels:
+        test: "labels-test"
+    headers:
+      request:
+        add:
+          x-envoy-upstream-rq-timeout-ms: "15000"
+          x-envoy-max-retries: "10"
+          x-envoy-retry-on: "gateway-error,connect-failure,refused-stream"
+  analysis:
+    interval: 15s
+    threshold: 15
+    maxWeight: 30
+    stepWeight: 10
+    metrics:
+    - name: request-success-rate
+      thresholdRange:
+        min: 99
+      interval: 1m
+    - name: latency
+      templateRef:
+        name: latency
+        namespace: istio-system
+      thresholdRange:
+        max: 500
+      interval: 1m
+    webhooks:
+      - name: load-test
+        url: http://flagger-loadtester.test/
+        timeout: 5s
+        metadata:
+          type: cmd
+          cmd: "hey -z 10m -q 10 -c 2 http://podinfo.test:9898/"
+          logCmdOutput: "true"
+EOF
+
 echo '>>> Waiting for primary to be ready'
 retries=50
 count=0
@@ -140,6 +193,19 @@ until ${ok}; do
 done
 
 echo '✔ Canary initialization test passed'
+
+passed=$(kubectl -n test get svc/podinfo -o jsonpath='{.spec.selector.app}' | { grep podinfo-primary || true; })
+if [ -z "$passed" ]; then
+  echo -e '\u2716 podinfo selector test failed'
+  exit 1
+fi
+passed=$(kubectl -n test get svc/podinfo-service-canary -o jsonpath='{.spec.selector.app}' | { grep podinfo || true; })
+if [ -z "$passed" ]; then
+  echo -e '\u2716 podinfo-service selector test failed'
+  exit 1
+fi
+
+echo '✔ Canary service custom metadata test passed'
 
 echo '>>> Triggering canary deployment'
 kubectl -n test set image deployment/podinfo podinfod=stefanprodan/podinfo:3.1.1

--- a/test/e2e-workload.yaml
+++ b/test/e2e-workload.yaml
@@ -66,3 +66,72 @@ spec:
           requests:
             cpu: 1m
             memory: 16Mi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: podinfo-service
+  namespace: test
+  labels:
+    app: podinfo
+spec:
+  minReadySeconds: 5
+  revisionHistoryLimit: 5
+  progressDeadlineSeconds: 60
+  strategy:
+    rollingUpdate:
+      maxUnavailable: 0
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app: podinfo
+  template:
+    metadata:
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "9797"
+      labels:
+        app: podinfo
+    spec:
+      containers:
+        - name: podinfod
+          image: stefanprodan/podinfo:3.1.0
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 9898
+              protocol: TCP
+            - name: http-metrics
+              containerPort: 9797
+              protocol: TCP
+            - name: grpc
+              containerPort: 9999
+              protocol: TCP
+          command:
+            - ./podinfo
+            - --port=9898
+            - --port-metrics=9797
+            - --grpc-port=9999
+            - --grpc-service-name=podinfo
+            - --level=info
+            - --random-delay=false
+            - --random-error=false
+          livenessProbe:
+            httpGet:
+              port: 9898
+              path: /healthz
+            initialDelaySeconds: 5
+            timeoutSeconds: 5
+          readinessProbe:
+            httpGet:
+              port: 9898
+              path: /readyz
+            initialDelaySeconds: 5
+            timeoutSeconds: 5
+          resources:
+            limits:
+              cpu: 1000m
+              memory: 128Mi
+            requests:
+              cpu: 1m
+              memory: 16Mi


### PR DESCRIPTION
Hi Friends 😄 , 

This PR changes how the label selector value is derived. The way it is today, the label selector is derived from the service name defined in the Canary CR. This PR changes it to be derived from the value as it is already defined in the target Deployment's matchLabels. 

This addresses a specific use case where the following occurs:
1. A pre-existing Deployment has labels that cannot be changed due to observability requirements in an organization
2. A pre-existing Service name cannot be changed due to downstream dependencies
3. The Deployment matchLabels are already defined and Deployment selectors are immutable
4. The Service name does not match the Deployment label value

The above points lead to a scenario where Flagger will create the service-canary with a selector based on the Service name defined in the Canary CR and thus not match the label/label-value on the original/canary Deployment. Initialization will pass and the primary Deployment will work fine because it is a newly created Deployment, but the canary Deployment will fail to receive traffic because of the mismatch in service selector and deployment label/label-value. 

This situation can be worked around by deleting the Deployment (without deleting the associated Pods) and creating a new Deployment with updated matchLabels (using a new label and label-value). This works for a PoC, but, this doesn't seem to be a scalable workaround if we adopt Flagger in our organization with dozens and dozens of services. A lot of our services have significant traffic and it only takes one mistake to bring down the Pods with the Deployment. 

The majority of the code changes here are tests. The actual change is really in getSelectorLabels and the associated interface changes. I would greatly appreciate any/all feedback. 😄   And thank you so much for this project! We are looking at adopting it more widely in our org. 👍 