### PR TITLE
Copy labels from canary to primary workloads based on prefix rules

### DIFF
--- a/charts/flagger/README.md
+++ b/charts/flagger/README.md
@@ -125,6 +125,7 @@ Parameter | Description | Default
 `serviceAccount.name` | The name of the service account to create or use. If not set and `serviceAccount.create` is `true`, a name is generated using the Flagger fullname | `""`
 `serviceAccount.annotations` | Annotations for service account | `{}`
 `ingressAnnotationsPrefix` | Annotations prefix for ingresses | `custom.ingress.kubernetes.io`
+`excludedLabelsPrefixes` | List of prefixes of labels that are excluded when creating primary controllers | `"fluxcd,jenkins"`
 `rbac.create` | If `true`, create and use RBAC resources | `true`
 `rbac.pspEnabled` | If `true`, create and use a restricted pod security policy | `false`
 `crd.create` | If `true`, create Flagger's CRDs (should be enabled for Helm v2 only) | `false`

--- a/charts/flagger/README.md
+++ b/charts/flagger/README.md
@@ -125,7 +125,7 @@ Parameter | Description | Default
 `serviceAccount.name` | The name of the service account to create or use. If not set and `serviceAccount.create` is `true`, a name is generated using the Flagger fullname | `""`
 `serviceAccount.annotations` | Annotations for service account | `{}`
 `ingressAnnotationsPrefix` | Annotations prefix for ingresses | `custom.ingress.kubernetes.io`
-`excludedLabelsPrefixes` | List of prefixes of labels that are excluded when creating primary controllers | `"fluxcd,jenkins"`
+`includeLabelPrefix` | List of prefixes of labels that are copied when creating primary deployments or daemonsets. Use * to include all | `""`
 `rbac.create` | If `true`, create and use RBAC resources | `true`
 `rbac.pspEnabled` | If `true`, create and use a restricted pod security policy | `false`
 `crd.create` | If `true`, create Flagger's CRDs (should be enabled for Helm v2 only) | `false`

--- a/charts/flagger/templates/deployment.yaml
+++ b/charts/flagger/templates/deployment.yaml
@@ -106,6 +106,9 @@ spec:
           {{- if .Values.ingressAnnotationsPrefix }}
           - -ingress-annotations-prefix={{ .Values.ingressAnnotationsPrefix }}
           {{- end }}
+          {{- if .Values.excludedLabelsPrefixes }}
+          - -excluded-labels-prefixes={{ .Values.excludedLabelsPrefixes }}
+          {{- end }}
           {{- if .Values.ingressClass }}
           - -ingress-class={{ .Values.ingressClass }}
           {{- end }}

--- a/charts/flagger/templates/deployment.yaml
+++ b/charts/flagger/templates/deployment.yaml
@@ -106,8 +106,8 @@ spec:
           {{- if .Values.ingressAnnotationsPrefix }}
           - -ingress-annotations-prefix={{ .Values.ingressAnnotationsPrefix }}
           {{- end }}
-          {{- if .Values.excludedLabelsPrefixes }}
-          - -excluded-labels-prefixes={{ .Values.excludedLabelsPrefixes }}
+          {{- if .Values.includeLabelPrefix }}
+          - -excluded-labels-prefixes={{ .Values.includeLabelPrefix }}
           {{- end }}
           {{- if .Values.ingressClass }}
           - -ingress-class={{ .Values.ingressClass }}

--- a/charts/flagger/templates/deployment.yaml
+++ b/charts/flagger/templates/deployment.yaml
@@ -107,7 +107,7 @@ spec:
           - -ingress-annotations-prefix={{ .Values.ingressAnnotationsPrefix }}
           {{- end }}
           {{- if .Values.includeLabelPrefix }}
-          - -excluded-labels-prefixes={{ .Values.includeLabelPrefix }}
+          - -include-label-prefix={{ .Values.includeLabelPrefix }}
           {{- end }}
           {{- if .Values.ingressClass }}
           - -ingress-class={{ .Values.ingressClass }}

