### PR TITLE
kubernetes_default.go optimize log output

### DIFF
--- a/docs/gitbook/tutorials/istio-progressive-delivery.md
+++ b/docs/gitbook/tutorials/istio-progressive-delivery.md
@@ -195,9 +195,11 @@ podinfod=stefanprodan/podinfo:3.1.1
 
 Flagger detects that the deployment revision changed and starts a new rollout:
 
-```text
+```bash
 kubectl -n test describe canary/podinfo
-
+```
+output:
+```
 Status:
   Canary Weight:         0
   Failed Checks:         0
@@ -235,7 +237,9 @@ You can monitor all canaries with:
 
 ```bash
 watch kubectl get canaries --all-namespaces
-
+```
+output:
+```
 NAMESPACE   NAME      STATUS        WEIGHT   LASTTRANSITIONTIME
 test        podinfo   Progressing   15       2019-01-16T14:05:07Z
 prod        frontend  Succeeded     0        2019-01-15T16:15:07Z
@@ -274,8 +278,11 @@ watch curl http://podinfo-canary:9898/delay/1
 When the number of failed checks reaches the canary analysis threshold, the traffic is routed back to the primary,
 the canary is scaled to zero and the rollout is marked as failed.
 
-```text
+```bash
 kubectl -n test describe canary/podinfo
+```
+output:
+```
 
 Status:
   Canary Weight:         0

--- a/pkg/router/istio.go
+++ b/pkg/router/istio.go
@@ -28,18 +28,18 @@ type IstioRouter struct {
 
 // Reconcile creates or updates the Istio virtual service and destination rules
 func (ir *IstioRouter) Reconcile(canary *flaggerv1.Canary) error {
-	_, primaryName, canaryName := canary.GetServiceNames()
+	apexName, primaryName, canaryName := canary.GetServiceNames()
 
 	if err := ir.reconcileDestinationRule(canary, canaryName); err != nil {
-		return fmt.Errorf("reconcileDestinationRule failed: %w", err)
+		return fmt.Errorf("%s reconcileDestinationRule failed: %w", canaryName, err)
 	}
 
 	if err := ir.reconcileDestinationRule(canary, primaryName); err != nil {
-		return fmt.Errorf("reconcileDestinationRule failed: %w", err)
+		return fmt.Errorf("%s reconcileDestinationRule failed: %w", primaryName, err)
 	}
 
 	if err := ir.reconcileVirtualService(canary); err != nil {
-		return fmt.Errorf("reconcileVirtualService failed: %w", err)
+		return fmt.Errorf("%s reconcileVirtualService failed: %w", apexName, err)
 	}
 	return nil
 }

--- a/pkg/router/kubernetes_default.go
+++ b/pkg/router/kubernetes_default.go
@@ -35,13 +35,13 @@ func (c *KubernetesDefaultRouter) Initialize(canary *flaggerv1.Canary) error {
 	// canary svc
 	err := c.reconcileService(canary, canaryName, canary.Spec.TargetRef.Name, canary.Spec.Service.Canary)
 	if err != nil {
-		return fmt.Errorf("reconcileService failed: %w", err)
+		return fmt.Errorf("%s reconcileService failed: %w", canaryName, err)
 	}
 
 	// primary svc
 	err = c.reconcileService(canary, primaryName, fmt.Sprintf("%s-primary", canary.Spec.TargetRef.Name), canary.Spec.Service.Primary)
 	if err != nil {
-		return fmt.Errorf("reconcileService failed: %w", err)
+		return fmt.Errorf("%s reconcileService failed: %w", primaryName, err)
 	}
 
 	return nil


### PR DESCRIPTION
paste will paste everything, so I separate the command from the output
![1599188307(1)](https://user-images.githubusercontent.com/40875627/92194651-c7590e80-ee9d-11ea-82d7-ec776b1522f9.png)
