### PR TITLE
Add QPS and Burst configs for kubernetes client

### DIFF
--- a/charts/flagger/templates/deployment.yaml
+++ b/charts/flagger/templates/deployment.yaml
@@ -115,6 +115,12 @@ spec:
           {{- if .Values.eventWebhook }}
           - -event-webhook={{ .Values.eventWebhook }}
           {{- end }}
+          {{- if .Values.kubeconfigQPS }}
+          - -kubeconfig-qps={{ .Values.kubeconfigQPS }}
+          {{- end }}
+          {{- if .Values.kubeconfigBurst }}
+          - -kubeconfig-burst={{ .Values.kubeconfigBurst }}
+          {{- end }}
           {{- if .Values.istio.kubeconfig.secretName }}
           - -kubeconfig-service-mesh=/tmp/istio-host/{{ .Values.istio.kubeconfig.key }}
           {{- end }}

--- a/charts/flagger/values.yaml
+++ b/charts/flagger/values.yaml
@@ -127,8 +127,8 @@ prometheus:
   image: docker.io/prom/prometheus:v2.21.0
   retention: 2h
 
-kubeconfigQPS: ""
-kubeconfigBurst: ""
+kubeconfigQPS: "100"
+kubeconfigBurst: "250"
 
 #  Istio multi-cluster service mesh (shared control plane single-network)
 # https://istio.io/docs/setup/install/multicluster/shared-vpn/

--- a/charts/flagger/values.yaml
+++ b/charts/flagger/values.yaml
@@ -127,12 +127,11 @@ prometheus:
   image: docker.io/prom/prometheus:v2.21.0
   retention: 2h
 
-#  Istio multi-cluster service mesh (shared control plane single-network)
-# https://istio.io/docs/setup/install/multicluster/shared-vpn/
-
 kubeconfigQPS: ""
 kubeconfigBurst: ""
 
+#  Istio multi-cluster service mesh (shared control plane single-network)
+# https://istio.io/docs/setup/install/multicluster/shared-vpn/
 istio:
   kubeconfig:
     # istio.kubeconfig.secretName: The name of the secret containing the Istio control plane kubeconfig

--- a/charts/flagger/values.yaml
+++ b/charts/flagger/values.yaml
@@ -129,6 +129,10 @@ prometheus:
 
 #  Istio multi-cluster service mesh (shared control plane single-network)
 # https://istio.io/docs/setup/install/multicluster/shared-vpn/
+
+kubeconfigQPS: ""
+kubeconfigBurst: ""
+
 istio:
   kubeconfig:
     # istio.kubeconfig.secretName: The name of the secret containing the Istio control plane kubeconfig

--- a/cmd/flagger/main.go
+++ b/cmd/flagger/main.go
@@ -38,7 +38,7 @@ import (
 var (
 	masterURL                string
 	kubeconfig               string
-	kubeconfigQPS            float64
+	kubeconfigQPS            int
 	kubeconfigBurst          int
 	metricsServer            string
 	controlLoopInterval      time.Duration
@@ -67,7 +67,7 @@ var (
 
 func init() {
 	flag.StringVar(&kubeconfig, "kubeconfig", "", "Path to a kubeconfig. Only required if out-of-cluster.")
-	flag.Float64Var(&kubeconfigQPS, "kubeconfig-qps", 0, "Set QPS for kubeconfig.")
+	flag.IntVar(&kubeconfigQPS, "kubeconfig-qps", 0, "Set QPS for kubeconfig.")
 	flag.IntVar(&kubeconfigBurst, "kubeconfig-burst", 0, "Set Burst for kubeconfig.")
 	flag.StringVar(&masterURL, "master", "", "The address of the Kubernetes API server. Overrides any value in kubeconfig. Only required if out-of-cluster.")
 	flag.StringVar(&metricsServer, "metrics-server", "http://prometheus:9090", "Prometheus URL.")

--- a/cmd/flagger/main.go
+++ b/cmd/flagger/main.go
@@ -38,6 +38,8 @@ import (
 var (
 	masterURL                string
 	kubeconfig               string
+	kubeconfigQPS            float64
+	kubeconfigBurst          int
 	metricsServer            string
 	controlLoopInterval      time.Duration
 	logLevel                 string
@@ -65,6 +67,8 @@ var (
 
 func init() {
 	flag.StringVar(&kubeconfig, "kubeconfig", "", "Path to a kubeconfig. Only required if out-of-cluster.")
+	flag.Float64Var(&kubeconfigQPS, "kubeconfig-qps", 0, "Set QPS for kubeconfig.")
+	flag.IntVar(&kubeconfigBurst, "kubeconfig-burst", 0, "Set Burst for kubeconfig.")
 	flag.StringVar(&masterURL, "master", "", "The address of the Kubernetes API server. Overrides any value in kubeconfig. Only required if out-of-cluster.")
 	flag.StringVar(&metricsServer, "metrics-server", "http://prometheus:9090", "Prometheus URL.")
 	flag.DurationVar(&controlLoopInterval, "control-loop-interval", 10*time.Second, "Kubernetes API sync interval.")
@@ -118,6 +122,13 @@ func main() {
 		logger.Fatalf("Error building kubeconfig: %v", err)
 	}
 
+	if kubeconfigQPS > 0 {
+		cfg.QPS = float32(kubeconfigQPS)
+	}
+
+	if kubeconfigBurst > 0 {
+		cfg.Burst = kubeconfigBurst
+	}
 	kubeClient, err := kubernetes.NewForConfig(cfg)
 	if err != nil {
 		logger.Fatalf("Error building kubernetes clientset: %v", err)
@@ -137,6 +148,13 @@ func main() {
 		logger.Fatalf("Error building host kubeconfig: %v", err)
 	}
 
+	if kubeconfigQPS > 0 {
+		cfgHost.QPS = float32(kubeconfigQPS)
+	}
+
+	if kubeconfigBurst > 0 {
+		cfgHost.Burst = kubeconfigBurst
+	}
 	meshClient, err := clientset.NewForConfig(cfgHost)
 	if err != nil {
 		logger.Fatalf("Error building mesh clientset: %v", err)


### PR DESCRIPTION
Hello,
I wasn't sure where to add the vars, didn't see an order.
Also, the var names may not be good but I've tried to add the config option as suggested here: https://github.com/weaveworks/flagger/issues/638#issuecomment-722177825

didn't add a default value, so it only applies if you set the arg.

Fixes: #638 