--- a/cmd/flagger/main.go
+++ b/cmd/flagger/main.go
@@ -43,6 +43,7 @@ var (
 	logLevel                 string
 	port                     string
 	msteamsURL               string
+	excludedLabelsPrefixes   string
 	slackURL                 string
 	slackUser                string
 	slackChannel             string
@@ -74,6 +75,7 @@ func init() {
 	flag.StringVar(&slackChannel, "slack-channel", "", "Slack channel.")
 	flag.StringVar(&eventWebhook, "event-webhook", "", "Webhook for publishing flagger events")
 	flag.StringVar(&msteamsURL, "msteams-url", "", "MS Teams incoming webhook URL.")
+	flag.StringVar(&excludedLabelsPrefixes, "excluded-labels-prefixes", "fluxcd,jenkins", "List of prefixes of labels that are excluded when creating primary controllers.")
 	flag.IntVar(&threadiness, "threadiness", 2, "Worker concurrency.")
 	flag.BoolVar(&zapReplaceGlobals, "zap-replace-globals", false, "Whether to change the logging level of the global zap logger.")
 	flag.StringVar(&zapEncoding, "zap-encoding", "json", "Zap logger encoding.")
@@ -184,7 +186,9 @@ func main() {
 		configTracker = &canary.NopTracker{}
 	}
 
-	canaryFactory := canary.NewFactory(kubeClient, flaggerClient, configTracker, labels, logger)
+	excludedLabelsPrefixesArray := strings.Split(excludedLabelsPrefixes, ",")
+
+	canaryFactory := canary.NewFactory(kubeClient, flaggerClient, configTracker, labels, excludedLabelsPrefixesArray, logger)
 
 	c := controller.NewController(
 		kubeClient,

--- a/cmd/flagger/main.go
+++ b/cmd/flagger/main.go
@@ -43,7 +43,7 @@ var (
 	logLevel                 string
 	port                     string
 	msteamsURL               string
-	excludedLabelsPrefixes   string
+	includeLabelPrefix       string
 	slackURL                 string
 	slackUser                string
 	slackChannel             string
@@ -75,7 +75,7 @@ func init() {
 	flag.StringVar(&slackChannel, "slack-channel", "", "Slack channel.")
 	flag.StringVar(&eventWebhook, "event-webhook", "", "Webhook for publishing flagger events")
 	flag.StringVar(&msteamsURL, "msteams-url", "", "MS Teams incoming webhook URL.")
-	flag.StringVar(&excludedLabelsPrefixes, "excluded-labels-prefixes", "fluxcd,jenkins", "List of prefixes of labels that are excluded when creating primary controllers.")
+	flag.StringVar(&includeLabelPrefix, "include-label-prefix", "", "List of prefixes of labels that are copied when creating primary deployments or daemonsets. Use * to include all.")
 	flag.IntVar(&threadiness, "threadiness", 2, "Worker concurrency.")
 	flag.BoolVar(&zapReplaceGlobals, "zap-replace-globals", false, "Whether to change the logging level of the global zap logger.")
 	flag.StringVar(&zapEncoding, "zap-encoding", "json", "Zap logger encoding.")
@@ -186,9 +186,9 @@ func main() {
 		configTracker = &canary.NopTracker{}
 	}
 
-	excludedLabelsPrefixesArray := strings.Split(excludedLabelsPrefixes, ",")
+	includeLabelPrefixArray := strings.Split(includeLabelPrefix, ",")
 
-	canaryFactory := canary.NewFactory(kubeClient, flaggerClient, configTracker, labels, excludedLabelsPrefixesArray, logger)
+	canaryFactory := canary.NewFactory(kubeClient, flaggerClient, configTracker, labels, includeLabelPrefixArray, logger)
 
 	c := controller.NewController(
 		kubeClient,

--- a/pkg/canary/daemonset_controller.go
+++ b/pkg/canary/daemonset_controller.go
@@ -243,9 +243,10 @@ func (c *DaemonSetController) createPrimaryDaemonSet(cd *flaggerv1.Canary, inclu
 		// create primary daemonset
 		primaryDae = &appsv1.DaemonSet{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      primaryName,
-				Namespace: cd.Namespace,
-				Labels:    makePrimaryLabels(labels, primaryLabelValue, label),
+				Name:        primaryName,
+				Namespace:   cd.Namespace,
+				Labels:      makePrimaryLabels(labels, primaryLabelValue, label),
+				Annotations: canaryDae.Annotations,
 				OwnerReferences: []metav1.OwnerReference{
 					*metav1.NewControllerRef(cd, schema.GroupVersionKind{
 						Group:   flaggerv1.SchemeGroupVersion.Group,

--- a/pkg/canary/deployment_controller.go
+++ b/pkg/canary/deployment_controller.go
@@ -244,9 +244,10 @@ func (c *DeploymentController) createPrimaryDeployment(cd *flaggerv1.Canary, inc
 		// create primary deployment
 		primaryDep = &appsv1.Deployment{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      primaryName,
-				Namespace: cd.Namespace,
-				Labels:    makePrimaryLabels(labels, primaryLabelValue, label),
+				Name:        primaryName,
+				Namespace:   cd.Namespace,
+				Labels:      makePrimaryLabels(labels, primaryLabelValue, label),
+				Annotations: canaryDep.Annotations,
 				OwnerReferences: []metav1.OwnerReference{
 					*metav1.NewControllerRef(cd, schema.GroupVersionKind{
 						Group:   flaggerv1.SchemeGroupVersion.Group,

--- a/pkg/canary/factory.go
+++ b/pkg/canary/factory.go
@@ -8,34 +8,38 @@ import (
 )
 
 type Factory struct {
-	kubeClient    kubernetes.Interface
-	flaggerClient clientset.Interface
-	logger        *zap.SugaredLogger
-	configTracker Tracker
-	labels        []string
+	kubeClient             kubernetes.Interface
+	flaggerClient          clientset.Interface
+	logger                 *zap.SugaredLogger
+	configTracker          Tracker
+	labels                 []string
+	excludedLabelsPrefixes []string
 }
 
 func NewFactory(kubeClient kubernetes.Interface,
 	flaggerClient clientset.Interface,
 	configTracker Tracker,
 	labels []string,
+	excludedLabelsPrefixes []string,
 	logger *zap.SugaredLogger) *Factory {
 	return &Factory{
-		kubeClient:    kubeClient,
-		flaggerClient: flaggerClient,
-		logger:        logger,
-		configTracker: configTracker,
-		labels:        labels,
+		kubeClient:             kubeClient,
+		flaggerClient:          flaggerClient,
+		logger:                 logger,
+		configTracker:          configTracker,
+		labels:                 labels,
+		excludedLabelsPrefixes: excludedLabelsPrefixes,
 	}
 }
 
 func (factory *Factory) Controller(kind string) Controller {
 	deploymentCtrl := &DeploymentController{
-		logger:        factory.logger,
-		kubeClient:    factory.kubeClient,
-		flaggerClient: factory.flaggerClient,
-		labels:        factory.labels,
-		configTracker: factory.configTracker,
+		logger:                 factory.logger,
+		kubeClient:             factory.kubeClient,
+		flaggerClient:          factory.flaggerClient,
+		labels:                 factory.labels,
+		configTracker:          factory.configTracker,
+		excludedLabelsPrefixes: factory.excludedLabelsPrefixes,
 	}
 	daemonSetCtrl := &DaemonSetController{
 		logger:        factory.logger,

--- a/pkg/canary/factory.go
+++ b/pkg/canary/factory.go
@@ -8,38 +8,38 @@ import (
 )
 
 type Factory struct {
-	kubeClient             kubernetes.Interface
-	flaggerClient          clientset.Interface
-	logger                 *zap.SugaredLogger
-	configTracker          Tracker
-	labels                 []string
-	excludedLabelsPrefixes []string
+	kubeClient         kubernetes.Interface
+	flaggerClient      clientset.Interface
+	logger             *zap.SugaredLogger
+	configTracker      Tracker
+	labels             []string
+	includeLabelPrefix []string
 }
 
 func NewFactory(kubeClient kubernetes.Interface,
 	flaggerClient clientset.Interface,
 	configTracker Tracker,
 	labels []string,
-	excludedLabelsPrefixes []string,
+	includeLabelPrefix []string,
 	logger *zap.SugaredLogger) *Factory {
 	return &Factory{
-		kubeClient:             kubeClient,
-		flaggerClient:          flaggerClient,
-		logger:                 logger,
-		configTracker:          configTracker,
-		labels:                 labels,
-		excludedLabelsPrefixes: excludedLabelsPrefixes,
+		kubeClient:         kubeClient,
+		flaggerClient:      flaggerClient,
+		logger:             logger,
+		configTracker:      configTracker,
+		labels:             labels,
+		includeLabelPrefix: includeLabelPrefix,
 	}
 }
 
 func (factory *Factory) Controller(kind string) Controller {
 	deploymentCtrl := &DeploymentController{
-		logger:                 factory.logger,
-		kubeClient:             factory.kubeClient,
-		flaggerClient:          factory.flaggerClient,
-		labels:                 factory.labels,
-		configTracker:          factory.configTracker,
-		excludedLabelsPrefixes: factory.excludedLabelsPrefixes,
+		logger:             factory.logger,
+		kubeClient:         factory.kubeClient,
+		flaggerClient:      factory.flaggerClient,
+		labels:             factory.labels,
+		configTracker:      factory.configTracker,
+		includeLabelPrefix: factory.includeLabelPrefix,
 	}
 	daemonSetCtrl := &DaemonSetController{
 		logger:        factory.logger,

--- a/pkg/canary/util.go
+++ b/pkg/canary/util.go
@@ -4,6 +4,7 @@ import (
 	"crypto/rand"
 	"fmt"
 	"io"
+	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -73,6 +74,24 @@ func makeAnnotations(annotations map[string]string) (map[string]string, error) {
 	res[idKey] = id
 
 	return res, nil
+}
+
+func excludeLabelsByPrefix(labels map[string]string, excludedLabelsPrefixes []string) map[string]string {
+	filteredLabels := make(map[string]string)
+	for key, value := range labels {
+		isPrefixExcluded := false
+		for _, excludeLabelPrefix := range excludedLabelsPrefixes {
+			if strings.HasPrefix(key, excludeLabelPrefix) {
+				isPrefixExcluded = true
+				break
+			}
+		}
+		if !isPrefixExcluded {
+			filteredLabels[key] = value
+		}
+	}
+
+	return filteredLabels
 }
 
 func makePrimaryLabels(labels map[string]string, labelValue string, label string) map[string]string {

--- a/pkg/canary/util.go
+++ b/pkg/canary/util.go
@@ -80,7 +80,7 @@ func includeLabelsByPrefix(labels map[string]string, includeLabelPrefixes []stri
 	filteredLabels := make(map[string]string)
 	for key, value := range labels {
 		for _, includeLabelPrefix := range includeLabelPrefixes {
-			if key == "*" || strings.HasPrefix(key, includeLabelPrefix) {
+			if includeLabelPrefix == "*" || strings.HasPrefix(key, includeLabelPrefix) {
 				filteredLabels[key] = value
 				break
 			}

--- a/pkg/canary/util.go
+++ b/pkg/canary/util.go
@@ -76,18 +76,14 @@ func makeAnnotations(annotations map[string]string) (map[string]string, error) {
 	return res, nil
 }
 
-func excludeLabelsByPrefix(labels map[string]string, excludedLabelsPrefixes []string) map[string]string {
+func includeLabelsByPrefix(labels map[string]string, includeLabelPrefixes []string) map[string]string {
 	filteredLabels := make(map[string]string)
 	for key, value := range labels {
-		isPrefixExcluded := false
-		for _, excludeLabelPrefix := range excludedLabelsPrefixes {
-			if strings.HasPrefix(key, excludeLabelPrefix) {
-				isPrefixExcluded = true
+		for _, includeLabelPrefix := range includeLabelPrefixes {
+			if key == "*" || strings.HasPrefix(key, includeLabelPrefix) {
+				filteredLabels[key] = value
 				break
 			}
-		}
-		if !isPrefixExcluded {
-			filteredLabels[key] = value
 		}
 	}
 

--- a/pkg/canary/util_test.go
+++ b/pkg/canary/util_test.go
@@ -1,0 +1,38 @@
+package canary
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExcludeLabelsByPrefix(t *testing.T) {
+	labels := map[string]string{
+		"foo":     "bar",
+		"jenkins": "foo",
+		"flux123": "bar",
+	}
+	excludedLabelsPrefixes := []string{"jenkins", "flux"}
+
+	filteredLabels := excludeLabelsByPrefix(labels, excludedLabelsPrefixes)
+
+	assert.Equal(t, filteredLabels, map[string]string{
+		"foo": "bar",
+		// jenkins excluded
+		// and flux123 also excluded
+	})
+}
+
+func TestMakePrimaryLabels(t *testing.T) {
+	labels := map[string]string{
+		"lorem": "ipsum",
+		"foo":   "old-bar",
+	}
+
+	primaryLabels := makePrimaryLabels(labels, "new-bar", "foo")
+
+	assert.Equal(t, primaryLabels, map[string]string{
+		"lorem": "ipsum",   // values from old map
+		"foo":   "new-bar", // overriden value for a specific label
+	})
+}

--- a/pkg/canary/util_test.go
+++ b/pkg/canary/util_test.go
@@ -6,20 +6,37 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestExcludeLabelsByPrefix(t *testing.T) {
+func TestIncludeLabelsByPrefix(t *testing.T) {
 	labels := map[string]string{
-		"foo":     "bar",
-		"jenkins": "foo",
-		"flux123": "bar",
+		"foo":   "foo-value",
+		"bar":   "bar-value",
+		"lorem": "ipsum",
 	}
-	excludedLabelsPrefixes := []string{"jenkins", "flux"}
+	includeLabelPrefix := []string{"foo", "lor"}
 
-	filteredLabels := excludeLabelsByPrefix(labels, excludedLabelsPrefixes)
+	filteredLabels := includeLabelsByPrefix(labels, includeLabelPrefix)
 
 	assert.Equal(t, filteredLabels, map[string]string{
-		"foo": "bar",
-		// jenkins excluded
-		// and flux123 also excluded
+		"foo":   "foo-value",
+		"lorem": "ipsum",
+		// bar excluded
+	})
+}
+
+func TestIncludeLabelsByPrefixWithWildcard(t *testing.T) {
+	labels := map[string]string{
+		"foo":   "foo-value",
+		"bar":   "bar-value",
+		"lorem": "ipsum",
+	}
+	includeLabelPrefix := []string{"*"}
+
+	filteredLabels := includeLabelsByPrefix(labels, includeLabelPrefix)
+
+	assert.Equal(t, filteredLabels, map[string]string{
+		"foo":   "foo-value",
+		"bar":   "bar-value",
+		"lorem": "ipsum",
 	})
 }
 

--- a/pkg/controller/scheduler_daemonset_fixture_test.go
+++ b/pkg/controller/scheduler_daemonset_fixture_test.go
@@ -87,7 +87,7 @@ func newDaemonSetFixture(c *flaggerv1.Canary) daemonSetFixture {
 		KubeClient:    kubeClient,
 		FlaggerClient: flaggerClient,
 	}
-	canaryFactory := canary.NewFactory(kubeClient, flaggerClient, configTracker, []string{"app", "name"}, logger)
+	canaryFactory := canary.NewFactory(kubeClient, flaggerClient, configTracker, []string{"app", "name"}, []string{"jenkins"}, logger)
 
 	ctrl := &Controller{
 		kubeClient:       kubeClient,

--- a/pkg/controller/scheduler_daemonset_fixture_test.go
+++ b/pkg/controller/scheduler_daemonset_fixture_test.go
@@ -87,7 +87,7 @@ func newDaemonSetFixture(c *flaggerv1.Canary) daemonSetFixture {
 		KubeClient:    kubeClient,
 		FlaggerClient: flaggerClient,
 	}
-	canaryFactory := canary.NewFactory(kubeClient, flaggerClient, configTracker, []string{"app", "name"}, []string{"jenkins"}, logger)
+	canaryFactory := canary.NewFactory(kubeClient, flaggerClient, configTracker, []string{"app", "name"}, []string{""}, logger)
 
 	ctrl := &Controller{
 		kubeClient:       kubeClient,

--- a/pkg/controller/scheduler_deployment_fixture_test.go
+++ b/pkg/controller/scheduler_deployment_fixture_test.go
@@ -115,7 +115,7 @@ func newDeploymentFixture(c *flaggerv1.Canary) fixture {
 		KubeClient:    kubeClient,
 		FlaggerClient: flaggerClient,
 	}
-	canaryFactory := canary.NewFactory(kubeClient, flaggerClient, configTracker, []string{"app", "name"}, logger)
+	canaryFactory := canary.NewFactory(kubeClient, flaggerClient, configTracker, []string{"app", "name"}, []string{"jenkins"}, logger)
 
 	ctrl := &Controller{
 		kubeClient:       kubeClient,

--- a/pkg/controller/scheduler_deployment_fixture_test.go
+++ b/pkg/controller/scheduler_deployment_fixture_test.go
@@ -115,7 +115,7 @@ func newDeploymentFixture(c *flaggerv1.Canary) fixture {
 		KubeClient:    kubeClient,
 		FlaggerClient: flaggerClient,
 	}
-	canaryFactory := canary.NewFactory(kubeClient, flaggerClient, configTracker, []string{"app", "name"}, []string{"jenkins"}, logger)
+	canaryFactory := canary.NewFactory(kubeClient, flaggerClient, configTracker, []string{"app", "name"}, []string{""}, logger)
 
 	ctrl := &Controller{
 		kubeClient:       kubeClient,


### PR DESCRIPTION
Copy labels from canary to primary deployment and daemonset but exclude labels by prefix.
Copy annotations too.

Fixes #329.
