### PR TITLE
Added PodDisruptionBudget to the Flagger Chart

### DIFF
--- a/charts/flagger/README.md
+++ b/charts/flagger/README.md
@@ -1,6 +1,6 @@
 # Flagger
 
-[Flagger](https://github.com/weaveworks/flagger) is an operator that automates the release process of applications on Kubernetes. 
+[Flagger](https://github.com/weaveworks/flagger) is an operator that automates the release process of applications on Kubernetes.
 
 Flagger can run automated application analysis, testing, promotion and rollback for the following deployment strategies:
 * Canary Release (progressive traffic shifting)
@@ -125,8 +125,8 @@ Parameter | Description | Default
 `slack.user` | Slack username | `flagger`
 `msteams.url` | Microsoft Teams incoming webhook | None
 `podMonitor.enabled` | If `true`, create a PodMonitor for [monitoring the metrics](https://docs.flagger.app/usage/monitoring#metrics) | `false`
-`podMonitor.namespace` | Namespace where the PodMonitor is created | the same namespace 
-`podMonitor.interval` | Interval at which metrics should be scraped | `15s` 
+`podMonitor.namespace` | Namespace where the PodMonitor is created | the same namespace
+`podMonitor.interval` | Interval at which metrics should be scraped | `15s`
 `podMonitor.podMonitor` | Additional labels to add to the PodMonitor | `{}`
 `leaderElection.enabled` | If `true`, Flagger will run in HA mode | `false`
 `leaderElection.replicaCount` | Number of replicas | `1`
@@ -151,6 +151,8 @@ Parameter | Description | Default
 `ingressAnnotationsPrefix` | Annotations prefix for NGINX ingresses | None
 `ingressClass` | Ingress class used for annotating HTTPProxy objects, e.g. `contour` | None
 `podPriorityClassName` | PriorityClass name for pod priority configuration | ""
+`podDisruptionBudget.enabled` | A PodDisruptionBudget will be created if `true` | `false`
+`podDisruptionBudget.minAvailable` | The minimal number of available replicas that will be set in the PodDisruptionBudget | `1`
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade`. For example,
 
@@ -170,5 +172,3 @@ $ helm upgrade -i flagger flagger/flagger \
 ```
 
 > **Tip**: You can use the default [values.yaml](values.yaml)
-
-

--- a/charts/flagger/templates/pdb.yaml
+++ b/charts/flagger/templates/pdb.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.podDisruptionBudget }}
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ template "flagger.name" . }}
+spec:
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ template "flagger.name" . }}
+{{- end }}

--- a/charts/flagger/templates/pdb.yaml
+++ b/charts/flagger/templates/pdb.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.podDisruptionBudget }}
+{{- if .Values.podDisruptionBudget.enabled }}
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:

--- a/charts/flagger/values.yaml
+++ b/charts/flagger/values.yaml
@@ -138,3 +138,7 @@ istio:
     secretName: ""
     # istio.kubeconfig.key: The name of secret data key that contains the Istio control plane kubeconfig
     key: "kubeconfig"
+
+podDisruptionBudget:
+  enabled: false
+  minAvailable: 1


### PR DESCRIPTION
The intention is that users of Flagger should be able to specify a PodDisruptionBudget if they are running Flagger with several replicas and leader election enabled.