### PR TITLE
fix spelling of "template" in scheduler_metrics.go

### DIFF
--- a/pkg/controller/scheduler_metrics.go
+++ b/pkg/controller/scheduler_metrics.go
@@ -65,7 +65,7 @@ func (c *Controller) checkMetricProviderAvailability(canary *flaggerv1.Canary) e
 			}
 
 			if ok, err := provider.IsOnline(); !ok || err != nil {
-				return fmt.Errorf("%v in metric tempalte %s.%s not avaiable: %v", template.Spec.Provider.Type,
+				return fmt.Errorf("%v in metric template %s.%s not avaiable: %v", template.Spec.Provider.Type,
 					template.Name, template.Namespace, err)
 			}
 		}


### PR DESCRIPTION
Hello - just noticed this minor misspelling when testing Flagger in our K8s cluster and figured I'd push a correction quick. 