### PR TITLE
Fixup some typos

### DIFF
--- a/docs/gitbook/tutorials/nginx-progressive-delivery.md
+++ b/docs/gitbook/tutorials/nginx-progressive-delivery.md
@@ -345,7 +345,7 @@ podinfod=stefanprodan/podinfo:3.1.3
 Generate high response latency:
 
 ```bash
-watch curl http://app.exmaple.com/delay/2
+watch curl http://app.example.com/delay/2
 ```
 
 Watch Flagger logs:

--- a/docs/gitbook/tutorials/skipper-progressive-delivery.md
+++ b/docs/gitbook/tutorials/skipper-progressive-delivery.md
@@ -351,7 +351,7 @@ podinfod=stefanprodan/podinfo:4.0.6
 Generate high response latency:
 
 ```bash
-watch curl http://app.exmaple.com/delay/2
+watch curl http://app.example.com/delay/2
 ```
 
 Watch Flagger logs:


### PR DESCRIPTION
I was following the nginx progressive delivery tutorial and I stumbled across this error, looks like it was copied into one other tutorial (skipper). Thanks for providing this!