### PR TITLE
add support to hpa behaviors on canaries

### DIFF
--- a/pkg/canary/deployment_controller_test.go
+++ b/pkg/canary/deployment_controller_test.go
@@ -31,7 +31,7 @@ func TestDeploymentController_Sync_ConsistentNaming(t *testing.T) {
 	primarySelectorValue := depPrimary.Spec.Selector.MatchLabels[dc.label]
 	assert.Equal(t, primarySelectorValue, fmt.Sprintf("%s-primary", dc.labelValue))
 
-	hpaPrimary, err := mocks.kubeClient.AutoscalingV2beta1().HorizontalPodAutoscalers("default").Get(context.TODO(), "podinfo-primary", metav1.GetOptions{})
+	hpaPrimary, err := mocks.kubeClient.AutoscalingV2beta2().HorizontalPodAutoscalers("default").Get(context.TODO(), "podinfo-primary", metav1.GetOptions{})
 	require.NoError(t, err)
 	assert.Equal(t, depPrimary.Name, hpaPrimary.Spec.ScaleTargetRef.Name)
 }
@@ -52,7 +52,7 @@ func TestDeploymentController_Sync_InconsistentNaming(t *testing.T) {
 	primarySelectorValue := depPrimary.Spec.Selector.MatchLabels[dc.label]
 	assert.Equal(t, primarySelectorValue, fmt.Sprintf("%s-primary", dc.labelValue))
 
-	hpaPrimary, err := mocks.kubeClient.AutoscalingV2beta1().HorizontalPodAutoscalers("default").Get(context.TODO(), "podinfo-primary", metav1.GetOptions{})
+	hpaPrimary, err := mocks.kubeClient.AutoscalingV2beta2().HorizontalPodAutoscalers("default").Get(context.TODO(), "podinfo-primary", metav1.GetOptions{})
 	require.NoError(t, err)
 	assert.Equal(t, depPrimary.Name, hpaPrimary.Spec.ScaleTargetRef.Name)
 }
@@ -70,13 +70,13 @@ func TestDeploymentController_Promote(t *testing.T) {
 	_, err = mocks.kubeClient.CoreV1().ConfigMaps("default").Update(context.TODO(), config2, metav1.UpdateOptions{})
 	require.NoError(t, err)
 
-	hpa, err := mocks.kubeClient.AutoscalingV2beta1().HorizontalPodAutoscalers("default").Get(context.TODO(), "podinfo", metav1.GetOptions{})
+	hpa, err := mocks.kubeClient.AutoscalingV2beta2().HorizontalPodAutoscalers("default").Get(context.TODO(), "podinfo", metav1.GetOptions{})
 	require.NoError(t, err)
 
 	hpaClone := hpa.DeepCopy()
 	hpaClone.Spec.MaxReplicas = 2
 
-	_, err = mocks.kubeClient.AutoscalingV2beta1().HorizontalPodAutoscalers("default").Update(context.TODO(), hpaClone, metav1.UpdateOptions{})
+	_, err = mocks.kubeClient.AutoscalingV2beta2().HorizontalPodAutoscalers("default").Update(context.TODO(), hpaClone, metav1.UpdateOptions{})
 	require.NoError(t, err)
 
 	err = mocks.controller.Promote(mocks.canary)
@@ -93,7 +93,7 @@ func TestDeploymentController_Promote(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, config2.Data["color"], configPrimary.Data["color"])
 
-	hpaPrimary, err := mocks.kubeClient.AutoscalingV2beta1().HorizontalPodAutoscalers("default").Get(context.TODO(), "podinfo-primary", metav1.GetOptions{})
+	hpaPrimary, err := mocks.kubeClient.AutoscalingV2beta2().HorizontalPodAutoscalers("default").Get(context.TODO(), "podinfo-primary", metav1.GetOptions{})
 	require.NoError(t, err)
 	assert.Equal(t, int32(2), hpaPrimary.Spec.MaxReplicas)
 }

--- a/pkg/canary/deployment_fixture_test.go
+++ b/pkg/canary/deployment_fixture_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 	appsv1 "k8s.io/api/apps/v1"
-	hpav2 "k8s.io/api/autoscaling/v2beta1"
+	hpav2 "k8s.io/api/autoscaling/v2beta2"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -319,7 +319,7 @@ func newDeploymentControllerTestCanary(cc canaryConfigs) *flaggerv1.Canary {
 			},
 			AutoscalerRef: &flaggerv1.CrossNamespaceObjectReference{
 				Name:       "podinfo",
-				APIVersion: "autoscaling/v2beta1",
+				APIVersion: "autoscaling/v2beta2",
 				Kind:       "HorizontalPodAutoscaler",
 			}, Service: flaggerv1.CanaryService{
 				Port: 9898,
@@ -766,8 +766,10 @@ func newDeploymentControllerTestHPA() *hpav2.HorizontalPodAutoscaler {
 				{
 					Type: "Resource",
 					Resource: &hpav2.ResourceMetricSource{
-						Name:                     "cpu",
-						TargetAverageUtilization: int32p(99),
+						Name: "cpu",
+						Target: hpav2.MetricTarget{
+							AverageUtilization: int32p(99),
+						},
 					},
 				},
 			},

--- a/pkg/controller/scheduler_deployment_fixture_test.go
+++ b/pkg/controller/scheduler_deployment_fixture_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 	appsv1 "k8s.io/api/apps/v1"
-	hpav2 "k8s.io/api/autoscaling/v2beta1"
+	hpav2 "k8s.io/api/autoscaling/v2beta2"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -280,7 +280,7 @@ func newDeploymentTestCanary() *flaggerv1.Canary {
 			},
 			AutoscalerRef: &flaggerv1.CrossNamespaceObjectReference{
 				Name:       "podinfo",
-				APIVersion: "autoscaling/v2beta1",
+				APIVersion: "autoscaling/v2beta2",
 				Kind:       "HorizontalPodAutoscaler",
 			}, Service: flaggerv1.CanaryService{
 				Port: 9898,
@@ -342,7 +342,7 @@ func newDeploymentTestCanaryAB() *flaggerv1.Canary {
 			},
 			AutoscalerRef: &flaggerv1.CrossNamespaceObjectReference{
 				Name:       "podinfo",
-				APIVersion: "autoscaling/v2beta1",
+				APIVersion: "autoscaling/v2beta2",
 				Kind:       "HorizontalPodAutoscaler",
 			}, Service: flaggerv1.CanaryService{
 				Port: 9898,
@@ -694,8 +694,10 @@ func newDeploymentTestHPA() *hpav2.HorizontalPodAutoscaler {
 				{
 					Type: "Resource",
 					Resource: &hpav2.ResourceMetricSource{
-						Name:                     "cpu",
-						TargetAverageUtilization: int32p(99),
+						Name: "cpu",
+						Target: hpav2.MetricTarget{
+							AverageUtilization: int32p(99),
+						},
 					},
 				},
 			},


### PR DESCRIPTION
Implements #727 

I've tested the client locally agains a 1.14 (kind) and it was alright.. If there is no behavior, it is just ignored.
Didn't fully test a deployment/canary rollout on that version. 

Tested it all against a 1.18 cluster, deployment and changes to HPA specs are synced correctly.
HPA is not tracked by itself, depends on changes on other resources to be applied to primary. 

The logs for diff in behavior fields

<img width="1181" alt="Screen Shot 2020-12-06 at 12 46 15 AM" src="https://user-images.githubusercontent.com/55003893/101272802-a4b8e900-375d-11eb-8385-c8e16783f448.png">
