### PR TITLE
Apply label prefix rules for cm and secrets

### DIFF
--- a/pkg/canary/config_tracker.go
+++ b/pkg/canary/config_tracker.go
@@ -263,7 +263,7 @@ func (ct *ConfigTracker) HasConfigChanged(cd *flaggerv1.Canary) (bool, error) {
 
 // CreatePrimaryConfigs syncs the primary Kubernetes ConfigMaps and Secretes
 // with those found in the target deployment
-func (ct *ConfigTracker) CreatePrimaryConfigs(cd *flaggerv1.Canary, refs map[string]ConfigRef) error {
+func (ct *ConfigTracker) CreatePrimaryConfigs(cd *flaggerv1.Canary, refs map[string]ConfigRef, includeLabelPrefix []string) error {
 	for _, ref := range refs {
 		switch ref.Type {
 		case ConfigRefMap:
@@ -272,11 +272,12 @@ func (ct *ConfigTracker) CreatePrimaryConfigs(cd *flaggerv1.Canary, refs map[str
 				return fmt.Errorf("configmap %s.%s get query failed : %w", ref.Name, cd.Name, err)
 			}
 			primaryName := fmt.Sprintf("%s-primary", config.GetName())
+			labels := includeLabelsByPrefix(config.Labels, includeLabelPrefix)
 			primaryConfigMap := &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      primaryName,
 					Namespace: cd.Namespace,
-					Labels:    config.Labels,
+					Labels:    labels,
 					OwnerReferences: []metav1.OwnerReference{
 						*metav1.NewControllerRef(cd, schema.GroupVersionKind{
 							Group:   flaggerv1.SchemeGroupVersion.Group,
@@ -309,11 +310,12 @@ func (ct *ConfigTracker) CreatePrimaryConfigs(cd *flaggerv1.Canary, refs map[str
 				return fmt.Errorf("secret %s.%s get query failed : %w", ref.Name, cd.Name, err)
 			}
 			primaryName := fmt.Sprintf("%s-primary", secret.GetName())
+			labels := includeLabelsByPrefix(secret.Labels, includeLabelPrefix)
 			primarySecret := &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      primaryName,
 					Namespace: cd.Namespace,
-					Labels:    secret.Labels,
+					Labels:    labels,
 					OwnerReferences: []metav1.OwnerReference{
 						*metav1.NewControllerRef(cd, schema.GroupVersionKind{
 							Group:   flaggerv1.SchemeGroupVersion.Group,

--- a/pkg/canary/daemonset_controller.go
+++ b/pkg/canary/daemonset_controller.go
@@ -124,7 +124,7 @@ func (c *DaemonSetController) Promote(cd *flaggerv1.Canary) error {
 	if err != nil {
 		return fmt.Errorf("GetTargetConfigs failed: %w", err)
 	}
-	if err := c.configTracker.CreatePrimaryConfigs(cd, configRefs); err != nil {
+	if err := c.configTracker.CreatePrimaryConfigs(cd, configRefs, c.includeLabelPrefix); err != nil {
 		return fmt.Errorf("CreatePrimaryConfigs failed: %w", err)
 	}
 
@@ -232,7 +232,7 @@ func (c *DaemonSetController) createPrimaryDaemonSet(cd *flaggerv1.Canary, inclu
 		if err != nil {
 			return fmt.Errorf("GetTargetConfigs failed: %w", err)
 		}
-		if err := c.configTracker.CreatePrimaryConfigs(cd, configRefs); err != nil {
+		if err := c.configTracker.CreatePrimaryConfigs(cd, configRefs, c.includeLabelPrefix); err != nil {
 			return fmt.Errorf("CreatePrimaryConfigs failed: %w", err)
 		}
 		annotations, err := makeAnnotations(canaryDae.Spec.Template.Annotations)

--- a/pkg/canary/deployment_controller.go
+++ b/pkg/canary/deployment_controller.go
@@ -89,7 +89,7 @@ func (c *DeploymentController) Promote(cd *flaggerv1.Canary) error {
 	if err != nil {
 		return fmt.Errorf("GetTargetConfigs failed: %w", err)
 	}
-	if err := c.configTracker.CreatePrimaryConfigs(cd, configRefs); err != nil {
+	if err := c.configTracker.CreatePrimaryConfigs(cd, configRefs, c.includeLabelPrefix); err != nil {
 		return fmt.Errorf("CreatePrimaryConfigs failed: %w", err)
 	}
 
@@ -228,7 +228,7 @@ func (c *DeploymentController) createPrimaryDeployment(cd *flaggerv1.Canary, inc
 		if err != nil {
 			return fmt.Errorf("GetTargetConfigs failed: %w", err)
 		}
-		if err := c.configTracker.CreatePrimaryConfigs(cd, configRefs); err != nil {
+		if err := c.configTracker.CreatePrimaryConfigs(cd, configRefs, c.includeLabelPrefix); err != nil {
 			return fmt.Errorf("CreatePrimaryConfigs failed: %w", err)
 		}
 		annotations, err := makeAnnotations(canaryDep.Spec.Template.Annotations)

--- a/pkg/canary/nop_tracker.go
+++ b/pkg/canary/nop_tracker.go
@@ -21,7 +21,7 @@ func (nt *NopTracker) HasConfigChanged(*flaggerv1.Canary) (bool, error) {
 	return false, nil
 }
 
-func (nt *NopTracker) CreatePrimaryConfigs(*flaggerv1.Canary, map[string]ConfigRef) error {
+func (nt *NopTracker) CreatePrimaryConfigs(*flaggerv1.Canary, map[string]ConfigRef, []string) error {
 	return nil
 }
 

--- a/pkg/canary/tracker.go
+++ b/pkg/canary/tracker.go
@@ -9,6 +9,6 @@ type Tracker interface {
 	GetTargetConfigs(cd *flaggerv1.Canary) (map[string]ConfigRef, error)
 	GetConfigRefs(cd *flaggerv1.Canary) (*map[string]string, error)
 	HasConfigChanged(cd *flaggerv1.Canary) (bool, error)
-	CreatePrimaryConfigs(cd *flaggerv1.Canary, refs map[string]ConfigRef) error
+	CreatePrimaryConfigs(cd *flaggerv1.Canary, refs map[string]ConfigRef, includeLabelPrefix []string) error
 	ApplyPrimaryConfigs(spec corev1.PodSpec, refs map[string]ConfigRef) corev1.PodSpec
 }


### PR DESCRIPTION
Copying of Configmaps and Secrets managed through Flagger should now
follow the same label prefix filtering rules as for the workloads.

Extends: #709